### PR TITLE
perf(cli): cut two vendor SDKs out of the binary (5.81 -> 3.93 MB)

### DIFF
--- a/.changeset/enterprise-bundle-diet.md
+++ b/.changeset/enterprise-bundle-diet.md
@@ -1,0 +1,11 @@
+---
+'@moxxy/cli': patch
+---
+
+Cut two vendor SDKs out of the published binary: 5.81 MB to 3.93 MB (-32%).
+
+Neither was imported on purpose. Reading the string helper `providerApiKeyName` from `@moxxy/plugin-provider-admin` also loaded its factory and with it the ~1 MB `openai` SDK; reading `~/.moxxy/mcp.json` through `@moxxy/plugin-mcp`'s barrel loaded `@modelcontextprotocol/sdk` and its `ajv` dependency. Together that was 1.9 MB, a third of the binary, for two config helpers.
+
+Both helpers already lived in clean leaf modules, so they are now exported as subpaths (`@moxxy/plugin-provider-admin/key-name`, `@moxxy/plugin-mcp/config-io`) and the CLI and TUI import those instead of the package barrels.
+
+The build now fails if either SDK reappears. That check lives in the tsup config rather than in dependency-cruiser: cross-package imports in this workspace resolve to `dist/`, which the dep-cruiser config excludes, so a rule there would silently pass forever.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
   "files": [
     "dist",
     "!dist/**/*.map",
+    "!dist/metafile-*.json",
     "README.md"
   ],
   "publishConfig": {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,9 +1,11 @@
+// Subpath, not the barrel: the barrel loads the MCP SDK (and its ~200 KB ajv
+// dependency) for a command that only reads and edits ~/.moxxy/mcp.json.
 import {
   mcpConfigPath,
   readMcpConfig,
   removeServerFromConfig,
   setServerDisabled,
-} from '@moxxy/plugin-mcp';
+} from '@moxxy/plugin-mcp/config-io';
 import type { ParsedArgv } from '../argv.js';
 import { helpRequested } from '../argv-helpers.js';
 import { colors } from '../colors.js';

--- a/packages/cli/src/provider-credentials.ts
+++ b/packages/cli/src/provider-credentials.ts
@@ -1,6 +1,7 @@
 import type { ProviderDef, ProviderHostContext } from '@moxxy/sdk';
 import type { VaultStore } from '@moxxy/plugin-vault';
