### PR TITLE
feat(cli): add `moxxy profile` and `moxxy sync`

### DIFF
--- a/.changeset/enterprise-profile-and-sync.md
+++ b/.changeset/enterprise-profile-and-sync.md
@@ -1,0 +1,11 @@
+---
+'@moxxy/cli': minor
+---
+
+Add `moxxy profile` and `moxxy sync`: install a baseline, then keep a fleet on it.
+
+`moxxy profile enterprise` prints a system-scope config with the security controls already set and locked: isolation enforced through a real process boundary, undeclared third-party tools denied, executable project configs refused, audit on. It only prints, and its site-specific entries (proxy URL, audit sink) ship commented out. The file belongs in a root-owned location and a profile that guessed a proxy would be wrong everywhere, so the operator reviews and places it.
+
+`moxxy sync` reconciles installed plugins against the merged `plugins.packages` manifest, which makes that map the reproducible, reviewable description of what a workstation runs. `--check` reports drift and exits 1 without changing anything, so it gates a provisioning pipeline. Sync installs what is missing and reports what is extra; it never removes a package a user chose to install.
+
+Extras are identified from the plugin host's own bundled-versus-discovered flag rather than from package names, so the bundled kernel is never reported as drift.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,28 @@ Configuration is merged from four layers, highest authority first:
 
 The system layer is YAML only on purpose: an executable file there would run as whoever starts moxxy, so a misconfigured `/etc/moxxy` would become a privilege-escalation path.
 
+### Installing a baseline
+
+`moxxy profile enterprise` prints a system-scope config with the security controls already locked. It only prints: the file it belongs in is root-owned and carries site-specific entries (proxy URL, audit sink) that have no safe default, so an operator reviews it before placing it.
+
+```sh
+moxxy profile list
+moxxy profile enterprise                              # review
+moxxy profile enterprise | sudo tee /etc/moxxy/config.yaml
+moxxy doctor                                          # confirm what took effect
+```
+
+### Keeping a fleet on the same plugin set
+
+`plugins.packages` is the install ledger. Commit it with a project, or push it from the system scope, and `moxxy sync` converges a machine on it.
+
+```sh
+moxxy sync            # install what the manifest declares and is missing
+moxxy sync --check    # report drift, exit 1, change nothing
+```
+
+`--check` exits non-zero only for *missing* packages, so it works as a provisioning gate in CI. Sync never removes anything: a package a user installed themselves is reported as extra, and removing it is their call.
+
 ### Locking settings a user must not change
 
 A system config can pin dot-paths. Every listed path is stripped from the user, project, and explicit layers before merging, and the attempt is reported on stderr.

--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -30,6 +30,7 @@ const BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
   'background',
   'allow-scripts',
   'list',
