### PR TITLE
feat(permissions): apply config rules as a managed layer, add anchored matchers

### DIFF
--- a/.changeset/enterprise-managed-permissions.md
+++ b/.changeset/enterprise-managed-permissions.md
@@ -1,0 +1,11 @@
+---
+'@moxxy/cli': minor
+---
+
+Apply config permission rules, and add anchored path matchers.
+
+`permissions.allow` and `permissions.deny` were declared in the config schema but never applied: only `permissions.policyPath` was read. The config surface was dead, so there was no way for an operator to push a permission rule at all.
+
+They now form an immutable layer above `~/.moxxy/permissions.json`: checked first, never written back, and not removable by editing that file, by answering "allow always", or by deleting it. From the system scope with `permissions` in `locked:`, that is a rule a user cannot get rid of. Decision order is managed deny, file deny, managed allow, file allow.
+
+Two anchored matchers join the existing unanchored `inputMatches`, whose semantics are unchanged. `inputPathPrefix` compares path segments, so `/srv/app` covers `/srv/app/x` but not `/srv/apple`, and `..` is normalised away before comparison. `inputGlob` anchors the whole value, with `*` staying inside a path segment and `**` crossing. An organisation's policy should prefer them: `{ Read: { path: '/etc' } }` as a regex means "contains /etc anywhere", which over-blocks as a deny and over-grants as an allow.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,36 @@ config:
 
 YAML configs are data and are never gated.
 
+### Permission rules an operator can push
+
+`permissions.allow` / `permissions.deny` in config are applied as an **immutable layer above** `~/.moxxy/permissions.json`. They are checked first, never written back, and cannot be removed by editing that file, by answering "allow always", or by deleting it. Put them in the system scope with `permissions` in `locked:` and they become policy a user cannot get rid of.
+
+```yaml
+permissions:
+  deny:
+    # Anchored and path-aware: covers /etc and everything under it.
+    - name: Read
+      inputPathPrefix: { path: /etc }
+      reason: managed policy
+    - name: Read
+      inputGlob: { path: "**/.ssh/**" }
+  allow:
+    - name: Read
+      inputPathPrefix: { path: /srv/app }
+```
+
+Three matchers, and the choice matters:
+
+| Matcher | Semantics |
+|---|---|
+| `inputPathPrefix` | anchored, path-segment aware. `/srv/app` covers `/srv/app/x` but not `/srv/apple`, and `..` is normalised away first. |
+| `inputGlob` | anchored whole-value. `*` stays within a path segment, `**` crosses, `?` is one character. |
+| `inputMatches` | **unanchored** regex, the long-standing policy-file contract. |
+
+Prefer the first two when writing an organisation's policy. `{ Read: { path: '/etc' } }` as `inputMatches` reads like "under /etc" but means "contains /etc anywhere", which over-blocks as a deny and over-grants as an allow.
+
+Decision order: managed deny, then file deny, then managed allow, then file allow.
+
 ### Audit trail
 
 Distinct from the event log. The event log is the conversation: complete, replayable, local. The audit trail is the receipt: bounded, redacted, hash-chained, and safe to forward off the machine.

