### PR TITLE
perf(cli): load commands on dispatch (--version 301ms -> 83ms)

### DIFF
--- a/.changeset/enterprise-lazy-command-dispatch.md
+++ b/.changeset/enterprise-lazy-command-dispatch.md
@@ -1,0 +1,11 @@
+---
+'@moxxy/cli': patch
+---
+
+Load commands on dispatch: `moxxy --version` goes from 301 ms to 83 ms.
+
+`bin.ts` statically imported all 24 command modules plus the session bootstrap, so any invocation evaluated the module graph of the entire program. A `--cpu-prof` run confirmed `react/index.js` really did execute just to print a version string, because the TUI channel is reachable from that graph.
+
+Commands are now dispatched through lazy loaders, so a command pays only for itself. The boot art and tagline moved to a new `@moxxy/plugin-cli/logo-data` subpath, which is a pure data module, so `--help` no longer reaches the Ink runtime either. A test walks the eager import graph from `bin.ts` and fails if the TUI runtime or the session bootstrap becomes statically reachable again.
+
+The binary grows by about 90 KB (3.94 to 4.03 MB) from esbuild's lazy-initialiser wrappers. That is the trade: a slightly larger artifact for a startup that no longer scales with the number of commands.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,38 +1,15 @@
 #!/usr/bin/env node
 import { ensurePrivateDir, moxxyHome, moxxyPath, pruneStaleTempFiles } from '@moxxy/sdk/server';
 import { detectCoreInstall, finalizeStagedCoreUpdate } from '@moxxy/plugin-self-update';
+// Subpath, not the barrel: `@moxxy/plugin-cli` is the Ink TUI, and `--help`
+// must not evaluate a React renderer to print a tagline. logo-data.ts has no
+// imports at all.
+import { pickSlogan } from '@moxxy/plugin-cli/logo-data';
 import { parseArgv, type ParsedArgv } from './argv.js';
-import { runPromptCommand } from './commands/prompt.js';
-import { runTuiCommand } from './commands/tui.js';
-import { runSkillsCommand } from './commands/skills.js';
-import { runPluginsCommand } from './commands/plugins.js';
-import { runChannelsCommand } from './commands/channels.js';
-import { runChannelByName } from './commands/run-channel.js';
-import { runInitCommand } from './commands/init.js';
-import { runOnboardCommand } from './commands/onboard.js';
-import { runProvisionCommand } from './commands/provision.js';
-import { runPermsCommand } from './commands/perms.js';
-import { runConfigCommand } from './commands/config.js';
-import { runMemoryCommand } from './commands/memory.js';
-import { runMcpCommand } from './commands/mcp.js';
-import { runScheduleCommand } from './commands/schedule.js';
-import { runDoctorCommand } from './commands/doctor.js';
-import { runLoginCommand } from './commands/login.js';
-import { runResumeCommand } from './commands/resume.js';
-import { runServiceCommand } from './commands/service.js';
-import { runServeCommand } from './commands/serve.js';
-import { runAgentCommand } from './commands/agent.js';
-import { runCollabCommand } from './commands/collab.js';
-import { runSessionsCommand } from './commands/sessions.js';
-import { runSecurityCommand } from './commands/security.js';
-import { runSelfUpdateCommand } from './commands/self-update.js';
-import { runUpdateCommand } from './commands/update.js';
-import { probeSession } from './setup.js';
 import { applyEgressSettings } from './setup/egress.js';
 import { renderLogo } from './logo.js';
 import { colors } from './colors.js';
 import { cliVersion } from './version.js';
-import { pickSlogan } from '@moxxy/plugin-cli';
 import { formatErrorForCli } from './error-formatter.js';
 import { installProcessGuards } from './process-guards.js';
 
