### PR TITLE
feat(secrets): make the secret store a swappable block

### DIFF
--- a/.changeset/enterprise-secret-provider.md
+++ b/.changeset/enterprise-secret-provider.md
@@ -1,0 +1,16 @@
+---
+'@moxxy/cli': minor
+'@moxxy/sdk': minor
+---
+
+Make the secret store a swappable block.
+
+The built-in vault (AES-256-GCM, OS-keychain unlocked) is a good design for one machine and unusable for a fleet: no central issuance, no rotation, no way to revoke a single workstation. Every organisation already runs something that does those three things.
+
+`SecretProvider` is a new registry-backed block. The vault is registered by the host as the protected floor, so an external store (HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, 1Password) sits above it and resolution falls back to the vault for anything the provider does not hold. That makes adoption incremental: point `plugins.secretProvider.default` at a store and move secrets over one at a time.
+
+A provider that throws is not treated as a miss. An unreachable store or an expired token surfaces as a failure, because silently falling through to the local vault would mean a machine running on credentials the operator believes they revoked.
+
+Deliberately one block, not two: a host-scoped credential is a named secret with a naming convention on top, so a separate `CredentialProvider` registry would be a second overlapping abstraction to keep in sync.
+
+Known limitation: `${vault:KEY}` placeholders in config still resolve against the local vault, because config is loaded before plugins register. Tool-facing `ctx.getSecret(name)` goes through the active provider.

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -23,6 +23,7 @@ import { buildSessionConfigApplier } from './config-applier.js';
 import { resolveOsPrincipal } from '@moxxy/sdk/server';
 import { loadRawConfig, resolveConfigPlaceholders } from './setup/load-config.js';
 import { applyEgressSettings } from './setup/egress.js';
+import { buildSecretResolver, vaultSecretProvider } from './setup/secrets.js';
 import { interactiveConfigTrustPrompt } from './setup/config-trust-prompt.js';
 import { selectEmbedder } from './setup/embedder.js';
 import { buildSession } from './setup/build-session.js';
@@ -105,6 +106,10 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   // mutate it so a runtime toggle takes effect without a restart.
   const disabledPackages = new Set<string>(disabledPackageNames(config));
 
+  // Late-bound so the resolver can consult the registry the session creates.
+  let sessionRef: Session | undefined;
+  const secretResolver = buildSecretResolver(() => sessionRef, vault, opts.cwd);
+
   const session = await buildSession({
     cwd: opts.cwd,
     config,
@@ -117,8 +122,15 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
     // value never enters the model's context or `process.env` — only the
     // handler that asks receives it. `vault.get` lazily opens the vault and
     // returns null for unknown names.
-    secretResolver: (name) => vault.get(name),
+    secretResolver,
   });
+  sessionRef = session;
+
+  // Register the vault as the protected FLOOR of the secret-provider registry.
+  // Done here rather than in core because core never imports a plugin, and the
+  // vault is one; making it the floor rather than a hardcoded special case lets
+  // an external store sit above it without migrating every secret first.
+  session.secretProviders.register(vaultSecretProvider(vault), { protected: true });
 
   // Attribute everything this session appends to the local OS account. It is
   // the FLOOR identity, worth exactly as much as local account separation,

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -143,6 +143,7 @@ const CATEGORY_REGISTRIES: ReadonlyArray<{
   { category: 'tunnelProvider', reg: (s) => s.tunnelProviders },
   { category: 'eventStore', reg: (s) => s.eventStores },
   { category: 'auditSink', reg: (s) => s.auditSinks },
+  { category: 'secretProvider', reg: (s) => s.secretProviders },
   { category: 'reflector', reg: (s) => s.reflectors },
 ];
 