--- a/packages/cli/src/setup/build-session.ts
+++ b/packages/cli/src/setup/build-session.ts
@@ -48,6 +48,16 @@ export async function buildSession(args: BuildSessionArgs): Promise<Session> {
   const userPolicyPath =
     args.config.permissions?.policyPath ?? path.join(os.homedir(), '.moxxy', 'permissions.json');
   const permissionEngine = await PermissionEngine.load(userPolicyPath);
+  // Config-supplied rules sit ABOVE the user's policy file and are never
+  // written back. From the system scope (with `permissions` in `locked:`) this
+  // is how an operator ships a deny a user cannot remove: not by editing the
+  // file, not by answering "allow always", not by deleting the file.
+  // Previously these config keys existed in the schema and were silently
+  // ignored, so there was no way to push a rule at all.
+  permissionEngine.setImmutableRules({
+    allow: args.config.permissions?.allow ?? [],
+    deny: args.config.permissions?.deny ?? [],
+  });
 
   // The effective session id: an explicit `--resume <id>` (errors if missing),
   // or a sticky `sessionId` (resume-if-present, fresh on first run). Both reuse

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -4,26 +4,34 @@ import { pluginsTreeSchema } from './plugins-tree-schema.js';
 
 export const watcherModeSchema = z.enum(['auto', 'manual', 'off']);
 
+/**
+ * One rule in a config-supplied permission policy.
+ *
+ * `inputMatches` is an UNANCHORED regex (the long-standing contract of the
+ * policy file, never silently anchored). `inputPathPrefix` and `inputGlob` are
+ * anchored alternatives, and an organisation's policy should prefer them: the
+ * obvious `{ Read: { path: '/etc' } }` reads like "under /etc" but as a regex
+ * means "contains /etc anywhere", which over-blocks as a deny and over-grants
+ * as an allow.
+ */
+const permissionRuleSchema = z.object({
+  name: z.string(),
+  inputMatches: z.record(z.string(), z.string()).optional(),
+  inputPathPrefix: z.record(z.string(), z.string()).optional(),
+  inputGlob: z.record(z.string(), z.string()).optional(),
+  reason: z.string().optional(),
+});
+
 export const permissionsConfigSchema = z.object({
   policyPath: z.string().optional(),
-  allow: z
-    .array(
-      z.object({
-        name: z.string(),
-        inputMatches: z.record(z.string(), z.string()).optional(),
-        reason: z.string().optional(),
-      }),
-    )
-    .optional(),
-  deny: z
-    .array(
-      z.object({
-        name: z.string(),
-        inputMatches: z.record(z.string(), z.string()).optional(),
-        reason: z.string().optional(),
-      }),
-    )
-    .optional(),
+  /**
+   * Rules applied as an IMMUTABLE layer above `~/.moxxy/permissions.json`.
+   * Checked first, never written back, and never removable by an "allow
+   * always" answer. Put them in the system scope with `permissions` in
+   * `locked:` and they become policy a user cannot get rid of.
+   */
+  allow: z.array(permissionRuleSchema).optional(),
+  deny: z.array(permissionRuleSchema).optional(),
 });
 
 export const securityConfigSchema = z.object({

--- a/packages/core/src/permissions/engine.test.ts
+++ b/packages/core/src/permissions/engine.test.ts
@@ -264,3 +264,97 @@ describe('PermissionEngine', () => {
     }
   });
 });
