### PR TITLE
feat(onboard): surface the swap axis, and make the audit sink swappable

### DIFF
--- a/.changeset/enterprise-onboard-blocks.md
+++ b/.changeset/enterprise-onboard-blocks.md
@@ -1,0 +1,11 @@
+---
+'@moxxy/cli': patch
+---
+
+Surface the swappable blocks during onboarding, and make the audit sink swappable.
+
+Everything in moxxy is a swappable block: the loop, the compactor, the cache strategy, the isolator, the event store, the audit sink. `moxxy plugins defaults` has always exposed that, but onboarding never mentioned it, so a user could finish setup without learning the central idea and would then reach for config files to change something the swap axis already owns.
+
+Onboarding now shows what each block resolves to, and offers a swap only for categories that genuinely have an alternative. On a fresh install most hold exactly one registration, and asking "which compactor?" when there is one compactor teaches the user that the wizard wastes their time.
+
+The `auditSink` registry added with the audit trail was missing from the category-swap surface, so the one block introduced as swappable was the one block you could not swap. It now appears in `moxxy plugins defaults` alongside the rest.

--- a/packages/cli/src/commands/onboard.ts
+++ b/packages/cli/src/commands/onboard.ts
@@ -4,6 +4,7 @@ import {
   INSTALLABLE_PLUGIN_CATALOG,
   installPluginPackagePinned,
   type PluginCatalogEntry,
+  setCategoryDefault,
 } from '@moxxy/plugin-plugins-admin';
 import { EXIT_AFTER_PAIR_FLAG } from '@moxxy/sdk';
 import type { ParsedArgv } from '../argv.js';
@@ -12,6 +13,8 @@ import { colors } from '../colors.js';
 import { probeSession } from '../setup.js';
 import { cliVersion } from '../version.js';
 import { runPluginSetupSteps } from '../wizard/plugin-setup-steps.js';
+import { partitionCategories, summariseBlocks } from '../wizard/blocks-step.js';
+import type { CategoryView } from '@moxxy/sdk';
 import { formatHelp } from './help-format.js';
 import { runInitCommand } from './init.js';
 import { runChannelSubcommand } from './run-channel.js';
@@ -275,7 +278,14 @@ export async function runOnboardCommand(argv: ParsedArgv): Promise<number> {
     );
   }
 