-import { storedProviderApiKeyName } from '@moxxy/plugin-provider-admin';
+// Subpath, not the barrel: the barrel pulls in the OpenAI SDK (see key-name.ts).
+import { storedProviderApiKeyName } from '@moxxy/plugin-provider-admin/key-name';
 import { resolveProviderApiKey, type ResolveOptions } from './provider-keys.js';
 
 /**

--- a/packages/cli/src/provider-keys.ts
+++ b/packages/cli/src/provider-keys.ts
@@ -1,5 +1,7 @@
 import type { VaultStore } from '@moxxy/plugin-vault';
-import { providerApiKeyName } from '@moxxy/plugin-provider-admin';
+// Subpath, not the barrel: the barrel pulls in the OpenAI SDK (see key-name.ts).
+// Subpath, not the barrel: the barrel pulls in the OpenAI SDK (see key-name.ts).
+import { providerApiKeyName } from '@moxxy/plugin-provider-admin/key-name';
 import { MoxxyError } from '@moxxy/sdk';
 import * as readline from 'node:readline/promises';
 

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
   splitting: false,
   treeshake: true,
   sourcemap: true,
+  metafile: true,
   clean: true,
   dts: false, // a binary ships no types; `tsc --noEmit` still typechecks
   shims: false, // code uses import.meta.url directly; no __dirname shims
@@ -76,6 +77,7 @@ export default defineConfig({
     };
   },
   async onSuccess() {
+    await assertNoHeavyVendorSdks();
     // bin.ts already carries the shebang; tsup preserves it. Just make it executable.
     await fs.chmod(path.resolve(here, 'dist/bin.js'), 0o755);
     // Copy builtin skill markdown next to the bin so the cli-local
@@ -88,3 +90,61 @@ export default defineConfig({
     // its own dist/public next to its module, so no dist/public copy here.)
   },
 });
+
+/**
+ * Vendor SDKs that must never reach the published binary, and the leaf subpath
+ * that keeps them out.
+ *
+ * Each of these arrived TRANSITIVELY, through a package barrel, never on
+ * purpose. Importing the string helper `providerApiKeyName` from
+ * `@moxxy/plugin-provider-admin` also loaded its factory and with it the ~1 MB
+ * `openai` SDK; reading `~/.moxxy/mcp.json` through `@moxxy/plugin-mcp`'s
+ * barrel loaded `@modelcontextprotocol/sdk` and its `ajv` dependency. Together
+ * that was 1.9 MB, a third of the binary, for two config helpers.
+ */
+const FORBIDDEN_VENDOR_SDKS: ReadonlyArray<{ readonly pkg: string; readonly useInstead: string }> = [
+  { pkg: 'openai', useInstead: '@moxxy/plugin-provider-admin/key-name' },
+  { pkg: '@modelcontextprotocol/sdk', useInstead: '@moxxy/plugin-mcp/config-io' },
+  { pkg: 'ajv', useInstead: '@moxxy/plugin-mcp/config-io' },
+];
+
+/**
+ * Fail the build when a heavy vendor SDK is back in the bundle.
+ *
+ * Asserted HERE rather than as a dependency-cruiser rule because cross-package
+ * imports in this workspace resolve to `dist/`, which that config excludes, so
+ * the edge is invisible to it and such a rule would pass forever without ever
+ * checking anything. The bundle is where this property actually exists, so this
+ * is where it gets checked.
+ */
+async function assertNoHeavyVendorSdks(): Promise<void> {
+  const metafilePath = path.resolve(here, 'dist/metafile-esm.json');
+  let raw: string;
+  try {
+    raw = await fs.readFile(metafilePath, 'utf8');
+  } catch {
+    throw new Error(
+      `bundle guard: ${metafilePath} is missing. It is produced by \`metafile: true\`; ` +
+        'do not remove that option without replacing this check.',
+    );
+  }
+  const meta = JSON.parse(raw) as { outputs: Record<string, { inputs: Record<string, unknown> }> };
+  const inputs = Object.keys(meta.outputs['dist/bin.js']?.inputs ?? {});
+
+  const offenders = FORBIDDEN_VENDOR_SDKS.filter(({ pkg }) =>
+    inputs.some((file) => file.includes(`/node_modules/${pkg}/`)),
+  );
+  if (offenders.length === 0) return;
+
+  const detail = offenders
+    .map(({ pkg, useInstead }) => {
+      const example = inputs.find((f) => f.includes(`/node_modules/${pkg}/`));
+      return `  ${pkg}\n    e.g. ${example}\n    import the leaf subpath instead: ${useInstead}`;
+    })
+    .join('\n');
+  throw new Error(
+    `bundle guard: a heavy vendor SDK is back in the moxxy binary.\n${detail}\n` +
+      'These are pulled in through a package barrel, not on purpose. Find the import with:\n' +
+      '  node -e "…" over dist/metafile-esm.json (walk the reverse import edges).',
+  );
+}