+
+describe('immutable (config-supplied) rules', () => {
+  const call = (name: string, input: unknown) => ({ name, input }) as never;
+
+  it('a managed deny beats a file allow', () => {
+    const engine = new PermissionEngine({ allow: [{ name: 'bash' }], deny: [] });
+    engine.setImmutableRules({ allow: [], deny: [{ name: 'bash', reason: 'no shell' }] });
+    expect(engine.check(call('bash', {}))).toEqual({ mode: 'deny', reason: 'no shell' });
+  });
+
+  // "allow always" is an answer the agent can provoke, so it must not be able
+  // to defeat a rule the operator pushed.
+  it('a later allow-always answer cannot defeat a managed deny', async () => {
+    const engine = new PermissionEngine();
+    engine.setImmutableRules({ allow: [], deny: [{ name: 'bash' }] });
+    await engine.addAllow({ name: 'bash' });
+    expect(engine.check(call('bash', {}))?.mode).toBe('deny');
+  });
+
+  it('a managed allow grants without touching the file policy', () => {
+    const engine = new PermissionEngine();
+    engine.setImmutableRules({ allow: [{ name: 'Read' }], deny: [] });
+    expect(engine.check(call('Read', {}))?.mode).toBe('allow');
+    expect(engine.policySnapshot.allow).toEqual([]);
+  });
+
+  it('falls through to the file layer when no managed rule matches', () => {
+    const engine = new PermissionEngine({ allow: [{ name: 'Glob' }], deny: [] });
+    engine.setImmutableRules({ allow: [], deny: [{ name: 'bash' }] });
+    expect(engine.check(call('Glob', {}))?.mode).toBe('allow');
+  });
+
+  it('is empty by default, so nothing changes without config', () => {
+    expect(new PermissionEngine().getImmutableRules()).toEqual({ allow: [], deny: [] });
+  });
+});
+
+describe('anchored matchers', () => {
+  const call = (name: string, input: unknown) => ({ name, input }) as never;
+  const denyPrefix = (prefix: string) =>
+    new PermissionEngine({ allow: [], deny: [{ name: 'Read', inputPathPrefix: { path: prefix } }] });
+
+  it('matches a path at or under the prefix', () => {
+    const e = denyPrefix('/srv/app');
+    expect(e.check(call('Read', { path: '/srv/app' }))?.mode).toBe('deny');
+    expect(e.check(call('Read', { path: '/srv/app/x/y.txt' }))?.mode).toBe('deny');
+  });
+
+  // The exact trap the unanchored regex sets: '/srv/app' must not cover
+  // '/srv/apple', and must not match merely because it appears somewhere.
+  it('does not match a sibling that shares a name prefix', () => {
+    expect(denyPrefix('/srv/app').check(call('Read', { path: '/srv/apple/x' }))).toBeNull();
+  });
+
+  it('does not match the prefix appearing mid-path', () => {
+    expect(denyPrefix('/srv/app').check(call('Read', { path: '/tmp/srv/app/x' }))).toBeNull();
+  });
+
+  // A traversal must not escape a prefix an operator meant as a boundary.
+  it('normalises .. before comparing', () => {
+    const e = denyPrefix('/srv/app');
+    expect(e.check(call('Read', { path: '/srv/app/../../etc/passwd' }))).toBeNull();
+    expect(e.check(call('Read', { path: '/srv/app/sub/../ok.txt' }))?.mode).toBe('deny');
+  });
+
+  it('globs are anchored whole-value', () => {
+    const e = new PermissionEngine({
+      allow: [],
+      deny: [{ name: 'Read', inputGlob: { path: '/etc/*.conf' } }],
+    });
+    expect(e.check(call('Read', { path: '/etc/nginx.conf' }))?.mode).toBe('deny');
+    expect(e.check(call('Read', { path: '/etc/nginx.conf.bak' }))).toBeNull();
+    // A single star must not cross a separator.
+    expect(e.check(call('Read', { path: '/etc/sub/nginx.conf' }))).toBeNull();
+  });
+
+  it('** crosses separators', () => {
+    const e = new PermissionEngine({
+      allow: [],
+      deny: [{ name: 'Read', inputGlob: { path: '/etc/**/*.conf' } }],
+    });
+    expect(e.check(call('Read', { path: '/etc/a/b/nginx.conf' }))?.mode).toBe('deny');
+  });
+
+  // A glob must never be able to smuggle in regex syntax.
+  it('escapes regex metacharacters in a glob', () => {
+    const e = new PermissionEngine({
+      allow: [],
+      deny: [{ name: 'Read', inputGlob: { path: '/etc/a+b.txt' } }],
+    });
+    expect(e.check(call('Read', { path: '/etc/a+b.txt' }))?.mode).toBe('deny');
+    expect(e.check(call('Read', { path: '/etc/aaab.txt' }))).toBeNull();
+  });
+});

--- a/packages/core/src/permissions/engine.ts
+++ b/packages/core/src/permissions/engine.ts
@@ -1,6 +1,7 @@
 import { createMutex, type Mutex, type PendingToolCall, type PermissionDecision } from '@moxxy/sdk';
 import { PRIVATE_FILE_MODE, writeFileAtomic } from '@moxxy/sdk/server';
 import { promises as fs } from 'node:fs';
+import { posix } from 'node:path';
 import { z } from 'zod';
 
 /**
@@ -26,20 +27,37 @@ export interface PolicyRule {
    * because a glob is a whole-name convention, not an author-supplied regex.)
    */
   readonly inputMatches?: Record<string, string>;
+  /**
+   * Field name to path PREFIX. Anchored and path-aware, unlike
+   * {@link inputMatches}: `{ path: '/srv/app' }` matches `/srv/app/x` but not
+   * `/srv/apple` and not `/tmp/srv/app`.
+   *
+   * Exists because the unanchored regex above is a trap for whoever writes an
+   * organisation's policy. The obvious `{ Read: { path: '/etc' } }` reads like
+   * "under /etc" and actually means "contains /etc anywhere", which as a DENY
+   * rule over-blocks and as an ALLOW rule grants far more than intended. Paths
+   * are normalised before comparison, so `..` cannot walk out of the prefix.
+   */
+  readonly inputPathPrefix?: Record<string, string>;
+  /**
+   * Field name to a glob, anchored whole-value. `*` matches within a path
+   * segment, `**` across segments, `?` one character.
+   */
+  readonly inputGlob?: Record<string, string>;
   readonly reason?: string;
 }
 