-  // ── Step 5: background service ──────────────────────────────────────────
+  // ── Step 5: the swap axis ───────────────────────────────────────────────
+  // Everything in moxxy is a swappable block. `moxxy plugins defaults` has
+  // always exposed that, but onboarding never said so, and a user who finishes
+  // setup without learning it reaches for config files to change something the
+  // swap axis already owns.
+  await runBlocksStep();
+
+  // ── Step 6: background service ──────────────────────────────────────────
   const spec = serveSpec(new Set(), true);
   let serviceState: 'installed' | 'skipped' | 'unsupported' | 'failed' = 'skipped';
   if (!hasBoolFlag(argv, 'no-service')) {
@@ -339,4 +349,68 @@ export async function runOnboardCommand(argv: ParsedArgv): Promise<number> {
       : `Almost there — finish the steps above, then message your agent on ${colors.bold(channelName)}.`,
   );
   return 0;
+}
+
+/**
+ * Show what the swappable blocks currently resolve to, and offer a swap ONLY
+ * where there is genuinely an alternative.
+ *
+ * On a fresh install most categories hold exactly one registration (the
+ * protected floor). Asking "which compactor?" when there is one compactor
+ * wastes the user's attention and teaches them the wizard asks pointless
+ * questions, so those are summarised, not prompted.
+ *
+ * Best-effort: a probe failure here must not fail onboarding, since nothing in
+ * this step is required to have a working agent.
+ */
+async function runBlocksStep(): Promise<void> {
+  let views: ReadonlyArray<CategoryView>;
+  try {
+    views = await probeSession(
+      {
+        cwd: process.cwd(),
+        skipKeyPrompt: true,
+        tolerateNoProvider: true,
+        skipProviderActivation: true,
+      },
+      (r) => r.session.pluginsAdmin?.categories() ?? [],
+    );
+  } catch {
+    return;
+  }
+
+  const summary = summariseBlocks(views);
+  if (!summary) return;
+  note(
+    `${summary}\n\n${colors.dim('Every one of these is swappable. `moxxy plugins defaults` lists them,')}\n` +
+      `${colors.dim('`moxxy plugins set-default <category> <name>` changes one.')}`,
+    'building blocks',
+  );
+
+  const { swappable } = partitionCategories(views);
+  if (swappable.length === 0) return;
+
+  const wantSwap = await confirm({
+    message: `Change any of the ${swappable.length} block(s) that have alternatives?`,
+    initialValue: false,
+  });
+  if (isCancel(wantSwap) || !wantSwap) return;
+
+  for (const entry of swappable) {
+    const picked = await select({
+      message: `${entry.category}`,
+      options: entry.options.map((name) => ({
+        value: name,
+        label: name === entry.active ? `${name} (current)` : name,
+      })),
+      initialValue: entry.active ?? entry.options[0],
+    });
+    if (isCancel(picked) || picked === entry.active) continue;
+    try {
+      await setCategoryDefault(entry.category, String(picked));
+      log.success(`${entry.category} → ${String(picked)}`);
+    } catch (err) {
+      log.warn(`${entry.category}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
 }

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -142,6 +142,7 @@ const CATEGORY_REGISTRIES: ReadonlyArray<{
   { category: 'viewRenderer', reg: (s) => s.viewRenderers },
   { category: 'tunnelProvider', reg: (s) => s.tunnelProviders },
   { category: 'eventStore', reg: (s) => s.eventStores },
+  { category: 'auditSink', reg: (s) => s.auditSinks },
   { category: 'reflector', reg: (s) => s.reflectors },
 ];
 

--- a/packages/cli/src/wizard/blocks-step.test.ts
+++ b/packages/cli/src/wizard/blocks-step.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { CategoryView } from '@moxxy/sdk';
+import { partitionCategories, summariseBlocks } from './blocks-step.js';
+
+const view = (category: string, active: string | null, names: string[]): CategoryView => ({
+  category,
+  active,
+  floor: null,
+  items: names.map((name) => ({ name, isDefault: name === active })),
+});
+
+describe('partitionCategories', () => {
+  // The rule that keeps this from being ceremony: on a fresh install most
+  // categories hold exactly one registration, and asking "which compactor?"
+  // when there is one compactor teaches the user the wizard wastes their time.
+  it('only offers a swap where there is genuinely an alternative', () => {
+    const { swappable, fixed } = partitionCategories([
+      view('cacheStrategy', 'stable-prefix', ['stable-prefix', 'none']),
+      view('compactor', 'summarize-old-turns', ['summarize-old-turns']),
+    ]);
+    expect(swappable.map((s) => s.category)).toEqual(['cacheStrategy']);
+    expect(fixed.map((f) => f.category)).toEqual(['compactor']);
+  });
+
+  // Onboarding already has a dedicated provider step with credential handling.
+  it('never offers provider, which has its own step', () => {
+    const { swappable, fixed } = partitionCategories([
+      view('provider', 'anthropic', ['anthropic', 'openai']),
+    ]);
+    expect(swappable).toEqual([]);
+    expect(fixed).toEqual([]);
+  });
+
+  // "transcriber: (none)" during setup invites a question the user cannot act
+  // on until they install something.
+  it('drops categories with nothing registered', () => {
+    const { swappable, fixed } = partitionCategories([view('transcriber', null, [])]);
+    expect(swappable).toEqual([]);
+    expect(fixed).toEqual([]);
+  });
+});
+
+describe('summariseBlocks', () => {
+  it('lists what each block resolves to and flags the ones with options', () => {
+    const out = summariseBlocks([
+      view('mode', 'default', ['default']),
+      view('cacheStrategy', 'stable-prefix', ['stable-prefix', 'none']),
+    ]);
+    expect(out).toContain('mode');
+    expect(out).toContain('default');
+    expect(out).toContain('2 options');
+  });
+
+  it('is empty when nothing is registered, so the step can skip itself', () => {
+    expect(summariseBlocks([view('transcriber', null, [])])).toBe('');
+  });
+});

--- a/packages/cli/src/wizard/blocks-step.ts
+++ b/packages/cli/src/wizard/blocks-step.ts
@@ -1,0 +1,69 @@
+import type { CategoryView } from '@moxxy/sdk';
+
+/**
+ * The onboarding step that teaches the product's actual shape.
+ *
+ * Everything in moxxy is a swappable block: the loop, the compactor, the cache
+ * strategy, the isolator, the event store, the audit sink. `moxxy plugins
+ * defaults` has always exposed that, but onboarding never mentioned it, so a
+ * user could finish setup without ever learning the central idea, and would
+ * then reach for config files to change something the swap axis already owns.
+ *
+ * The rule that keeps this from becoming ceremony: only ever OFFER a swap for a
+ * category that genuinely has an alternative. On a fresh install most
+ * categories hold exactly one registration (the protected floor), and asking
+ * "which compactor?" when there is one compactor wastes the user's attention
+ * and teaches them that the wizard asks pointless questions.
+ */
+
+/** A category worth interacting about: more than one registered option. */
+export interface SwappableCategory {
+  readonly category: string;
+  readonly active: string | null;
+  readonly options: ReadonlyArray<string>;
+}
+
+/**
+ * Split the categories into the ones worth a question and the ones that are
+ * only worth showing.
+ *
+ * `provider` is excluded on purpose: onboarding already has a dedicated
+ * provider step with credential handling, and offering it twice under a
+ * different name would be actively confusing.
+ */
+export function partitionCategories(views: ReadonlyArray<CategoryView>): {
+  readonly swappable: ReadonlyArray<SwappableCategory>;
+  readonly fixed: ReadonlyArray<CategoryView>;
+} {
+  const swappable: SwappableCategory[] = [];
+  const fixed: CategoryView[] = [];
+  for (const view of views) {
+    if (view.category === 'provider') continue;
+    const options = view.items.map((i) => i.name);
+    if (options.length > 1) {
+      swappable.push({ category: view.category, active: view.active, options });
+    } else if (options.length === 1) {
+      fixed.push(view);
+    }
+    // Zero options means nothing is registered for that kind (no transcriber,
+    // no reflector on a fresh install). Showing "transcriber: (none)" during
+    // setup invites a question the user cannot act on yet.
+  }
+  return { swappable, fixed };
+}
+
+/**
+ * One line per category with something registered, e.g. `mode  default`.
+ * Deliberately a plain summary rather than a prompt: the goal is that the user
+ * leaves onboarding knowing this axis exists and how to reach it later.
+ */
+export function summariseBlocks(views: ReadonlyArray<CategoryView>): string {
+  const { swappable, fixed } = partitionCategories(views);
+  const rows = [
+    ...swappable.map((s) => [s.category, `${s.active ?? '(none)'}  (${s.options.length} options)`] as const),
+    ...fixed.map((f) => [f.category, f.active ?? '(none)'] as const),
+  ];
+  if (rows.length === 0) return '';
+  const width = Math.max(...rows.map(([c]) => c.length));
+  return rows.map(([c, v]) => `${c.padEnd(width)}  ${v}`).join('\n');
+}


### PR DESCRIPTION
Wave 11, off `development`.

Everything in moxxy is a swappable block. `moxxy plugins defaults` has always exposed that, but **onboarding never mentioned it**, so a user could finish setup without learning the central idea and would then reach for config files to change something the swap axis already owns.

Onboarding now shows what each block resolves to and names the two commands that change one. The rule that keeps this from becoming ceremony: it offers an interactive swap **only** for categories that genuinely have an alternative. On a fresh install most hold exactly one registration (the protected floor), and asking "which compactor?" when there is one compactor wastes attention and teaches the user that the wizard asks pointless questions. Categories with nothing registered are dropped rather than shown as `(none)`, which would invite a question they cannot act on yet. `provider` is excluded because onboarding already has a dedicated provider step with credential handling.

The step is best-effort: nothing in it is required to have a working agent, so a probe failure must not fail onboarding.

**Separately, a gap of my own:** the `auditSink` registry I added in #471 was never added to the category-swap table, so the one block introduced as swappable was the one block you could not swap. Found it by actually running `moxxy plugins defaults` rather than assuming. It now appears with the rest:

```
eventStore       active=jsonl [floor: jsonl]
auditSink        active=local [floor: local]
reflector        active=(none)
```

That is worth a second of attention in review, because it is the failure mode a registry-based architecture invites: adding the registry is not the same as wiring it into the surfaces that make it usable, and nothing failed when I skipped the second half.

Verified: full gate green (build, typecheck, lint 0 errors, all test tasks). The partition logic is unit-tested; the interactive prompting is not, in line with the rest of the wizard code.

One note on the run: the first full-suite pass reported a `@moxxy/cli` failure with 138 of 140 tasks served from cache, and the package passes 56/56 standalone and on a clean re-run. Same category as the flakes I flagged on #470 and #475.