--- a/packages/plugin-cli/src/session/picker-handlers.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.ts
@@ -512,7 +512,7 @@ function handleMcpServerSelected(id: string, deps: PickerHandlerDeps): void {
   // action label so the picker accurately reads "disable" vs "enable".
   void (async () => {
     try {
-      const { readMcpConfig } = await import('@moxxy/plugin-mcp');
+      const { readMcpConfig } = await import('@moxxy/plugin-mcp/config-io');
       const cfg = await readMcpConfig();
       const server = cfg.servers.find((s) => s.name === id);
       const isDisabled = server?.disabled ?? false;
@@ -552,7 +552,7 @@ function handleMcpAction(serverName: string, id: string, deps: PickerHandlerDeps
   void (async () => {
     try {
       const { readMcpConfig, setServerDisabled, removeServerFromConfig } = await import(
-        '@moxxy/plugin-mcp'
+        '@moxxy/plugin-mcp/config-io'
       );
       if (id === 'remove') {
         const ok = await removeServerFromConfig(serverName);

--- a/packages/plugin-cli/src/session/run-slash.ts
+++ b/packages/plugin-cli/src/session/run-slash.ts
@@ -448,7 +448,7 @@ export function openMcpPicker(deps: OpenMcpPickerDeps): void {
   // CLI (moxxy mcp ...) show up immediately on next invocation.
   void (async () => {
     try {
-      const { readMcpConfig } = await import('@moxxy/plugin-mcp');
+      const { readMcpConfig } = await import('@moxxy/plugin-mcp/config-io');
       const cfg = await readMcpConfig();
       if (cfg.servers.length === 0) {
         deps.setSystemNotice('no MCP servers registered — add one in chat via mcp_add_server');

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -30,6 +30,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./config-io": {
+      "types": "./dist/admin/config-io.d.ts",
+      "import": "./dist/admin/config-io.js"
     }
   },
   "files": [

--- a/packages/plugin-mcp/src/admin/config-io.ts
+++ b/packages/plugin-mcp/src/admin/config-io.ts
@@ -1,3 +1,11 @@
+/**
+ * Exported as its own entry point (`@moxxy/plugin-mcp/config-io`), NOT only
+ * through the package barrel: the barrel loads the MCP client runtime and with
+ * it `@modelcontextprotocol/sdk` and `ajv`. Surfaces that merely read or edit
+ * `~/.moxxy/mcp.json` (the `moxxy mcp` command) must not pay for that, so keep
+ * this file's imports confined to node builtins, `@moxxy/sdk`, and local
+ * schema/type modules.
+ */
 import { promises as fs } from 'node:fs';
 import { assertDefined, createMutex } from '@moxxy/sdk';
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';

--- a/packages/plugin-provider-admin/package.json
+++ b/packages/plugin-provider-admin/package.json
@@ -30,6 +30,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./key-name": {
+      "types": "./dist/key-name.d.ts",
+      "import": "./dist/key-name.js"
     }
   },
   "files": [

--- a/packages/plugin-provider-admin/src/key-name.ts
+++ b/packages/plugin-provider-admin/src/key-name.ts
@@ -1,3 +1,14 @@
+/**
+ * Exported as its own entry point (`@moxxy/plugin-provider-admin/key-name`),
+ * NOT only through the package barrel.
+ *
+ * The barrel also loads `factory.ts`, which imports
+ * `@moxxy/plugin-provider-openai` and therefore the ~1 MB `openai` SDK. The CLI
+ * needs nothing from this module but two pure name helpers, so importing them
+ * through the barrel inlined that entire SDK into the published binary. Keep
+ * this file's imports confined to the local store and `@moxxy/sdk` so the
+ * subpath stays cheap.
+ */
 import { readProvidersConfig } from './store.js';
 
 /**


### PR DESCRIPTION
Wave 6. Branches off `development` (P0 waves #467-#471 are all merged now).

**This wave corrects a claim in my own audit.** I wrote that the CLI bundles ~30 workspace packages, counted from `devDependencies`. That was wrong: tsup inlines what is *imported*, not what is *declared*, and the bundled plugin set was already fairly lean. So I measured the bundle instead of the manifest, and the real picture was different and much more actionable.

Two vendor SDKs were in the binary, neither on purpose:

```
cli/src/provider-keys.ts
  -> @moxxy/plugin-provider-admin   (barrel)
  -> factory.ts -> @moxxy/plugin-provider-openai -> openai        ~1 MB

cli/src/commands/mcp.ts + plugin-cli pickers
  -> @moxxy/plugin-mcp              (barrel)
  -> admin/runtime -> client -> @modelcontextprotocol/sdk + ajv   ~0.85 MB
```

1.9 MB, a third of the published binary, to obtain a function that upper-snakes a provider name and a function that reads a JSON file. Both helpers already lived in leaf modules with clean imports, so the fix is a subpath export and pointing callers at it. No code moved.

Result: 5.81 MB → 3.93 MB (-32%).

**On the regression guard, which I got wrong first.** I wrote it as a dependency-cruiser rule with `reachable: true`, and it passed. Then I reintroduced the bad import to check it fails, and it still passed. Cause: cross-package imports in this workspace resolve to `dist/`, which the dep-cruiser config excludes, so the edge is invisible to it and the rule could never fire. I removed it and moved the assertion into the tsup config, checked against esbuild's metafile, where the property actually exists. That version I did verify fails with the regression live. A guard that cannot fail is worse than no guard, because it reads like coverage.

What is left at 3.93 MB is either genuinely needed or belongs elsewhere. The largest remaining item is the Ink runtime at 1.18 MB (react-reconciler 818 KB + yoga-layout 152 + react 123 + ink 84), which is the `plugin-cli`-in-the-floor problem from the audit and is W7's job. I deliberately did **not** externalize `jiti` (272 KB) or `yaml` (256 KB): both are already dynamically imported, so externalizing shrinks the artifact without changing load time or install footprint. That would be a cosmetic number, not a fix.

I also dropped the speculative "convert builtins.ts to a lazy manifest with code splitting" plan from the audit. The measurement says it would buy very little.

Verified: full gate green (build, typecheck, lint 0 errors, check:deps 0 errors, all test tasks).