+const policyRuleSchema = z.object({
+  name: z.string(),
+  inputMatches: z.record(z.string(), z.string()).optional(),
+  inputPathPrefix: z.record(z.string(), z.string()).optional(),
+  inputGlob: z.record(z.string(), z.string()).optional(),
+  reason: z.string().optional(),
+});
+
 export const permissionPolicySchema = z.object({
-  allow: z.array(z.object({
-    name: z.string(),
-    inputMatches: z.record(z.string(), z.string()).optional(),
-    reason: z.string().optional(),
-  })).default([]),
-  deny: z.array(z.object({
-    name: z.string(),
-    inputMatches: z.record(z.string(), z.string()).optional(),
-    reason: z.string().optional(),
-  })).default([]),
+  allow: z.array(policyRuleSchema).default([]),
+  deny: z.array(policyRuleSchema).default([]),
 });
 
 export type PermissionPolicy = z.infer<typeof permissionPolicySchema>;
@@ -115,10 +133,55 @@ export class PermissionEngine {
     }
   }
 
+  /**
+   * Rules from CONFIG, which the mutators never touch and `save()` never
+   * writes. When they come from the system scope (with the path in `locked:`)
+   * they are the operator's policy, and the point is that a user cannot get rid
+   * of them: not by editing `~/.moxxy/permissions.json`, not by answering
+   * "allow always", not by deleting the file.
+   */
+  private immutable: PermissionPolicy = emptyPolicy;
+
+  /**
+   * Install the config-supplied layer. Separate from `policy` because the two
+   * have different owners and different lifetimes: this one is re-derived from
+   * config on every boot, the other is a user file the agent writes to.
+   */
+  setImmutableRules(rules: PermissionPolicy): void {
+    this.immutable = rules;
+  }
+
+  /** The config-supplied layer currently in force. */
+  getImmutableRules(): PermissionPolicy {
+    return this.immutable;
+  }
+
+  /**
+   * Decision order, and each step is load-bearing:
+   *   1. immutable deny:  the operator's policy wins over everything.
+   *   2. file deny:       the user's own standing denials.
+   *   3. immutable allow: an operator-granted exception.
+   *   4. file allow:      "allow always" answers.
+   *
+   * Deny always precedes allow within a layer, and the immutable layer always
+   * precedes the file. Checking the file first would let an "allow always"
+   * answer, which the agent itself can provoke, silently defeat a rule the
+   * operator pushed.
+   */
   check(call: PendingToolCall): PermissionDecision | null {
+    for (const rule of this.immutable.deny) {
+      if (matchRule(rule, call, 'deny')) {
+        return { mode: 'deny', reason: rule.reason ?? `Denied by managed policy: ${rule.name}` };
+      }
+    }
     for (const rule of this.policy.deny) {
       if (matchRule(rule, call, 'deny')) {
         return { mode: 'deny', reason: rule.reason ?? `Denied by policy: ${rule.name}` };
+      }
+    }
+    for (const rule of this.immutable.allow) {
+      if (matchRule(rule, call, 'allow')) {
+        return { mode: 'allow', reason: rule.reason ?? `Allowed by managed policy: ${rule.name}` };
       }
     }
     for (const rule of this.policy.allow) {
@@ -234,7 +297,92 @@ function matchRule(rule: PolicyRule, call: PendingToolCall, intent: 'allow' | 'd
       if (!re.test(candidate)) return false;
     }
   }
+  if (rule.inputPathPrefix) {
+    const input = call.input as Record<string, unknown> | null;
+    if (!input || typeof input !== 'object') return false;
+    for (const [k, prefix] of Object.entries(rule.inputPathPrefix)) {
+      if (!pathHasPrefix(stringifyCandidate(input[k]), prefix)) return false;
+    }
+  }
+  if (rule.inputGlob) {
+    const input = call.input as Record<string, unknown> | null;
+    if (!input || typeof input !== 'object') return false;
+    for (const [k, glob] of Object.entries(rule.inputGlob)) {
+      const re = compileGlob(glob);
+      if (re === null) {
+        // An uncompilable glob fails the same way a bad regex does: a deny
+        // still denies, an allow does not grant.
+        if (intent === 'deny') continue;
+        return false;
+      }
+      if (!re.test(stringifyCandidate(input[k]))) return false;
+    }
+  }
   return true;
+}
+
+/**
+ * Whether `candidate` sits at or under `prefix`, comparing path SEGMENTS.
+ *
+ * `/srv/app` must cover `/srv/app` and `/srv/app/x` but never `/srv/apple`, and
+ * `..` must not walk out: `path.normalize` collapses the traversal before the
+ * comparison, so `/srv/app/../../etc/passwd` is rejected. A relative candidate
+ * is resolved against nothing, so it can only match a relative prefix, which is
+ * the conservative reading.
+ */
+function pathHasPrefix(candidate: string, prefix: string): boolean {
+  if (prefix.length === 0) return false;
+  const c = normalizePath(candidate);
+  const p = normalizePath(prefix);
+  if (c === p) return true;
+  return c.startsWith(p.endsWith('/') ? p : `${p}/`);
+}
+
+function normalizePath(value: string): string {
+  // posix semantics on every platform: policies are written once and shipped to
+  // a fleet, so a rule must not mean different things on Windows.
+  const normalized = posix.normalize(value.replace(/\\/g, '/'));
+  return normalized.length > 1 && normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
+}
+
+/**
+ * Anchored glob to RegExp. `**` crosses path separators, `*` does not, `?` is
+ * one non-separator character. Everything else is escaped, so a glob can never
+ * smuggle in regex syntax.
+ */
+const globCache = new Map<string, RegExp | null>();
+
+function compileGlob(glob: string): RegExp | null {
+  const cached = globCache.get(glob);
+  if (cached !== undefined) return cached;
+  let out = '';
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i]!;
+    if (ch === '*') {
+      if (glob[i + 1] === '*') {
+        out += '.*';
+        i++;
+      } else {
+        out += '[^/]*';
+      }
+    } else if (ch === '?') {
+      out += '[^/]';
+    } else {
+      out += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  let compiled: RegExp | null;
+  try {
+    compiled = new RegExp(`^${out}$`);
+  } catch {
+    compiled = null;
+  }
+  if (globCache.size >= MAX_REGEX_CACHE) {
+    const oldest = globCache.keys().next().value;
+    if (oldest !== undefined) globCache.delete(oldest);
+  }
+  globCache.set(glob, compiled);
+  return compiled;
 }
 
 /**


### PR DESCRIPTION
Wave 9. Off `development`; independent of #474, which is still open (different files).

**The finding that drove this:** `permissions.allow` and `permissions.deny` exist in the config schema and are **never applied**. `build-session.ts` reads only `permissions.policyPath`. So that config surface was dead, and an operator had no way to push a permission rule at all.

That was the last hole in the chain the P0 waves built. The system scope could pin every other setting, but the permission policy stayed a user-writable JSON file with nothing above it, which made "the operator decides" untrue exactly where it matters most.

Config rules now form an immutable layer above `~/.moxxy/permissions.json`: checked first, never written back by the mutators or `save()`, and not removable by editing the file, by answering "allow always", or by deleting it.

Order is **managed deny, file deny, managed allow, file allow**. Checking the file first would let an allow-always answer, which the agent itself can provoke through a prompt, silently defeat a rule the operator pushed. There is a test for exactly that sequence.

**On the matchers.** `inputMatches` keeps its unanchored semantics, unchanged, because existing policy files depend on them. But that contract is a trap for whoever writes an organisation's policy: `{ Read: { path: '/etc' } }` reads like "under /etc" and means "contains /etc anywhere", which over-blocks as a deny and over-grants as an allow. So:

- `inputPathPrefix` compares path **segments**. `/srv/app` covers `/srv/app/x` but not `/srv/apple`, and paths are normalised first so `..` cannot walk out of a boundary an operator meant to hold.
- `inputGlob` anchors the whole value. `*` stays inside a segment, `**` crosses, everything else is escaped so a glob can never smuggle in regex syntax.

Both use posix semantics on every platform: a policy is written once and shipped to a fleet, and must not mean two different things on Windows.

**Scope note:** `SecretProvider` was in this wave's original description and I took it out. It is a whole new registry-backed block, and this change is already reviewable on its own. It should be its own PR.

Verified: full gate green (build, typecheck, lint 0 errors, check:deps 0 errors). 12 new tests covering the layer ordering, the allow-always-cannot-win case, prefix vs sibling-name (`/srv/apple`), traversal normalisation, glob anchoring, and metacharacter escaping.

One flake to flag: `@moxxy/isolator-subprocess` failed once in the full turbo run on a timing-sensitive abort test (aborts at 150 ms, then polls for a marker a child writes before SIGKILL). It passes 23/23 standalone three times in a row, and nothing here touches isolators. Same category as the `workflows` flake I reported on #470.