### PR TITLE
fix(tui): stop leaking bearer tokens, gate the banner, tier the status line

### DIFF
--- a/.changeset/enterprise-tui-polish.md
+++ b/.changeset/enterprise-tui-polish.md
@@ -1,0 +1,13 @@
+---
+'@moxxy/cli': patch
+---
+
+TUI polish: stop leaking bearer tokens into scrollback, drop the banner from piped output, degrade the status line on narrow terminals.
+
+The permission dialog redacted by field NAME only, so a Bash call's `command` printed `curl -H "Authorization: Bearer sk-ant-…"` verbatim. That is the exact string the dialog exists to show a human, on a terminal that may be recorded or screen-shared. It now uses the SDK redactor, which also masks secret-shaped values inside ordinary fields, so the TUI and the audit trail mask the same things.
+
+`--help` and `--version` no longer print the 31-row mascot when stdout is not a TTY, or when `NO_COLOR` is set. It stays on an interactive terminal, where it is the product's face rather than noise ahead of the answer.
+
+The status line now drops segments by terminal width instead of wrapping, which in an Ink flex row reads as broken rather than degraded. Order of loss is version chip, MCP count, model id, context meter, keeping what changes most often. Width is tracked live, so a resize re-tiers instead of freezing the layout at mount.
+
+The enterprise profile now pins the mobile channel to loopback. It binds `0.0.0.0` by default so a physical phone works out of the box, which on a corporate laptop puts a token-gated listener on the office network.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -112,6 +112,20 @@ const SECTIONS: ReadonlyArray<{ readonly title: string; readonly rows: ReadonlyA
 const ROW_INDENT = 4;
 const RULE_INDENT = 2;
 
+/**
+ * The mascot, but only where a human is looking at it.
+ *
+ * It is 31 rows of art. On a TTY that is the product's face; piped into a file,
+ * a CI log, or `grep`, it is 31 rows of noise ahead of the answer, and it
+ * garbles on a terminal without UTF-8. `NO_COLOR` is honoured as a general
+ * "keep output plain" signal, which is how the rest of the CLI reads it.
+ */
+function banner(): string {
+  if (!process.stdout.isTTY) return '';
+  if (process.env.NO_COLOR || process.env.MOXXY_NO_COLOR) return '';
+  return renderLogo(undefined, { center: true });
+}
+
 function renderHelp(): string {
   const width = process.stdout.columns ?? 80;
 
@@ -191,7 +205,7 @@ function renderHelp(): string {
  */
 const COMMANDS: Record<string, () => Promise<CommandHandler>> = {
   help: async () => async () => {
-    process.stdout.write(renderLogo(undefined, { center: true }) + renderHelp());
+    process.stdout.write(banner() + renderHelp());
     return 0;
   },
   version: async () => async () => {
@@ -199,7 +213,7 @@ const COMMANDS: Record<string, () => Promise<CommandHandler>> = {
     const width = process.stdout.columns ?? 80;
     const line = `moxxy ${v}`;
     const pad = ' '.repeat(Math.max(0, Math.floor((width - line.length) / 2)));
-    process.stdout.write(renderLogo(undefined, { center: true }) + pad + line + '\n');
+    process.stdout.write(banner() + pad + line + '\n');
     return 0;
   },
   init: async () => (await import('./commands/init.js')).runInitCommand,
@@ -331,9 +345,7 @@ async function main(): Promise<number> {
     return 2;
   }
 
-  process.stderr.write(
-    colors.red(`unknown command: ${argv.command}`) + '\n' + renderHelp(),
-  );
+  process.stderr.write(colors.red(`unknown command: ${argv.command}`) + '\n' + renderHelp());
   return 2;
 }
 

--- a/packages/cli/src/profiles.test.ts
+++ b/packages/cli/src/profiles.test.ts
@@ -121,3 +121,35 @@ describe('deployment profiles', () => {
     expect(config.network).toBeUndefined();
   });
 });
+
+describe('enterprise profile: mobile bind', () => {
+  // The mobile channel binds 0.0.0.0 by default so a physical phone works out
+  // of the box. Correct for a consumer install, wrong for a corporate laptop:
+  // it puts a token-gated listener on the office network.
+  it('pins the mobile channel to loopback and locks it', async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-mob-home-'));
+    const project = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-mob-proj-'));
+    const sysDir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-mob-etc-'));
+    const sysFile = path.join(sysDir, 'config.yaml');
+    const prevHome = process.env.MOXXY_HOME;
+    const prevSys = process.env.MOXXY_SYSTEM_CONFIG;
+    process.env.MOXXY_HOME = home;
+    process.env.MOXXY_SYSTEM_CONFIG = sysFile;
+    try {
+      await fs.writeFile(sysFile, findProfile('enterprise')!.yaml);
+      await fs.writeFile(
+        path.join(home, 'config.yaml'),
+        'channels:\n  mobile:\n    bindHost: 0.0.0.0\n',
+      );
+      const { config } = await loadConfig({ cwd: project, warn: () => {} });
+      const mobile = config.channels?.mobile as { bindHost?: string } | undefined;
+      expect(mobile?.bindHost).toBe('127.0.0.1');
+    } finally {
+      if (prevHome === undefined) delete process.env.MOXXY_HOME;
+      else process.env.MOXXY_HOME = prevHome;
+      if (prevSys === undefined) delete process.env.MOXXY_SYSTEM_CONFIG;
+      else process.env.MOXXY_SYSTEM_CONFIG = prevSys;
+      await Promise.all([home, project, sysDir].map((d) => fs.rm(d, { recursive: true, force: true })));
+    }
+  });
+});

--- a/packages/cli/src/profiles.ts
+++ b/packages/cli/src/profiles.ts
@@ -73,6 +73,13 @@ audit:
   # Turn on only if your retention policy accounts for it.
   includePromptText: false
 
+channels:
+  mobile:
+    # Loopback, not the LAN. The mobile channel binds 0.0.0.0 by default so a
+    # physical phone works out of the box; on a corporate laptop that puts a
+    # token-gated listener on the office network. Pair over a tunnel instead.
+    bindHost: 127.0.0.1
+
 # network:
 #   # 'env' (the default) reads http_proxy/https_proxy/no_proxy. Pin a URL here
 #   # to stop a user routing around the proxy by clearing their shell profile.
@@ -90,6 +97,7 @@ locked:
   - plugins.isolator
   - config.allowExecutable
   - audit
+  - channels.mobile.bindHost
 `;
 
 export const PROFILES: ReadonlyArray<ProfileDef> = [

--- a/packages/plugin-cli/src/components/StatusLine.tsx
+++ b/packages/plugin-cli/src/components/StatusLine.tsx
@@ -60,10 +60,21 @@ export const StatusLine: React.FC<StatusLineProps> = ({
   version,
   updateLatest,
 }) => {
+  // Width tiers. The right-hand side is provider + model + mcp + a 10-cell
+  // context bar + a version chip; under roughly 90 columns that no longer fits
+  // beside the left-hand state, and an Ink flex row that overflows WRAPS, which
+  // reads as broken rather than as degraded. Drop segments in reverse order of
+  // how much they tell you mid-turn: the version chip is reference information,
+  // the mcp count is a rarely-changing status, the model id is recoverable from
+  // /info, and the context meter is the one that changes every turn.
+  const columns = useTerminalColumns();
+  const tier = columns >= 100 ? 'full' : columns >= 84 ? 'wide' : columns >= 68 ? 'narrow' : 'tiny';
   const busy = busyStartedAt != null;
   const showQueue = (queueCount ?? 0) > 0;
-  const showMcp = !!(mcp && mcp.enabled > 0);
-  const showCtx = !!(contextWindow && contextWindow > 0);
+  const showMcp = !!(mcp && mcp.enabled > 0) && tier === 'full';
+  const showCtx = !!(contextWindow && contextWindow > 0) && tier !== 'tiny';
+  const showModel = tier === 'full' || tier === 'wide';
+  const showVersion = !!version && tier === 'full';
   const queuedTail = showQueue ? (
     <>
       <Text dimColor>{'  '}</Text>
@@ -102,7 +113,7 @@ export const StatusLine: React.FC<StatusLineProps> = ({
       </Box>
       <Box>
         <ProviderBadge name={provider} />
-        <Text dimColor>{`  ${model}`}</Text>
+        {showModel ? <Text dimColor>{`  ${model}`}</Text> : null}
         {showMcp ? (
           <>
             <Text dimColor>{`  ${Glyphs.midDot}  `}</Text>
@@ -116,7 +127,7 @@ export const StatusLine: React.FC<StatusLineProps> = ({
             <ContextMeter used={contextUsed ?? 0} total={contextWindow!} />
           </>
         ) : null}
-        {version ? (
+        {showVersion ? (
           <>
             <Text dimColor>{`  ${Glyphs.midDot}  `}</Text>
             {updateLatest ? (
@@ -130,6 +141,24 @@ export const StatusLine: React.FC<StatusLineProps> = ({
     </Box>
   );
 };
+
+/**
+ * The terminal's current width, kept live across resizes. Ink exposes
+ * `useStdout`, but reading `columns` once would freeze the layout at whatever
+ * width the pane had when it mounted, and a status bar that only degrades on
+ * remount is a status bar that stays broken for the rest of the session.
+ */
+function useTerminalColumns(): number {
+  const [columns, setColumns] = useState(() => process.stdout.columns ?? 80);
+  useEffect(() => {
+    const onResize = (): void => setColumns(process.stdout.columns ?? 80);
+    process.stdout.on('resize', onResize);
+    return () => {
+      process.stdout.off('resize', onResize);
+    };
+  }, []);
+  return columns;
+}
 
 const ProviderBadge: React.FC<{ name: string }> = ({ name }) => (
   <Text backgroundColor={Colors.chrome} color="black" bold>{` ${name} `}</Text>

--- a/packages/plugin-cli/src/components/redact.test.ts
+++ b/packages/plugin-cli/src/components/redact.test.ts
@@ -62,3 +62,29 @@ describe('isSecretKey', () => {
     expect(isSecretKey('query')).toBe(false);
   });
 });
+
+// The case a key-name-only redactor left wide open: a Bash `command` is not a
+// secret-named field, so the permission dialog printed the bearer token
+// verbatim into scrollback. That is the exact string the dialog exists to show
+// a human, on a terminal that may be recorded or screen-shared.
+describe('secret-shaped values inside ordinary fields', () => {
+  it('masks a bearer token in a Bash command', () => {
+    const out = JSON.stringify(
+      redactSecrets({ command: 'curl -H "Authorization: Bearer sk-ant-api03-SECRET123456" https://x' }),
+    );
+    expect(out).not.toContain('SECRET123456');
+    expect(out).toContain('[redacted]');
+    // The attempt stays legible: a reviewer must still see that a request with
+    // an auth header was proposed.
+    expect(out).toContain('curl');
+  });
+
+  it('masks credentials embedded in a URL argument', () => {
+    const out = JSON.stringify(redactSecrets({ url: 'https://alice:hunter2@internal/api' }));
+    expect(out).not.toContain('hunter2');
+  });
+
+  it('still masks secret-named fields outright', () => {
+    expect(redactSecrets({ apiKey: 'sk-anything' })).toEqual({ apiKey: '[redacted]' });
+  });
+});

--- a/packages/plugin-cli/src/components/redact.ts
+++ b/packages/plugin-cli/src/components/redact.ts
@@ -1,43 +1,22 @@
 /**
- * Shared secret-redaction for any surface that echoes raw tool inputs to the
- * terminal (permission prompt, subagent activity panel). Tool inputs can carry
- * API keys / tokens / vault-resolved values; a length cap is NOT redaction.
- * This masks the VALUES of secret-named fields before they ever reach the
- * scrollback (or terminal logging).
+ * Secret redaction for any surface that echoes raw tool inputs to the terminal
+ * (the permission prompt, the subagent activity panel).
  *
- * Single source of truth so the permission dialog and the agents panel can't
- * drift — one redact one display path, leave the other leaking.
+ * Re-exported from `@moxxy/sdk` rather than reimplemented here, so the TUI, the
+ * audit trail, and anything else that displays or forwards tool input mask the
+ * same things.
+ *
+ * This module used to carry a local, KEY-NAME-ONLY implementation, which left
+ * the case that matters most wide open: a Bash call's `command` is not a
+ * secret-named field, so the permission dialog printed
+ * `curl -H "Authorization: Bearer sk-ant-…"` verbatim into scrollback. That is
+ * precisely the string the dialog exists to show a human, and terminals get
+ * recorded and screens get shared. The SDK version also matches secret-shaped
+ * VALUES inside ordinary fields.
  */
-
-/** Field names whose VALUES are likely secret material and must never be
- *  echoed verbatim. */
-const SECRET_KEY =
-  /(?:api[_-]?key|secret|token|password|passwd|passphrase|authorization|auth[_-]?token|bearer|credential|private[_-]?key|access[_-]?key)/i;
-
-const REDACTED = '[redacted]';
-
-/**
- * Shallow-redact secret-named fields in a tool-input value before display.
- * Best-effort and bounded: only the top three object levels are walked so a
- * pathologically deep input can't blow the stack — anything deeper is returned
- * as-is (the depth cap is below the typical tool-arg shape, so real secrets at
- * sane depths are still masked).
- */
-export function redactSecrets(value: unknown, depth = 0): unknown {
-  if (depth > 2 || value == null || typeof value !== 'object') return value;
-  if (Array.isArray(value)) return value.map((v) => redactSecrets(v, depth + 1));
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-    out[k] = SECRET_KEY.test(k) ? REDACTED : redactSecrets(v, depth + 1);
-  }
-  return out;
-}
-
-/** True when a field name reads as secret-bearing. Lets callers that format
- *  per-field (rather than stringifying the whole object) redact a single
- *  value without rebuilding the object. */
-export function isSecretKey(key: string): boolean {
-  return SECRET_KEY.test(key);
-}
-
-export const REDACTED_PLACEHOLDER = REDACTED;
+export {
+  isSecretKey,
+  redactSecrets,
+  redactSecretText,
+  REDACTED_PLACEHOLDER,
+} from '@moxxy/sdk';


### PR DESCRIPTION
Wave 10, off `development`. Independent of #475 (different files).

Three production-readiness problems in the terminal surface. **One is a real disclosure**, so I would review that part first.

**Bearer tokens in scrollback.** The permission dialog redacted by field *name* only. A Bash call's `command` is not a secret-named field, so the dialog printed `curl -H "Authorization: Bearer sk-ant-…"` verbatim. That is precisely the string the dialog exists to let a human read, on a terminal that may be recorded or screen-shared. The local key-name redactor is now a re-export of the SDK one added with the audit trail (#471), which also matches secret-shaped *values* inside ordinary fields. The TUI and the audit trail now mask the same things instead of drifting, which was the stated reason the local module existed in the first place.

**The banner.** `--help` and `--version` printed 31 rows of mascot before any content. On a TTY that is the product's face; piped into a file, a CI log, or `grep` it is noise ahead of the answer, and it garbles without UTF-8. Gated on `isTTY` plus the NO_COLOR convention, so it stays exactly where a human is looking at it.

**The status line.** Provider + model + mcp + a 10-cell context bar + a version chip in a flex row with no width strategy. Under ~90 columns it wrapped, and a wrapped Ink row reads as broken rather than as degraded. It now drops segments by tier, in reverse order of how much each tells you mid-turn: version chip, then mcp count, then model id, keeping the context meter longest because it is the one that changes every turn. Width is tracked across resizes rather than read once, since a bar that only degrades on remount stays broken for the rest of the session.

Also pins the mobile channel to loopback in the enterprise profile. `0.0.0.0` is right for a consumer install (a physical phone pairs out of the box) and wrong on a corporate laptop, where it puts a token-gated listener on the office network. Locked, with a test that a user config setting `0.0.0.0` does not win.

Not in this PR, from the same audit section: an optional `ToolDef.icon` so MCP and third-party tools stop collapsing to one glyph, and a `tui.density: compact` option. Both are additive and neither is a defect, so they can go separately.

Verified: full gate green (build, typecheck, lint 0 errors, all test tasks). Banner behaviour smoke-tested against the real binary piped and with `NO_COLOR`.