+  'check',
 ]);
 
 /**

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -66,6 +66,9 @@ const SECTIONS: ReadonlyArray<{ readonly title: string; readonly rows: ReadonlyA
       ['self-update status|rollback', 'inspect / roll back self-update transactions'],
       ['perms list|allow|deny|remove|clear|path', 'view / edit the permission policy'],
       ['config show|get|set|path', 'read / edit the moxxy config (user or project scope)'],
+      ['config trust|untrust', 'approve an executable project config so it may run'],
+      ['profile list|<name>', 'print a deployment baseline for the system config scope'],
+      ['sync [--check]', 'reconcile installed plugins with the config manifest'],
       ['memory list|audit|show|revert|prune-stale|path', 'curate long-term memory'],
       ['security audit|isolators|status', 'inspect plugin-security isolation state'],
       ['mcp list|enable|disable|remove|path', 'manage Model Context Protocol servers'],
@@ -224,6 +227,8 @@ const COMMANDS: Record<string, () => Promise<CommandHandler>> = {
   skills: async () => (await import('./commands/skills.js')).runSkillsCommand,
   plugins: async () => (await import('./commands/plugins.js')).runPluginsCommand,
   channels: async () => (await import('./commands/channels.js')).runChannelsCommand,
+  profile: async () => (await import('./commands/profile.js')).runProfileCommand,
+  sync: async () => (await import('./commands/sync.js')).runSyncCommand,
   'self-update': async () => (await import('./commands/self-update.js')).runSelfUpdateCommand,
 };
 

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -1,0 +1,94 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { ParsedArgv } from '../argv.js';
+import { helpRequested, stringFlag } from '../argv-helpers.js';
+import { printError } from '../errors.js';
+import { colors } from '../colors.js';
+import { formatHelp } from './help-format.js';
+import { findProfile, PROFILES } from '../profiles.js';
+
+const HELP = formatHelp({
+  title: 'moxxy profile',
+  tagline: 'print a deployment baseline for the system config scope',
+  sections: [
+    {
+      title: 'COMMANDS',
+      rows: [
+        ['list', 'show the available profiles'],
+        ['<name>', 'print the profile to stdout for review'],
+        ['<name> --write <path>', 'write it to a file (refuses to overwrite)'],
+      ],
+    },
+    {
+      title: 'NOTES',
+      rows: [
+        [
+          'system scope',
+          'a profile belongs in /etc/moxxy/config.yaml (or %PROGRAMDATA%\\moxxy\\, or $MOXXY_SYSTEM_CONFIG), which usually needs root',
+        ],
+        ['review first', 'profiles carry commented, site-specific entries with no safe default'],
+      ],
+    },
+    {
+      title: 'EXAMPLES',
+      rows: [
+        ['moxxy profile enterprise', ''],
+        ['moxxy profile enterprise | sudo tee /etc/moxxy/config.yaml', ''],
+      ],
+    },
+  ],
+});
+
+export async function runProfileCommand(argv: ParsedArgv): Promise<number> {
+  const sub = argv.positional[0];
+  if (!sub || sub === 'help' || helpRequested(argv)) {
+    process.stdout.write(HELP);
+    return sub ? 0 : 2;
+  }
+
+  if (sub === 'list') {
+    const col = Math.max(...PROFILES.map((p) => p.name.length));
+    for (const p of PROFILES) {
+      process.stdout.write(`${colors.bold(p.name.padEnd(col))}  ${colors.dim(p.description)}\n`);
+      process.stdout.write(`${' '.repeat(col)}  ${colors.dim(`goes in ${p.target}`)}\n`);
+    }
+    return 0;
+  }
+
+  const profile = findProfile(sub);
+  if (!profile) {
+    printError(`unknown profile: ${sub}\nrun \`moxxy profile list\` to see what exists`);
+    return 2;
+  }
+
+  const target = stringFlag(argv, 'write');
+  if (!target) {
+    // Bare stdout, no decoration: the common use is piping into `sudo tee`.
+    process.stdout.write(profile.yaml);
+    return 0;
+  }
+
+  const resolved = path.resolve(target);
+  try {
+    // Never overwrite: a system config already in place encodes decisions
+    // somebody made, and clobbering it could silently unlock a control.
+    await fs.writeFile(resolved, profile.yaml, { flag: 'wx' });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') {
+      printError(
+        `refusing to overwrite ${resolved}\n` +
+          'It may already encode decisions someone made. Diff against ' +
+          `\`moxxy profile ${profile.name}\` and merge by hand.`,
+      );
+      return 1;
+    }
+    printError(`cannot write ${resolved}: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+  process.stdout.write(
+    `wrote ${resolved}\n` +
+      colors.dim(`review it, fill in the commented entries, then verify with \`moxxy doctor\`\n`),
+  );
+  return 0;
+}

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { computeDrift } from './sync.js';
+
+const base = {
+  loaded: [] as string[],
+  installedSeparately: [] as string[],
+  packages: {} as Record<string, { enabled?: boolean } | undefined>,
+};
+
+describe('computeDrift', () => {
+  it('reports a declared package that is not loaded', () => {
+    const d = computeDrift({ ...base, packages: { '@moxxy/plugin-memory': {} } });
+    expect(d.missing).toEqual(['@moxxy/plugin-memory']);
+  });
+
+  it('is silent when the manifest is satisfied', () => {
+    const d = computeDrift({
+      ...base,
+      loaded: ['@moxxy/plugin-memory'],
+      packages: { '@moxxy/plugin-memory': {} },
+    });
+    expect(d).toEqual({ missing: [], disabledButPresent: [], extra: [] });
+  });
+
+  // A package the operator turned off is not missing; it applies on next boot.
+  it('does not treat a deliberately disabled package as missing', () => {
+    const d = computeDrift({ ...base, packages: { '@moxxy/plugin-memory': { enabled: false } } });
+    expect(d.missing).toEqual([]);
+  });
+
+  it('separates disabled-but-still-installed from missing', () => {
+    const d = computeDrift({
+      ...base,
+      loaded: ['@moxxy/plugin-memory'],
+      packages: { '@moxxy/plugin-memory': { enabled: false } },
+    });
+    expect(d.disabledButPresent).toEqual(['@moxxy/plugin-memory']);
+    expect(d.missing).toEqual([]);
+  });
+
+  // The bug this replaced: a name-shape heuristic reported every bundled
+  // kernel package as drift, a dozen false lines on a healthy machine.
+  it('never reports a bundled package as extra', () => {
+    const d = computeDrift({
+      ...base,
+      loaded: ['@moxxy/plugin-cli', '@moxxy/plugin-vault', '@moxxy/plugin-commands'],
+      installedSeparately: [],
+      packages: {},
+    });
+    expect(d.extra).toEqual([]);
+  });
+
+  it('reports a separately-installed package that the manifest omits', () => {
+    const d = computeDrift({
+      ...base,
+      loaded: ['@moxxy/plugin-cli', 'some-third-party-plugin'],
+      installedSeparately: ['some-third-party-plugin'],
+      packages: {},
+    });
+    expect(d.extra).toEqual(['some-third-party-plugin']);
+  });
+
+  it('does not report a separately-installed package the manifest declares', () => {
+    const d = computeDrift({
+      ...base,
+      loaded: ['@moxxy/plugin-memory'],
+      installedSeparately: ['@moxxy/plugin-memory'],
+      packages: { '@moxxy/plugin-memory': {} },
+    });
+    expect(d.extra).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,0 +1,167 @@
+import { installPluginPackagePinned, resolveInstallSource } from '@moxxy/plugin-plugins-admin';
+import type { ParsedArgv } from '../argv.js';
+import { argvToSetupOptions, hasBoolFlag, helpRequested } from '../argv-helpers.js';
+import { probeSession } from '../setup.js';
+import { printError } from '../errors.js';
+import { colors } from '../colors.js';
+import { cliVersion } from '../version.js';
+import { formatHelp } from './help-format.js';
+
+const HELP = formatHelp({
+  title: 'moxxy sync',
+  tagline: 'reconcile installed plugins with the config manifest',
+  sections: [
+    {
+      title: 'COMMANDS',
+      rows: [
+        ['moxxy sync', 'install everything the manifest declares and is missing'],
+        ['moxxy sync --check', 'report drift and exit 1 without changing anything'],
+      ],
+    },
+    {
+      title: 'NOTES',
+      rows: [
+        [
+          'the manifest',
+          'the merged `plugins.packages` map. Commit it with the project (or push it from the system scope) and every workstation converges on the same set.',
+        ],
+        [
+          'not a remover',
+          'sync installs what is missing and reports what is extra. Removing a package a user installed is their call, so it is reported, never done.',
+        ],
+      ],
+    },
+  ],
+});
+
+export interface Drift {
+  /** Declared and enabled, but not loaded. The only hard failure. */
+  readonly missing: ReadonlyArray<string>;
+  /** Installed separately, absent from the manifest. */
+  readonly extra: ReadonlyArray<string>;
+  /** Present on disk but turned off in config; applies on the next boot. */
+  readonly disabledButPresent: ReadonlyArray<string>;
+}
+
+export interface DriftInput {
+  readonly loaded: ReadonlyArray<string>;
+  /** Loaded packages the host flagged as discovered from ~/.moxxy/plugins. */
+  readonly installedSeparately: ReadonlyArray<string>;
+  readonly packages: Readonly<Record<string, { enabled?: boolean } | undefined>>;
+}
+
+/**
+ * Compare the manifest against what is actually loaded.
+ *
+ * `extra` is computed from the host's static-vs-discovered flag rather than
+ * from the package name: bundled kernel packages are always loaded and never
+ * declared, so name-shape heuristics report a dozen false positives on a
+ * healthy machine and train the operator to ignore the output.
+ */
+export function computeDrift(input: DriftInput): Drift {
+  const loaded = new Set(input.loaded);
+  const declared = Object.entries(input.packages);
+  return {
+    missing: declared
+      .filter(([name, settings]) => settings?.enabled !== false && !loaded.has(name))
+      .map(([name]) => name),
+    disabledButPresent: declared
+      .filter(([name, settings]) => settings?.enabled === false && loaded.has(name))
+      .map(([name]) => name),
+    extra: input.installedSeparately.filter((name) => !(name in input.packages)),
+  };
+}
+
+export async function runSyncCommand(argv: ParsedArgv): Promise<number> {
+  if (helpRequested(argv)) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const checkOnly = hasBoolFlag(argv, 'check');
+
+  // A probe: registries only, no init hooks or daemons, and the session is
+  // closed before we act. Booting a full session to decide what to install
+  // would need the very plugins we are about to install.
+  const probe = await probeSession(
+    argvToSetupOptions(argv, {
+      skipKeyPrompt: true,
+      tolerateNoProvider: true,
+      skipProviderActivation: true,
+    }),
+    ({ session, config }) => ({
+      loaded: session.pluginHost.list().map((p) => p.name),
+      // `installed` is the host's own static-vs-discovered flag: true only for
+      // packages that came from ~/.moxxy/plugins. Bundled kernel packages are
+      // always loaded without ever being declared, so counting those as drift
+      // would print a dozen lines on a healthy machine and train the operator
+      // to ignore the output.
+      installedSeparately: session.pluginHost
+        .list()
+        .filter((p) => p.installed)
+        .map((p) => p.name),
+      packages: config.plugins?.packages ?? {},
+    }),
+  );
+
+  const declared = Object.entries(probe.packages);
+  if (declared.length === 0) {
+    process.stdout.write(
+      colors.dim('no `plugins.packages` manifest found; nothing to reconcile\n'),
+    );
+    return 0;
+  }
+
+  const drift = computeDrift(probe);
+
+  report(drift);
+
+  if (checkOnly) {
+    // Only MISSING is a hard failure. An extra package is a local decision, and
+    // a disabled-but-present one applies on the next boot, so neither should
+    // fail a pipeline that is checking "is this machine provisioned".
+    return drift.missing.length > 0 ? 1 : 0;
+  }
+  if (drift.missing.length === 0) return 0;
+
+  let failed = 0;
+  for (const name of drift.missing) {
+    try {
+      const resolved = await resolveInstallSource(name);
+      const result = await installPluginPackagePinned({
+        packageName: resolved?.spec ?? name,
+        ...(resolved?.pinnedVersion ? { pinnedVersion: resolved.pinnedVersion } : {}),
+        ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
+        onWarn: (msg) => process.stderr.write(colors.dim(msg) + '\n'),
+      });
+      process.stdout.write(`installed ${colors.bold(name)} ${colors.dim(`(${result.installed})`)}\n`);
+    } catch (err) {
+      failed++;
+      printError(`${name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  if (failed > 0) return 1;
+  process.stdout.write(colors.dim('run `moxxy plugins reload` (or restart) to load them\n'));
+  return 0;
+}
+
+function report(drift: Drift): void {
+  if (drift.missing.length > 0) {
+    process.stdout.write(colors.bold('missing') + colors.dim(' (declared, not installed)') + '\n');
+    for (const n of drift.missing) process.stdout.write(`  ${n}\n`);
+  }
+  if (drift.disabledButPresent.length > 0) {
+    process.stdout.write(
+      colors.bold('\ndisabled') + colors.dim(' (installed but turned off in config)') + '\n',
+    );
+    for (const n of drift.disabledButPresent) process.stdout.write(`  ${n}\n`);
+  }
+  if (drift.extra.length > 0) {
+    process.stdout.write(
+      colors.bold('\nextra') + colors.dim(' (installed, not in the manifest)') + '\n',
+    );
+    for (const n of drift.extra) process.stdout.write(`  ${n}\n`);
+  }
+  if (drift.missing.length === 0 && drift.extra.length === 0 && drift.disabledButPresent.length === 0) {
+    process.stdout.write(colors.dim('in sync with the manifest\n'));
+  }
+}

--- a/packages/cli/src/profiles.test.ts
+++ b/packages/cli/src/profiles.test.ts
@@ -1,0 +1,123 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadConfig } from '@moxxy/config';
+import { findProfile, PROFILES } from './profiles.js';
+
+describe('deployment profiles', () => {
+  let home: string;
+  let project: string;
+  let sysFile: string;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-profile-home-'));
+    project = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-profile-proj-'));
+    const sysDir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-profile-etc-'));
+    sysFile = path.join(sysDir, 'config.yaml');
+    for (const k of ['MOXXY_HOME', 'MOXXY_SYSTEM_CONFIG']) saved[k] = process.env[k];
+    process.env.MOXXY_HOME = home;
+    process.env.MOXXY_SYSTEM_CONFIG = sysFile;
+  });
+
+  afterEach(async () => {
+    for (const k of ['MOXXY_HOME', 'MOXXY_SYSTEM_CONFIG']) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    await Promise.all([home, project].map((d) => fs.rm(d, { recursive: true, force: true })));
+  });
+
+  it('every profile names a target and a description', () => {
+    expect(PROFILES.length).toBeGreaterThan(0);
+    for (const p of PROFILES) {
+      expect(p.name).toMatch(/^[a-z][a-z0-9-]*$/);
+      expect(p.description.length).toBeGreaterThan(0);
+      expect(p.target.length).toBeGreaterThan(0);
+    }
+  });
+
+  // The profile is shipped as text, so nothing else would catch a typo in it.
+  // Load it through the REAL loader rather than a YAML parser, so schema drift
+  // (a renamed key, a tightened enum) fails here too.
+  it('the enterprise profile parses and applies through the real loader', async () => {
+    const profile = findProfile('enterprise');
+    expect(profile).toBeDefined();
+    await fs.writeFile(sysFile, profile!.yaml);
+
+    const { config, sources } = await loadConfig({ cwd: project });
+
+    expect(sources.some((s) => s.scope === 'system')).toBe(true);
+    expect(config.security?.enabled).toBe(true);
+    expect(config.security?.requireDeclaration).toBe(true);
+    expect(config.security?.thirdPartyRequireDeclaration).toBe('enforce');
+    expect(config.plugins?.isolator?.default).toBe('subprocess');
+    expect(config.config?.allowExecutable).toBe(false);
+    expect(config.audit?.enabled).toBe(true);
+  });
+
+  // The whole point of the profile: these cannot be switched off downstream.
+  it('locks the security controls against a user config', async () => {
+    await fs.writeFile(sysFile, findProfile('enterprise')!.yaml);
+    await fs.writeFile(
+      path.join(home, 'config.yaml'),
+      [
+        'security:',
+        '  enabled: false',
+        '  requireDeclaration: false',
+        '  thirdPartyRequireDeclaration: "off"',
+        'config:',
+        '  allowExecutable: true',
+        'audit:',
+        '  enabled: false',
+        '',
+      ].join('\n'),
+    );
+
+    const { config, lockedOverrides } = await loadConfig({ cwd: project, warn: () => {} });
+
+    expect(config.security?.enabled).toBe(true);
+    expect(config.security?.requireDeclaration).toBe(true);
+    expect(config.security?.thirdPartyRequireDeclaration).toBe('enforce');
+    expect(config.config?.allowExecutable).toBe(false);
+    expect(config.audit?.enabled).toBe(true);
+    expect(lockedOverrides.map((o) => o.key).sort()).toContain('security.enabled');
+  });
+
+  // Locking `audit` as a subtree must take a sibling with it, not just the leaf.
+  it('locking a subtree pins the whole subtree', async () => {
+    await fs.writeFile(sysFile, findProfile('enterprise')!.yaml);
+    await fs.writeFile(
+      path.join(home, 'config.yaml'),
+      'audit:\n  enabled: false\n  includePromptText: true\n',
+    );
+    const { config } = await loadConfig({ cwd: project, warn: () => {} });
+    expect(config.audit?.enabled).toBe(true);
+    expect(config.audit?.includePromptText).toBe(false);
+  });
+
+  // With allowExecutable pinned false, a project's moxxy.config.ts must not run
+  // even for a user who would happily approve it.
+  it('forbids executable project configs once installed', async () => {
+    await fs.writeFile(sysFile, findProfile('enterprise')!.yaml);
+    await fs.writeFile(path.join(project, 'moxxy.config.ts'), 'export default { maxIterations: 99 }\n');
+
+    const { config, skipped } = await loadConfig({
+      cwd: project,
+      trustPrompt: async () => true,
+      warn: () => {},
+    });
+
+    expect(config.maxIterations).toBeUndefined();
+    expect(skipped[0]?.reason).toContain('disabled by the system config');
+  });
+
+  // Site-specific values have no safe default, so they must ship commented out
+  // rather than as a guess a deployment would silently inherit.
+  it('leaves the proxy unset rather than guessing one', async () => {
+    await fs.writeFile(sysFile, findProfile('enterprise')!.yaml);
+    const { config } = await loadConfig({ cwd: project });
+    expect(config.network).toBeUndefined();
+  });
+});

--- a/packages/cli/src/profiles.ts
+++ b/packages/cli/src/profiles.ts
@@ -1,0 +1,106 @@
+/**
+ * Deployment profiles: a starting config an operator installs, rather than a
+ * new code path.
+ *
+ * A profile is only ever TEXT. It deliberately does not mutate anything by
+ * itself, because the file it belongs in (`/etc/moxxy/config.yaml`) is
+ * root-owned and site-specific: the operator has to read it, fill in the parts
+ * only they know (proxy URL, audit sink, internal registry), and place it. A
+ * command that silently wrote a machine-wide security policy would be doing
+ * the reviewing for them.
+ */
+
+export interface ProfileDef {
+  readonly name: string;
+  readonly description: string;
+  /** Where this profile is meant to live, for the printed instructions. */
+  readonly target: string;
+  readonly yaml: string;
+}
+
+/**
+ * The enterprise baseline.
+ *
+ * Every `locked:` entry is a control a user must not be able to switch off on
+ * their own machine. Everything NOT locked is either site-specific (the proxy
+ * URL) or a preference that carries no security weight, and locking those would
+ * only generate support tickets.
+ *
+ * Left deliberately unset, with comments instead of values: the proxy URL, the
+ * audit sink, and the plugin registry. A profile that guessed those would be
+ * wrong everywhere, and a wrong proxy is indistinguishable from an outage.
+ */
+const ENTERPRISE = `# moxxy enterprise baseline.
+#
+# Place at /etc/moxxy/config.yaml (or %PROGRAMDATA%\\moxxy\\config.yaml, or the
+# path in $MOXXY_SYSTEM_CONFIG). This is the SYSTEM scope: it loads before the
+# user and project configs, and the keys under \`locked:\` are stripped from
+# those layers, so a user cannot turn them off.
+#
+# Review before installing. The commented entries are site-specific and have no
+# safe default.
+
+security:
+  # Enforce declared capabilities at every tool call.
+  enabled: true
+  # Refuse tools that declare no capabilities at all.
+  requireDeclaration: true
+  # Deny undeclared tools from packages outside the @moxxy scope.
+  thirdPartyRequireDeclaration: enforce
+  # Fail closed when a path or URL arrives under an unrecognised field name.
+  strict: true
+
+plugins:
+  isolator:
+    # A real process boundary. 'inproc' is best-effort only and cannot contain
+    # a hostile plugin; 'worker' is the lighter middle ground.
+    default: subprocess
+
+config:
+  # Never execute a project's moxxy.config.ts. Only YAML data is loaded.
+  allowExecutable: false
+
+audit:
+  enabled: true
+  # 'local' is the hash-chained file under ~/.moxxy/audit. It is tamper-EVIDENT
+  # (it detects silent deletion) but not tamper-proof, because whoever can write
+  # the file can recompute the chain. Point this at a remote sink to get a chain
+  # head the workstation cannot rewrite.
+  # sink: <your-sink>
+  retentionDays: 400
+  # Prompt TEXT is off by default; only its length and SHA-256 are recorded, so
+  # a prompt stays provable without the trail disclosing business content.
+  # Turn on only if your retention policy accounts for it.
+  includePromptText: false
+
+# network:
+#   # 'env' (the default) reads http_proxy/https_proxy/no_proxy. Pin a URL here
+#   # to stop a user routing around the proxy by clearing their shell profile.
+#   proxy: http://proxy.example.internal:3128
+#   noProxy: .example.internal,localhost
+#
+# Set NODE_EXTRA_CA_CERTS in the environment when the proxy terminates TLS.
+# Node reads it at startup, so it cannot be configured here.
+
+locked:
+  - security.enabled
+  - security.requireDeclaration
+  - security.thirdPartyRequireDeclaration
+  - security.strict
+  - plugins.isolator
+  - config.allowExecutable
+  - audit
+`;
+
+export const PROFILES: ReadonlyArray<ProfileDef> = [
+  {
+    name: 'enterprise',
+    description: 'managed workstation: isolation enforced, no executable configs, audit on',
+    target: '/etc/moxxy/config.yaml',
+    yaml: ENTERPRISE,
+  },
+];
+
+export function findProfile(name: string): ProfileDef | undefined {
+  return PROFILES.find((p) => p.name === name);
+}


### PR DESCRIPTION
Wave 8. Stacked on #473 (both touch the `COMMANDS` table in `bin.ts`).

The P0 waves added the controls: system config scope, locked keys, audit trail, isolation, proxy. **Nothing turned them on.** An operator had to know all of it existed and hand-write the YAML, which is not a deployment story. This wave is the part that makes the previous five usable in one command.

**`moxxy profile enterprise` only prints.** That is a deliberate choice, not an unfinished one. The file belongs at `/etc/moxxy/config.yaml`, which is root-owned, and it carries site-specific entries with no safe default. A command that silently wrote a machine-wide security policy would be doing the reviewing for the operator, and a guessed proxy URL is indistinguishable from an outage. Proxy, audit sink and registry ship commented out for the same reason.

Every `locked:` entry is a control a user must not be able to switch off on their own machine. Everything else is either site-specific or carries no security weight; locking those would only generate support tickets.

**`moxxy sync`** makes `plugins.packages` the reproducible description of what a workstation runs. `--check` exits 1 on drift so it gates a provisioning pipeline, but only *missing* fails: an extra package is a local decision and a disabled-but-present one applies on next boot, so neither should fail a pipeline asking "is this machine provisioned". Sync never removes; a package a user installed is theirs to remove.

**Bug I shipped and then caught in the smoke test:** my first cut identified extras by package-name shape (`@moxxy/plugin-*`), which reported every bundled kernel package as drift. A dozen false lines on a healthy machine, which is exactly the noise that teaches an operator to stop reading the output. I had even written a comment claiming to avoid that. It now uses the plugin host's own bundled-versus-discovered flag, and there is a test pinning it.

Also worth noting: my first `--check` exit-code test piped through `head`, so `$?` was `head`'s. The check was fine; my verification wasn't. Re-tested with the output redirected.

The profile is shipped as **text**, so nothing else would catch a typo or a schema drift in it. Its tests load it through the real config loader and assert the locked keys actually resist a user config trying to unset them, including that locking `audit` as a subtree takes `includePromptText` with it, rather than parsing the YAML in isolation.

Verified: full gate green (build, typecheck, lint 0 errors, check:deps 0 errors, all test tasks), plus both commands smoke-tested against the real binary with a temporary `MOXXY_HOME`.