--- a/packages/cli/src/setup/secrets.test.ts
+++ b/packages/cli/src/setup/secrets.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { defineSecretProvider } from '@moxxy/sdk';
+import type { Session } from '@moxxy/core';
+import type { VaultStore } from '@moxxy/plugin-vault';
+import { buildSecretResolver, vaultSecretProvider } from './secrets.js';
+
+const fakeVault = (entries: Record<string, string>): VaultStore =>
+  ({ get: async (name: string) => entries[name] ?? null }) as unknown as VaultStore;
+
+const sessionWith = (active: ReturnType<typeof defineSecretProvider> | null): Session =>
+  ({ secretProviders: { getActive: () => active } }) as unknown as Session;
+
+describe('buildSecretResolver', () => {
+  it('falls back to the vault when no provider is active', async () => {
+    const resolve = buildSecretResolver(() => sessionWith(null), fakeVault({ K: 'v' }), '/tmp');
+    expect(await resolve('K')).toBe('v');
+  });
+
+  it('prefers the active provider', async () => {
+    const provider = defineSecretProvider({
+      name: 'remote',
+      open: () => ({ get: async (n) => (n === 'K' ? 'from-remote' : null), close: async () => {} }),
+    });
+    const resolve = buildSecretResolver(() => sessionWith(provider), fakeVault({ K: 'from-vault' }), '/tmp');
+    expect(await resolve('K')).toBe('from-remote');
+  });
+
+  // The fallback is what makes adoption incremental: point at an external store
+  // and move secrets over one at a time rather than in a big bang.
+  it('falls through to the vault for a secret the provider does not hold', async () => {
+    const provider = defineSecretProvider({
+      name: 'remote',
+      open: () => ({ get: async () => null, close: async () => {} }),
+    });
+    const resolve = buildSecretResolver(() => sessionWith(provider), fakeVault({ K: 'from-vault' }), '/tmp');
+    expect(await resolve('K')).toBe('from-vault');
+  });
+
+  // An unreachable store must NOT look like a miss: silently using the local
+  // vault would mean running on credentials the operator believes they revoked.
+  it('propagates a provider failure instead of falling back', async () => {
+    const provider = defineSecretProvider({
+      name: 'remote',
+      open: () => ({
+        get: async () => {
+          throw new Error('vault unreachable');
+        },
+        close: async () => {},
+      }),
+    });
+    const resolve = buildSecretResolver(() => sessionWith(provider), fakeVault({ K: 'stale' }), '/tmp');
+    await expect(resolve('K')).rejects.toThrow(/unreachable/);
+  });
+
+  // An external store holds a connection or a cached auth token; opening one
+  // per getSecret would re-authenticate on every tool call.
+  it('opens the provider once and reuses it', async () => {
+    const open = vi.fn(() => ({ get: async () => 'x', close: async () => {} }));
+    const provider = defineSecretProvider({ name: 'remote', open });
+    const resolve = buildSecretResolver(() => sessionWith(provider), fakeVault({}), '/tmp');
+    await resolve('A');
+    await resolve('B');
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-open when the vault floor is the active provider', async () => {
+    const vault = fakeVault({ K: 'v' });
+    const resolve = buildSecretResolver(() => sessionWith(vaultSecretProvider(vault)), vault, '/tmp');
+    expect(await resolve('K')).toBe('v');
+  });
+});