@@ -196,47 +173,58 @@ function renderHelp(): string {
 // Single source of truth: a command name → handler dispatch table. Adding a
 // new built-in subcommand here is enough; there's no separate KNOWN_COMMANDS
 // set that can drift out of sync.
-const COMMANDS: Record<string, CommandHandler> = {
-  help: async () => {
+/**
+ * Command name to a LAZY loader for its module.
+ *
+ * Every handler used to be a static import, which meant `moxxy --version` in a
+ * container evaluated the module graph of all 24 commands: the whole setup
+ * path, the runner, and through the TUI channel the entire Ink runtime
+ * (react-reconciler + yoga + react). A `--cpu-prof` run confirmed `react/index.js`
+ * really did execute just to print a version string.
+ *
+ * Loading on dispatch means a command pays only for itself. Still a single
+ * source of truth for "what commands exist", so there is no separate
+ * KNOWN_COMMANDS set to drift out of sync.
+ */
+const COMMANDS: Record<string, () => Promise<CommandHandler>> = {
+  help: async () => async () => {
     process.stdout.write(renderLogo(undefined, { center: true }) + renderHelp());
     return 0;
   },
-  version: async () => {
+  version: async () => async () => {
     const v = cliVersion() ?? '0.0.0';
     const width = process.stdout.columns ?? 80;
     const line = `moxxy ${v}`;
     const pad = ' '.repeat(Math.max(0, Math.floor((width - line.length) / 2)));
-    process.stdout.write(
-      renderLogo(undefined, { center: true }) + pad + line + '\n',
-    );
+    process.stdout.write(renderLogo(undefined, { center: true }) + pad + line + '\n');
     return 0;
   },
-  init: runInitCommand,
-  onboard: runOnboardCommand,
-  provision: runProvisionCommand,
-  login: runLoginCommand,
-  perms: runPermsCommand,
-  config: runConfigCommand,
-  memory: runMemoryCommand,
-  mcp: runMcpCommand,
-  schedule: runScheduleCommand,
-  doctor: runDoctorCommand,
-  update: runUpdateCommand,
-  prompt: runPromptCommand,
-  tui: runTuiCommand,
-  resume: runResumeCommand,
-  service: runServiceCommand,
-  serve: runServeCommand,
+  init: async () => (await import('./commands/init.js')).runInitCommand,
+  onboard: async () => (await import('./commands/onboard.js')).runOnboardCommand,
+  provision: async () => (await import('./commands/provision.js')).runProvisionCommand,
+  login: async () => (await import('./commands/login.js')).runLoginCommand,
+  perms: async () => (await import('./commands/perms.js')).runPermsCommand,
+  config: async () => (await import('./commands/config.js')).runConfigCommand,
+  memory: async () => (await import('./commands/memory.js')).runMemoryCommand,
+  mcp: async () => (await import('./commands/mcp.js')).runMcpCommand,
+  schedule: async () => (await import('./commands/schedule.js')).runScheduleCommand,
+  doctor: async () => (await import('./commands/doctor.js')).runDoctorCommand,
+  update: async () => (await import('./commands/update.js')).runUpdateCommand,
+  prompt: async () => (await import('./commands/prompt.js')).runPromptCommand,
+  tui: async () => (await import('./commands/tui.js')).runTuiCommand,
+  resume: async () => (await import('./commands/resume.js')).runResumeCommand,
+  service: async () => (await import('./commands/service.js')).runServiceCommand,
+  serve: async () => (await import('./commands/serve.js')).runServeCommand,
   // Internal: a collaboration peer runner spawned by `collaborative` mode.
-  agent: runAgentCommand,
+  agent: async () => (await import('./commands/agent.js')).runAgentCommand,
   // The dedicated collaboration coordinator runner (spawned by the collaborate UI).
-  collab: runCollabCommand,
-  sessions: runSessionsCommand,
-  security: runSecurityCommand,
-  skills: runSkillsCommand,
-  plugins: runPluginsCommand,
-  channels: runChannelsCommand,
-  'self-update': runSelfUpdateCommand,
+  collab: async () => (await import('./commands/collab.js')).runCollabCommand,
+  sessions: async () => (await import('./commands/sessions.js')).runSessionsCommand,
+  security: async () => (await import('./commands/security.js')).runSecurityCommand,
+  skills: async () => (await import('./commands/skills.js')).runSkillsCommand,
+  plugins: async () => (await import('./commands/plugins.js')).runPluginsCommand,
+  channels: async () => (await import('./commands/channels.js')).runChannelsCommand,
+  'self-update': async () => (await import('./commands/self-update.js')).runSelfUpdateCommand,
 };
 
 async function main(): Promise<number> {
@@ -284,8 +272,8 @@ async function main(): Promise<number> {
     }
   });
 
-  const handler = COMMANDS[argv.command];
-  if (handler) return handler(argv);
+  const load = COMMANDS[argv.command];
+  if (load) return (await load())(argv);
 
   // Not a built-in. See if it names a registered channel — skip the
   // API-key prompt so a typo doesn't accidentally boot the provider.
@@ -303,6 +291,7 @@ async function main(): Promise<number> {
     // the provider. Activating it can hang or throw on hosts without a
     // configured key, which would mask the real "unknown command"
     // feedback.
+    const { probeSession } = await import('./setup.js');
     isChannel = await probeSession(
       {
         cwd: process.cwd(),
@@ -319,6 +308,7 @@ async function main(): Promise<number> {
   if (isChannel) {
     // Outside the try: any error from running the channel propagates
     // normally and is surfaced by the top-level .catch in main().then().
+    const { runChannelByName } = await import('./commands/run-channel.js');
     return await runChannelByName(argv.command, argv);
   }
 

--- a/packages/cli/src/eager-graph.test.ts
+++ b/packages/cli/src/eager-graph.test.ts
@@ -1,0 +1,86 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
+
+/**
+ * Modules that must never be reachable through a STATIC import from `bin.ts`.
+ *
+ * `moxxy --version` in a container used to evaluate the module graph of all 24
+ * commands, and through the TUI channel the whole Ink runtime. A `--cpu-prof`
+ * run confirmed `react/index.js` really did execute just to print a version
+ * string. Commands are dispatched lazily now, so a command pays only for
+ * itself, and the eager graph must stay that way.
+ *
+ * `@moxxy/plugin-cli` is the Ink TUI. Its `/logo-data` subpath is a pure data
+ * module with no imports at all, which is why the boot art is allowed.
+ */
+const FORBIDDEN_EAGER = [
+  { spec: '@moxxy/plugin-cli', reason: 'the Ink TUI; use the /logo-data subpath or import it lazily' },
+  { spec: 'ink', reason: 'the TUI renderer' },
+  { spec: 'react', reason: 'the TUI renderer' },
+  { spec: './setup.js', reason: 'the whole session bootstrap; import it inside the command that needs it' },
+] as const;
+
+/** Static `import ... from '<spec>'` specifiers. Dynamic `import()` is
+ *  deliberately NOT matched: deferring to it is the fix, not the problem. */
+function staticImports(source: string): string[] {
+  const out: string[] = [];
+  const re = /^\s*import\s(?:[^'"]*?\sfrom\s)?['"]([^'"]+)['"]/gm;
+  for (let m = re.exec(source); m; m = re.exec(source)) out.push(m[1]!);
+  // `export ... from '<spec>'` is an eager re-export too.
+  const reExport = /^\s*export\s(?:[^'"]*?\sfrom\s)['"]([^'"]+)['"]/gm;
+  for (let m = reExport.exec(source); m; m = reExport.exec(source)) out.push(m[1]!);
+  return out;
+}
+
+/** Walk the eager graph from an entry, following only relative specifiers
+ *  (a bare package is a leaf: we care THAT it is reached, not through what). */
+async function eagerGraph(entry: string): Promise<Map<string, string[]>> {
+  const seen = new Map<string, string[]>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    if (seen.has(file)) continue;
+    let source: string;
+    try {
+      source = await fs.readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+    const specs = staticImports(source);
+    seen.set(file, specs);
+    for (const spec of specs) {
+      if (!spec.startsWith('.')) continue;
+      // Sources are `.ts`; imports are written with the emitted `.js` suffix.
+      const resolved = path.resolve(path.dirname(file), spec.replace(/\.js$/, '.ts'));
+      queue.push(resolved);
+    }
+  }
+  return seen;
+}
+
+describe('bin.ts eager import graph', () => {
+  it('never statically reaches the TUI runtime or the session bootstrap', async () => {
+    const graph = await eagerGraph(path.join(SRC, 'bin.ts'));
+    const offenders: string[] = [];
+    for (const [file, specs] of graph) {
+      for (const { spec, reason } of FORBIDDEN_EAGER) {
+        // Exact match only: `@moxxy/plugin-cli/logo-data` is a pure data leaf.
+        if (!specs.includes(spec)) continue;
+        offenders.push(`${path.relative(SRC, file)} imports "${spec}" (${reason})`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  // Guards the guard: if the walk silently resolved nothing, the assertion
+  // above would pass vacuously forever.
+  it('actually walks a graph', async () => {
+    const graph = await eagerGraph(path.join(SRC, 'bin.ts'));
+    expect(graph.size).toBeGreaterThan(3);
+    expect([...graph.keys()].some((f) => f.endsWith('argv.ts'))).toBe(true);
+  });
+});

--- a/packages/cli/src/logo.ts
+++ b/packages/cli/src/logo.ts
@@ -8,7 +8,9 @@
  * that keeps the slogan from appearing twice.
  */
 
-import { selectLogo } from '@moxxy/plugin-cli';
+// Subpath, not the barrel: this renders the boot art for `--help` and
+// `--version`, which must not evaluate the Ink/React runtime.
+import { selectLogo } from '@moxxy/plugin-cli/logo-data';
 import { colors } from './colors.js';
 
 export interface RenderLogoOptions {

--- a/packages/plugin-cli/package.json
+++ b/packages/plugin-cli/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./logo-data": {
+      "types": "./dist/logo-data.d.ts",
+      "import": "./dist/logo-data.js"
     }
   },
   "files": [


### PR DESCRIPTION
Wave 7, off `development` (W6 merged).

`bin.ts` statically imported all 24 command modules plus `setup.js`, so any invocation evaluated the module graph of the whole program. A `--cpu-prof` run confirmed `react/index.js` really does execute just to print a version string, so the audit's complaint was real. But the cause was broader than `plugin-cli`: it was eager dispatch.

Commands now resolve through lazy loaders. Two remaining eager edges into the TUI package were the boot art and the tagline, both in `logo-data.ts`, a module with no imports at all, so that becomes a subpath and `--help` stops reaching Ink too.

Measured on one machine, same base, 21 warmed runs, median, and I re-ran A/B/A to be sure:

```
without:  301 ms   (min 135)
with:      83 ms   (min 80)
```

The baseline's spread is itself the finding: 135 to 301 ms is the cost of parsing and evaluating a large graph, which moves with system load. With lazy dispatch median and min converge, because there is almost nothing left to evaluate.

Binary grows ~90 KB (3.94 → 4.03 MB) from esbuild's lazy-initialiser wrappers. Right way round: a slightly larger artifact for a startup that no longer scales with the number of commands.

**Two things worth flagging for review.**

First, this achieves the container/CI property the audit asked for **without** demoting `@moxxy/plugin-cli` out of `CRITICAL_PACKAGES` or writing a separate headless stdio floor channel, which is what the audit proposed. Those were the proposed *means*; the *end* was that a headless invocation must not boot a React renderer, and lazy dispatch delivers it at a fraction of the disruption. Unbundling the TUI would still shave 1.18 MB off the artifact, but it would mean `moxxy` no longer shows a UI until a plugin is installed. That is a product decision, not a performance one, so I have left it out rather than smuggling it in here. Happy to do it if you want the size.

Second, `tsup` does not typecheck, so when my regex stripped one import too many (`runChannelByName`) the build stayed green and only `tsc` caught it. Worth remembering when reading the diff: the build passing is not evidence this file is correct.

Verified: full gate green (build, typecheck, lint 0 errors, check:deps 0 errors, all test tasks), plus `--help`, `--version` and unknown-command dispatch smoke-tested against the real binary.