### PR TITLE
feat(plugins): add an install policy and a config-pinned registry

### DIFF
--- a/.changeset/enterprise-install-policy.md
+++ b/.changeset/enterprise-install-policy.md
@@ -1,0 +1,15 @@
+---
+'@moxxy/cli': minor
+---
+
+Add an install policy and a config-pinned plugin registry.
+
+`moxxy plugins install` ran `npm install` against whatever spec it was given: a bare name, `name@version`, a git URL, or a filesystem path. On a personal machine that is the point. On a managed fleet it meant the supply chain had no boundary, and an organisation had no way to draw one.
+
+`plugins.installPolicy` takes `open` (the default, unchanged behaviour), `registry-only` (accept only packages the signed Ed25519 index vouches for, which also pins an exact version), or `denied` (nothing installs at runtime, for an image built once and shipped).
+
+It is enforced inside the install function rather than at the CLI surface, because the `install_plugin` model tool reaches the same path. A policy the agent could route around by asking itself would not be a policy.
+
+`plugins.registryUrl` moves the index location into config so the system scope can pin an internal mirror. It was previously reachable only through `MOXXY_REGISTRY_URL`, a variable a user can unset, which makes it useless as a control. Whatever the URL serves must still verify against the key baked into the CLI, so this is a source decision, not a trust decision.
+
+The enterprise profile now sets `registry-only` and locks it.

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -12,6 +12,8 @@ import {
   resolveCatalogEntry,
   resolveCatalogPackageName,
   resolveInstallSource,
+  isInstallPolicy,
+  type InstallPolicy,
   searchInstallablePlugins,
   setCategoryDefault,
   setPluginEnabled,
@@ -183,10 +185,13 @@ async function runInstall(argv: ParsedArgv): Promise<number> {
   // maintainer key is unprovisioned) — a signed entry contributes its exact,
   // signature-covered version as the pin. Pin precedence:
   // user --version > signed index > cliVersion lockstep > latest.
+  // Config decides both the source (an internal mirror) and the policy. Read
+  // through a probe so the system scope's pin applies, not just the env var.
+  const policyCfg = await readInstallConfig(argv);
   const resolved =
     version || ref
       ? undefined
-      : await resolveInstallSource(target);
+      : await resolveInstallSource(target, policyCfg.registryUrl ? { url: policyCfg.registryUrl } : {});
   const spec =
     resolved?.spec ??
     buildInstallSpec({
@@ -212,6 +217,7 @@ async function runInstall(argv: ParsedArgv): Promise<number> {
     }
     const result = await installPluginPackagePinned({
       packageName: spec,
+      ...(policyCfg.policy ? { policy: policyCfg.policy } : {}),
       ...(resolved?.pinnedVersion ? { pinnedVersion: resolved.pinnedVersion } : {}),
       ...(cliVersion() ? { cliVersion: cliVersion()! } : {}),
       ...(allowScripts ? { allowScripts } : {}),
@@ -511,4 +517,35 @@ function stringFlag(argv: ParsedArgv, name: string): string | undefined {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * The install-source and install-policy settings in force.
+ *
+ * Read through a probe rather than from the environment, so a pin in the SYSTEM
+ * config scope actually binds: `MOXXY_REGISTRY_URL` alone is a variable a user
+ * can unset, which makes it useless as a control.
+ */
+async function readInstallConfig(
+  argv: ParsedArgv,
+): Promise<{ policy?: InstallPolicy; registryUrl?: string }> {
+  try {
+    return await probeSession(
+      argvToSetupOptions(argv, {
+        skipKeyPrompt: true,
+        tolerateNoProvider: true,
+        skipProviderActivation: true,
+      }),
+      ({ config }) => ({
+        ...(isInstallPolicy(config.plugins?.installPolicy)
+          ? { policy: config.plugins.installPolicy }
+          : {}),
+        ...(config.plugins?.registryUrl ? { registryUrl: config.plugins.registryUrl } : {}),
+      }),
+    );
+  } catch {
+    // A probe failure must not silently DROP a restriction, so fail closed on
+    // the policy while leaving the source at its default.
+    return { policy: 'denied' };
+  }
 }

--- a/packages/cli/src/profiles.ts
+++ b/packages/cli/src/profiles.ts
@@ -51,6 +51,14 @@ security:
   strict: true
 
 plugins:
+  # Only packages the signed index vouches for. The index is Ed25519-verified
+  # and pins an exact version, which is what makes "we run reviewed code only"
+  # enforceable rather than aspirational. Use 'denied' for an image built once
+  # and shipped, where any runtime install is by definition drift.
+  installPolicy: registry-only
+  # Point at your own mirror. Whatever it serves must still verify against the
+  # key baked into the CLI, so this is a SOURCE decision, not a trust decision.
+  # registryUrl: https://registry.example.internal/moxxy/index.json
   isolator:
     # A real process boundary. 'inproc' is best-effort only and cannot contain
     # a hostile plugin; 'worker' is the lighter middle ground.
@@ -95,6 +103,7 @@ locked:
   - security.thirdPartyRequireDeclaration
   - security.strict
   - plugins.isolator
+  - plugins.installPolicy
   - config.allowExecutable
   - audit
   - channels.mobile.bindHost

--- a/packages/config/src/plugins-tree-schema.ts
+++ b/packages/config/src/plugins-tree-schema.ts
@@ -64,6 +64,21 @@ export const pluginsTreeSchema = z
   .object({
     /** Install/enable ledger keyed by npm package name. */
     packages: z.record(z.string(), pluginSettingsSchema).optional(),
+    /**
+     * How much freedom this machine has over what it installs.
+     * `open` (default) installs anything; `registry-only` accepts only packages
+     * the signed index vouches for; `denied` installs nothing. Enforced inside
+     * the install path, so the `install_plugin` model tool is bound by it too.
+     */
+    installPolicy: z.enum(['open', 'registry-only', 'denied']).optional(),
+    /**
+     * Signed plugin index to consult. Config-settable so the system scope can
+     * pin an internal mirror; previously this was reachable only through the
+     * `MOXXY_REGISTRY_URL` env var, which a user can simply unset. Whatever the
+     * URL serves must still verify against the baked key, so this is a
+     * SOURCE decision, not a trust decision.
+     */
+    registryUrl: z.string().url().optional(),
     // Swap axis — one slot per ActiveDef registry kind.
     provider: providerSlotSchema.optional(),
     mode: categorySlotSchema.optional(),

--- a/packages/plugin-plugins-admin/src/index.ts
+++ b/packages/plugin-plugins-admin/src/index.ts
@@ -194,3 +194,9 @@ export function buildPluginsAdminPlugin(opts: BuildPluginsAdminOpts): Plugin {
     ],
   });
 }
+export {
+  assertInstallAllowed,
+  isInstallPolicy,
+  INSTALL_POLICIES,
+  type InstallPolicy,
+} from './install-policy.js';

--- a/packages/plugin-plugins-admin/src/install-policy.test.ts
+++ b/packages/plugin-plugins-admin/src/install-policy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { assertInstallAllowed, isInstallPolicy, INSTALL_POLICIES } from './install-policy.js';
+
+describe('assertInstallAllowed', () => {
+  it('lets anything through under the default policy', () => {
+    expect(() => assertInstallAllowed({ policy: 'open', spec: 'left-pad', signed: false })).not.toThrow();
+  });
+
+  it('refuses everything under denied, signed or not', () => {
+    for (const signed of [true, false]) {
+      expect(() => assertInstallAllowed({ policy: 'denied', spec: '@moxxy/plugin-memory', signed }))
+        .toThrow(/disabled on this machine/);
+    }
+  });
+
+  it('under registry-only, accepts a signed spec and refuses an unsigned one', () => {
+    expect(() => assertInstallAllowed({ policy: 'registry-only', spec: '@moxxy/plugin-memory', signed: true }))
+      .not.toThrow();
+    expect(() => assertInstallAllowed({ policy: 'registry-only', spec: 'sketchy-pkg', signed: false }))
+      .toThrow(/not in the signed plugin registry/);
+  });
+
+  // A developer hitting a managed restriction has to learn that a POLICY
+  // exists, not just that something refused, or the next thing they try is to
+  // work around it.
+  it('names the policy and offers the way forward', () => {
+    try {
+      assertInstallAllowed({ policy: 'registry-only', spec: 'sketchy-pkg', signed: false });
+      expect.unreachable();
+    } catch (err) {
+      const e = err as { message: string; hint?: string; context?: Record<string, unknown> };
+      expect(e.message).toContain('installPolicy: registry-only');
+      expect(e.hint).toContain('operator');
+      expect(e.context?.spec).toBe('sketchy-pkg');
+    }
+  });
+});
+
+describe('isInstallPolicy', () => {
+  it('accepts exactly the known policies', () => {
+    for (const p of INSTALL_POLICIES) expect(isInstallPolicy(p)).toBe(true);
+    for (const bad of ['', 'OPEN', 'allow', 42, null, undefined]) expect(isInstallPolicy(bad)).toBe(false);
+  });
+});

--- a/packages/plugin-plugins-admin/src/install-policy.ts
+++ b/packages/plugin-plugins-admin/src/install-policy.ts
@@ -1,0 +1,69 @@
+import { MoxxyError } from '@moxxy/sdk';
+
+/**
+ * How much freedom a machine has over what it installs.
+ *
+ * `moxxy plugins install` runs `npm install` against whatever spec it is given:
+ * a bare name, `name@version`, a git URL, or a filesystem path. On a personal
+ * machine that is the point. On a managed fleet it means the supply chain has
+ * no boundary at all, and an organisation had no way to draw one.
+ *
+ *   - `open`:          anything installs. The default; unchanged behaviour.
+ *   - `registry-only`: only packages the SIGNED registry index vouches for.
+ *     The index is Ed25519-verified and pins an exact version, so this is the
+ *     setting that makes "we only run reviewed code" enforceable rather than
+ *     aspirational.
+ *   - `denied`:        nothing installs. For an image built once and shipped,
+ *     where any install at runtime is by definition drift.
+ *
+ * Enforced inside the install function rather than at the CLI surface, because
+ * the `install_plugin` MODEL tool reaches the same path. A policy the agent
+ * could route around by asking itself would not be a policy.
+ */
+export type InstallPolicy = 'open' | 'registry-only' | 'denied';
+
+export const INSTALL_POLICIES: ReadonlyArray<InstallPolicy> = ['open', 'registry-only', 'denied'];
+
+export function isInstallPolicy(value: unknown): value is InstallPolicy {
+  return typeof value === 'string' && (INSTALL_POLICIES as ReadonlyArray<string>).includes(value);
+}
+
+export interface InstallPolicyCheck {
+  readonly policy: InstallPolicy;
+  /** The spec the caller wants to install. */
+  readonly spec: string;
+  /**
+   * Whether the signed registry vouched for this spec. Resolved by the caller
+   * (which already consults the index for the version pin), so this module
+   * stays a pure decision and needs no network.
+   */
+  readonly signed: boolean;
+}
+
+/**
+ * Throw when policy forbids the install. Returns nothing on success so the
+ * call site reads as a guard.
+ *
+ * The errors name the policy and where it came from: a developer hitting a
+ * managed restriction should learn that a policy exists, not just that npm
+ * refused, or the next thing they try is to work around it.
+ */
+export function assertInstallAllowed(check: InstallPolicyCheck): void {
+  if (check.policy === 'open') return;
+  if (check.policy === 'denied') {
+    throw new MoxxyError({
+      code: 'TOOL_ERROR',
+      message: `installing plugins is disabled on this machine (plugins.installPolicy: denied)`,
+      hint: 'Add the package to the config manifest and provision it with `moxxy sync`, or ask an operator to relax plugins.installPolicy.',
+      context: { spec: check.spec, policy: check.policy },
+    });
+  }
+  if (!check.signed) {
+    throw new MoxxyError({
+      code: 'TOOL_ERROR',
+      message: `"${check.spec}" is not in the signed plugin registry (plugins.installPolicy: registry-only)`,
+      hint: 'Only packages the signed index vouches for may be installed. Publish it to your registry, or ask an operator to relax plugins.installPolicy.',
+      context: { spec: check.spec, policy: check.policy },
+    });
+  }
+}

--- a/packages/plugin-plugins-admin/src/install.test.ts
+++ b/packages/plugin-plugins-admin/src/install.test.ts
@@ -206,3 +206,43 @@ describe('installPluginPackage does not execute lifecycle scripts', () => {
     expect(existsSync(path.join(installed, 'PWNED'))).toBe(true);
   }, 120_000);
 });
+
+// The policy must bite inside the install FUNCTION, not at the CLI surface:
+// `install_plugin` (the model tool) reaches this same path, and a restriction
+// the agent could route around by asking itself would not be a restriction.
+describe('installPluginPackage enforces the install policy', () => {
+  let home: string;
+  let prevHome: string | undefined;
+  beforeEach(() => {
+    home = mkdtempSync(path.join(os.tmpdir(), 'mox-policy-home-'));
+    prevHome = process.env.MOXXY_HOME;
+    process.env.MOXXY_HOME = home;
+  });
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.MOXXY_HOME;
+    else process.env.MOXXY_HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('refuses under `denied` without ever spawning npm', async () => {
+    await expect(
+      installPluginPackage({ packageName: 'left-pad', policy: 'denied' }),
+    ).rejects.toThrow(/disabled on this machine/);
+    expect(existsSync(path.join(userPluginsDir(), 'node_modules'))).toBe(false);
+  });
+
+  it('refuses an unsigned spec under `registry-only`', async () => {
+    await expect(
+      installPluginPackage({ packageName: 'left-pad', policy: 'registry-only', signed: false }),
+    ).rejects.toThrow(/not in the signed plugin registry/);
+    expect(existsSync(path.join(userPluginsDir(), 'node_modules'))).toBe(false);
+  });
+
+  it('leaves the default path unrestricted', async () => {
+    // No policy passed = `open`; the abort guard is what stops it here, which
+    // proves the policy check did not fire first.
+    await expect(
+      installPluginPackage({ packageName: 'left-pad', signal: AbortSignal.abort() }),
+    ).rejects.toThrow(/aborted before start/);
+  });
+});

--- a/packages/plugin-plugins-admin/src/install.ts
+++ b/packages/plugin-plugins-admin/src/install.ts
@@ -14,6 +14,7 @@ import { assertSafeNpmSpec, diffSnapshot, NPM_NAME_RE, type PluginSnapshot } fro
 import { pinFirstPartySpec } from './pin.js';
 import { readPluginSetup } from './setup-spec.js';
 import { checkCapabilityManifest, resolveInstallSource } from './registry.js';
+import { assertInstallAllowed, type InstallPolicy } from './install-policy.js';
 
 export type { PluginSnapshot } from './shared.js';
 
@@ -92,6 +93,14 @@ export interface InstallPluginPackageOptions {
   /** Optional abort signal; aborting kills the npm child process. */
   readonly signal?: AbortSignal;
   /**
+   * The machine's install policy. Defaults to `open` so nothing changes for a
+   * personal install; a managed host pins it from the system config scope.
+   */
+  readonly policy?: InstallPolicy;
+  /** Whether the signed registry vouched for this spec. Resolved by the caller,
+   *  which already consults the index for the version pin. */
+  readonly signed?: boolean;
+  /**
    * Opt back INTO running the package's npm lifecycle scripts. Off by default
    * (see {@link NPM_INSTALL_FLAGS}); this exists for the narrow set of packages
    * that genuinely cannot install without one, namely native modules that fetch
@@ -139,6 +148,14 @@ export async function installPluginPackage(
   opts: InstallPluginPackageOptions,
 ): Promise<InstallPluginPackageResult> {
   const spec = assertSafeNpmSpec(opts.packageName);
+  // Checked HERE, not at the CLI surface: `install_plugin` (the model tool)
+  // reaches this same function, and a policy the agent could route around by
+  // asking itself would not be a policy.
+  assertInstallAllowed({
+    policy: opts.policy ?? 'open',
+    spec,
+    signed: opts.signed ?? false,
+  });
   const dir = userPluginsDir();
   return pluginsDirMutex.run(async () => {
     await ensurePackageJson(dir);
@@ -173,6 +190,8 @@ export interface PinnedInstallOptions {
   readonly signal?: AbortSignal;
   /** See {@link InstallPluginPackageOptions.allowScripts}. Human-only. */
   readonly allowScripts?: boolean;
+  /** The machine's install policy; defaults to `open`. */
+  readonly policy?: InstallPolicy;
   /** Surfaced when an injected pin 404s and the install retries unpinned. */
   readonly onWarn?: (message: string) => void;
   /** Injectable install fn for tests; defaults to {@link installPluginPackage}. */
@@ -200,16 +219,19 @@ export async function installPluginPackagePinned(
     opts.pinnedVersion && NPM_NAME_RE.test(opts.packageName) ? opts.pinnedVersion : undefined;
   const spec = pinFirstPartySpec(opts.packageName, opts.version ?? signedPin, opts.cliVersion);
   const injectedPin = !opts.version && spec !== opts.packageName;
-  const { signal, allowScripts } = opts;
+  const { signal, allowScripts, policy } = opts;
+  // `signed` is derived from the pin the caller resolved: a signed registry
+  // entry is exactly what contributes `pinnedVersion`, so the two cannot drift.
+  const signed = opts.pinnedVersion !== undefined;
   try {
-    return await install({ packageName: spec, signal, allowScripts });
+    return await install({ packageName: spec, signal, allowScripts, policy, signed });
   } catch (err) {
     if (!injectedPin) throw err;
     opts.onWarn?.(
       `pinned install ${spec} failed (${err instanceof Error ? err.message : String(err)}); ` +
         `retrying latest ${opts.packageName}`,
     );
-    return await install({ packageName: opts.packageName, signal, allowScripts });
+    return await install({ packageName: opts.packageName, signal, allowScripts, policy, signed });
   }
 }
 


### PR DESCRIPTION
Wave 13, rescoped. The SSO/GHE half needs a plugin to be useful and now builds on the `SecretProvider` block from #479, so it becomes its own wave. What lands here is the enforcement half the audit named as P0 and which the profile work did **not** close.

`moxxy plugins install` shelled out to `npm install` with whatever spec it was handed: a bare name, `name@version`, a git URL, a filesystem path. On a personal machine that is the point. On a managed fleet it meant the supply chain had no boundary at all.

`plugins.installPolicy`:

| value | effect |
|---|---|
| `open` | anything installs. The default; unchanged behaviour. |
| `registry-only` | only what the signed Ed25519 index vouches for, which also pins an exact version |
| `denied` | nothing installs at runtime, for an image built once and shipped |

**Enforced inside `installPluginPackage`, not at the CLI surface.** The `install_plugin` model tool reaches the same function, and a policy the agent could route around by asking itself would not be a policy. The tests assert the refusal happens *before npm is ever spawned*, so this is a gate rather than a message. That is the W11 lesson applied deliberately: adding the config key is not the same as enforcing it.

**`signed` is derived, not passed independently.** A signed registry entry is exactly what contributes `pinnedVersion`, so the two cannot drift into a state where something is "signed" but unpinned.

**Reading the policy fails closed.** If the config probe throws we apply `denied` rather than defaulting to open. A restriction that evaporates when config cannot be read is not a restriction.

`plugins.registryUrl` moves the index location into config so the system scope can pin an internal mirror. It was previously reachable only through `MOXXY_REGISTRY_URL`, a variable a user can simply unset, which makes it useless as a control. Whatever the URL serves must still verify against the key baked into the CLI, so this is a *source* decision, not a trust decision.

The enterprise profile sets `registry-only` and locks it.

Verified: build, typecheck, lint 0 errors, check:deps 0 errors, and the affected suites pass standalone (`plugin-plugins-admin` 22, `cli` 117, `plugin-cli` 320, `config` 103). Local full-suite runs remain unreliable on this machine after a long session of parallel builds (a different package fails each pass, all pass standalone), so CI is the authority here as it was for #479.