--- a/packages/cli/src/setup/secrets.ts
+++ b/packages/cli/src/setup/secrets.ts
@@ -1,0 +1,65 @@
+import { defineSecretProvider, type SecretProviderDef } from '@moxxy/sdk';
+import type { Session } from '@moxxy/core';
+import type { VaultStore } from '@moxxy/plugin-vault';
+
+/**
+ * The local vault, expressed as a {@link SecretProviderDef} so it can be the
+ * protected floor of the registry.
+ *
+ * Registered by the HOST rather than by core: core never imports a plugin, and
+ * the vault lives in `@moxxy/plugin-vault`. Making it the floor rather than a
+ * hardcoded special case is what lets an external store sit above it without
+ * anyone having to migrate every secret first.
+ */
+export function vaultSecretProvider(vault: VaultStore): SecretProviderDef {
+  return defineSecretProvider({
+    name: 'vault',
+    description: 'the local AES-256-GCM vault (~/.moxxy/vault.json)',
+    open: () => ({
+      get: (name) => vault.get(name),
+      close: async () => {},
+    }),
+  });
+}
+
+/**
+ * Resolve a named secret through the ACTIVE provider, falling back to the
+ * vault.
+ *
+ * The fallback is what makes adopting an external store incremental: a team can
+ * point `plugins.secretProvider.default` at HashiCorp Vault and move secrets
+ * over one at a time instead of in a big bang.
+ *
+ * A provider that THROWS is not treated as a miss. An unreachable store or an
+ * expired token must surface as a failure, because silently falling through to
+ * the local vault would mean a machine quietly running on stale credentials the
+ * operator believes they revoked.
+ */
+export function buildSecretResolver(
+  // Late-bound: the resolver must be handed to `buildSession` at construction,
+  // but it needs the registry the session itself creates. A getter closes that
+  // loop without adding a setter to Session's public surface.
+  getSession: () => Session | undefined,
+  vault: VaultStore,
+  cwd: string,
+): (name: string) => Promise<string | null> {
+  // One session per provider, opened lazily and reused: an external store
+  // typically holds a connection or a cached auth token, and opening one per
+  // `getSecret` call would re-authenticate on every tool invocation.
+  let openedFor: string | null = null;
+  let active: ReturnType<SecretProviderDef['open']> | null = null;
+
+  return async (name: string): Promise<string | null> => {
+    const def = getSession()?.secretProviders.getActive();
+    if (def && def.name !== 'vault') {
+      if (openedFor !== def.name || !active) {
+        await active?.close().catch(() => undefined);
+        active = def.open({ cwd });
+        openedFor = def.name;
+      }
+      const found = await active.get(name);
+      if (found !== null) return found;
+    }
+    return vault.get(name);
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,3 +142,4 @@ export {
   verifyAuditDay,
 } from './audit/jsonl-audit-sink.js';
 export { AuditSinkRegistry } from './registries/audit-sinks.js';
+export { SecretProviderRegistry } from './registries/secret-providers.js';

--- a/packages/core/src/plugins/host-options.ts
+++ b/packages/core/src/plugins/host-options.ts
@@ -26,6 +26,7 @@ import type { IsolatorRegistry } from '../registries/isolators.js';
 import type { WorkflowExecutorRegistry } from '../registries/workflow-executors.js';
 import type { EventStoreRegistry } from '../registries/event-stores.js';
 import type { AuditSinkRegistry } from '../registries/audit-sinks.js';
+import type { SecretProviderRegistry } from '../registries/secret-providers.js';
 import type { ReflectorRegistry } from '../registries/reflectors.js';
 import type { HookDispatcherImpl } from './lifecycle.js';
 import type { RequirementRegistry } from '../requirements.js';
@@ -51,6 +52,7 @@ export interface PluginHostOptions {
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
   readonly auditSinks: AuditSinkRegistry;
+  readonly secretProviders: SecretProviderRegistry;
   readonly reflectors: ReflectorRegistry;
   readonly requirements: RequirementRegistry;
   readonly dispatcher: HookDispatcherImpl;

--- a/packages/core/src/plugins/registry-kinds.test.ts
+++ b/packages/core/src/plugins/registry-kinds.test.ts
@@ -37,6 +37,7 @@ import { EmbedderRegistry } from '../registries/embedders.js';
 import { IsolatorRegistry } from '../registries/isolators.js';
 import { WorkflowExecutorRegistry } from '../registries/workflow-executors.js';
 import { AuditSinkRegistry } from '../registries/audit-sinks.js';
+import { SecretProviderRegistry } from '../registries/secret-providers.js';
 import { EventStoreRegistry } from '../registries/event-stores.js';
 import { ReflectorRegistry } from '../registries/reflectors.js';
 import { RequirementRegistry } from '../requirements.js';
@@ -95,6 +96,12 @@ const everyKindPlugin = definePlugin({
       open: () => ({ write: async () => true, close: async () => {} }),
     },
   ],
+  secretProviders: [
+    {
+      name: 'sp-1',
+      open: () => ({ get: async () => null, close: async () => {} }),
+    },
+  ],
   reflectors: [{ name: 'refl-1', reflect: async () => [] }],
 });
 
@@ -118,6 +125,7 @@ function makeHost() {
     workflowExecutors: new WorkflowExecutorRegistry(),
     eventStores: new EventStoreRegistry(),
     auditSinks: new AuditSinkRegistry(),
+    secretProviders: new SecretProviderRegistry(),
     reflectors: new ReflectorRegistry(),
   };
   const requirements = new RequirementRegistry({
@@ -159,6 +167,7 @@ function makeHost() {
     workflowExecutor: registries.workflowExecutors,
     eventStore: registries.eventStores,
     auditSink: registries.auditSinks,
+    secretProvider: registries.secretProviders,
     reflector: registries.reflectors,
   };
   return { host, byKind };

--- a/packages/core/src/plugins/registry-kinds.ts
+++ b/packages/core/src/plugins/registry-kinds.ts
@@ -17,6 +17,7 @@ import type {
   TunnelProviderDef,
   WorkflowExecutorDef,
   AuditSinkDef,
+  SecretProviderDef,
   EventStoreDef,
   ReflectorDef,
 } from '@moxxy/sdk';
@@ -47,6 +48,7 @@ export interface RegistryNameRecord {
   readonly workflowExecutorNames: ReadonlyArray<string>;
   readonly eventStoreNames: ReadonlyArray<string>;
   readonly auditSinkNames: ReadonlyArray<string>;
+  readonly secretProviderNames: ReadonlyArray<string>;
   readonly reflectorNames: ReadonlyArray<string>;
 }
 
@@ -259,6 +261,17 @@ export const REGISTRY_KINDS: ReadonlyArray<RegistryKind<unknown>> = [
     register: (o, a: AuditSinkDef) => o.auditSinks.register(a),
     unregister: (o, n) => o.auditSinks.unregister(n),
   } satisfies RegistryKind<AuditSinkDef>,
+  {
+    kind: 'secretProvider',
+    recordField: 'secretProviderNames',
+    defs: (p) => p.secretProviders ?? [],
+    nameOf: (sp: SecretProviderDef) => sp.name,
+    // Throw-on-duplicate, no auto-activation. A secret provider is asked for
+    // plaintext credentials BY NAME, so one that activated itself on discovery
+    // would be a credential-harvesting path wearing a convenience hat.
+    register: (o, sp: SecretProviderDef) => o.secretProviders.register(sp),
+    unregister: (o, n) => o.secretProviders.unregister(n),
+  } satisfies RegistryKind<SecretProviderDef>,
   {
     kind: 'reflector',
     recordField: 'reflectorNames',

--- a/packages/core/src/registries/secret-providers.ts
+++ b/packages/core/src/registries/secret-providers.ts
@@ -1,0 +1,21 @@
+import type { SecretProviderDef } from '@moxxy/sdk';
+import { ActiveDefRegistry } from './active-def-registry.js';
+
+/**
+ * The single-active SecretProvider registry.
+ *
+ * Unlike the event-store and audit-sink registries, core seeds NO floor here:
+ * the built-in vault lives in `@moxxy/plugin-vault`, and core never imports a
+ * plugin. The host (the CLI) registers the vault as the protected floor at
+ * boot, which keeps the dependency arrow pointing the right way.
+ *
+ * Throw-on-duplicate `register`, so a discovered plugin's provider is added but
+ * never silently becomes active. That opt-in matters more here than almost
+ * anywhere: a secret provider is asked for plaintext credentials by name, so a
+ * provider that activated itself would be a credential-harvesting path.
+ */
+export class SecretProviderRegistry extends ActiveDefRegistry<SecretProviderDef> {
+  constructor() {
+    super({ noun: 'SecretProvider' });
+  }
+}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -37,6 +37,7 @@ import { IsolatorRegistry } from './registries/isolators.js';
 import { WorkflowExecutorRegistry } from './registries/workflow-executors.js';
 import { EventStoreRegistry } from './registries/event-stores.js';
 import { AuditSinkRegistry } from './registries/audit-sinks.js';
+import { SecretProviderRegistry } from './registries/secret-providers.js';
 import { jsonlAuditSink } from './audit/jsonl-audit-sink.js';
 import { ReflectorRegistry } from './registries/reflectors.js';
 import { ServiceRegistryImpl } from './registries/services.js';
@@ -142,6 +143,9 @@ export class Session implements ClientSession, SessionRuntime {
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
   readonly auditSinks: AuditSinkRegistry;
+  /** External secret stores. No core floor: the vault is a plugin, so the
+   *  host registers it as the protected floor at boot. */
+  readonly secretProviders: SecretProviderRegistry;
   /**
    * The learning-loop block: watches finished turns and proposes memory/skill
    * improvements. NULLABLE — no core-seeded floor, so it stays empty until a
@@ -291,6 +295,7 @@ export class Session implements ClientSession, SessionRuntime {
     // is to send recorded actions somewhere else, so silent adoption would be
     // an exfiltration path wearing a compliance hat.
     this.auditSinks.register(jsonlAuditSink, { protected: true });
+    this.secretProviders = new SecretProviderRegistry();
     // Reflectors are nullable — no core floor is seeded, so reflection stays off
     // until a reflector plugin registers one. Published on the service registry
     // so a discovery-loaded driver (the reflector plugin's own hooks) can resolve
@@ -345,6 +350,7 @@ export class Session implements ClientSession, SessionRuntime {
       workflowExecutors: this.workflowExecutors,
       eventStores: this.eventStores,
       auditSinks: this.auditSinks,
+      secretProviders: this.secretProviders,
       reflectors: this.reflectors,
       requirements: this.requirements,
       dispatcher: this.dispatcher,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -58,6 +58,14 @@ export type {
 } from './audit.js';
 export { defineAuditSink, auditActionOf } from './audit.js';
 
+// Where a named secret comes from (external store instead of the local vault).
+export type {
+  SecretProviderDef,
+  SecretProviderScope,
+  SecretProviderSession,
+} from './secret-provider.js';
+export { defineSecretProvider } from './secret-provider.js';
+
 // Secret redaction for anything leaving the process.
 export {
   isSecretKey,

--- a/packages/sdk/src/plugin.ts
+++ b/packages/sdk/src/plugin.ts
@@ -18,6 +18,7 @@ import type { TunnelProviderDef } from './tunnel.js';
 import type { WorkflowExecutorDef } from './workflow.js';
 import type { EventStoreDef } from './event-store.js';
 import type { AuditSinkDef } from './audit.js';
+import type { SecretProviderDef } from './secret-provider.js';
 import type { ReflectorDef } from './reflector.js';
 
 export type PluginKind = 'tools' | 'provider' | 'mode' | 'compactor' | 'cache-strategy' | 'view-renderer' | 'tunnel-provider' | 'mcp' | 'cli' | 'channel' | 'surface' | 'hooks' | 'agent' | 'command' | 'transcriber' | 'synthesizer' | 'embedder' | 'isolator' | 'workflow-executor' | 'event-store' | 'reflector';
@@ -58,6 +59,9 @@ export interface PluginSpec {
   /** Audit-trail sinks (syslog, OTel, S3, webhook). Registered alongside the
    *  protected local floor; never auto-activated, see registry-kinds. */
   readonly auditSinks?: ReadonlyArray<AuditSinkDef>;
+  /** External secret stores (Vault, AWS/Azure, 1Password). Registered
+   *  alongside the vault floor; never auto-activated. */
+  readonly secretProviders?: ReadonlyArray<SecretProviderDef>;
   /**
    * Reflector backends — the learning-loop block that watches a finished turn
    * and *proposes* memory/skill improvements without silently writing. One

--- a/packages/sdk/src/secret-provider.ts
+++ b/packages/sdk/src/secret-provider.ts
@@ -1,0 +1,48 @@
+/**
+ * Where a named secret comes from: a swappable block, like every other.
+ *
+ * The built-in vault (AES-256-GCM under `~/.moxxy/vault.json`, unlocked via the
+ * OS keychain) is a good design for one machine and unusable for a fleet: there
+ * is no central issuance, no rotation, and no way to revoke a single
+ * workstation. Every organisation already runs something that does those three
+ * things, so the answer is to let them plug it in rather than to reimplement it.
+ *
+ * Deliberately ONE block rather than two. A host-scoped credential (a token for
+ * an internal registry or a GitHub Enterprise host) is a named secret with a
+ * naming convention on top; splitting it into a second `CredentialProvider`
+ * registry would leave two overlapping abstractions to keep in sync for no
+ * gain.
+ */
+
+export interface SecretProviderScope {
+  readonly cwd: string;
+}
+
+export interface SecretProviderSession {
+  /**
+   * Resolve a secret by name, or null when this provider does not hold it.
+   *
+   * Returning null rather than throwing is what makes providers composable: the
+   * host tries the active provider and falls back to the local vault, so
+   * adopting an external store does not require migrating every secret on day
+   * one.
+   *
+   * MUST NOT throw for an ordinary miss. A genuine failure (the store is
+   * unreachable, the token expired) SHOULD throw, because silently reporting
+   * "no such secret" for an outage would send the caller down a
+   * missing-credential path and hide the real cause.
+   */
+  get(name: string): Promise<string | null>;
+  close(): Promise<void>;
+}
+
+export interface SecretProviderDef {
+  readonly name: string;
+  readonly description?: string;
+  open(scope: SecretProviderScope): SecretProviderSession;
+}
+
+/** Freeze a secret-provider spec, mirroring the other `defineX` factories. */
+export function defineSecretProvider(def: SecretProviderDef): SecretProviderDef {
+  return Object.freeze({ ...def });
+}


### PR DESCRIPTION
Wave 14, split out of #475 because that change was already reviewable without it.

The built-in vault is a good design for **one machine** and unusable for a fleet: no central issuance, no rotation, no way to revoke a single workstation. Every organisation already runs something that does those three things, so the answer is to let them plug it in rather than to reimplement any of it.

`SecretProvider` is a registry-backed block like every other. Core seeds **no** floor, because the vault lives in `@moxxy/plugin-vault` and core never imports a plugin; the host registers it as the protected floor at boot. Making the vault the floor rather than a hardcoded special case is the whole trick that lets an external store sit above it.

Resolution falls back to the vault for anything the active provider does not hold, so adoption is incremental: point `plugins.secretProvider.default` at a store and move secrets over one at a time.

**A provider that throws is not a miss.** An unreachable store or an expired token surfaces as a failure. Falling through to the local vault there would mean a machine quietly running on credentials the operator believes they revoked, which is worse than an error.

**One block, not two.** W13's outbound host credentials (GitHub Enterprise, an internal registry) are named secrets with a naming convention on top. A separate `CredentialProvider` registry would leave two overlapping abstractions to keep in sync for no gain, so W13 will build on this.

**Known limitation, stated rather than hidden:** `${vault:KEY}` placeholders in *config* still resolve against the local vault, because config is loaded before plugins register. Tool-facing `ctx.getSecret(name)` does go through the active provider. Closing that gap means resolving placeholders after plugin registration, which is a real reordering and belongs in its own change.

Also registers the block in the category-swap surface, so `moxxy plugins defaults` shows it. That is the exact step I missed for `auditSink` in #471 and had to fix in #477.

Verified: build, typecheck, lint 0 errors, check:deps 0 errors, and the affected suites pass (`core` registry lockstep, the new resolver tests, `plugin-mcp` 98/98, `anonymizer` 82/82).

**On the full-suite runs:** two consecutive `pnpm test` passes each reported a different package failing, and each of those passes standalone. This machine has been running parallel builds and suites all session and is saturated; I confirmed the same category of failure earlier by reproducing one on a clean baseline with my work stashed (noted on #470). CI on a clean runner is the authority here, and I would not merge this until it is green.