### PR TITLE
test: make three load-sensitive tests deterministic

### DIFF
--- a/.changeset/test-determinism.md
+++ b/.changeset/test-determinism.md
@@ -1,0 +1,15 @@
+---
+'@moxxy/cli': patch
+---
+
+Make three load-sensitive tests deterministic.
+
+Each asserted wall-clock timing rather than behaviour, so a local `pnpm test` could not distinguish a regression from a busy machine.
+
+`CrossProcessFireLock` used a 15 ms TTL with a real sleep: any scheduling pause between claiming the fresh marker and sweeping expired it too. It now sets file mtimes and passes the already-injectable clock, with no sleep at all.
+
+The workflows "fires once across two concurrent runners" test raised its `vi.waitFor` budget to 20 s while vitest's default test timeout stayed 10 s, so the generous budget was dead code and the test died first. It now declares its own timeout.
+
+`isolator-subprocess`'s cooperative-abort test asserted that the production 150 ms grace was enough for a child to be scheduled and flush. `abortGraceMs` is now injectable and the test passes a generous value, so it asserts the mechanism while the production default is unchanged.
+
+A repo-wide scan found no other test whose internal wait budget exceeds its own timeout.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -24,6 +24,23 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [med, tests/determinism, RESOLVED 2026-07-27] Three suites failed only under
+  full-suite parallelism, which made a local `pnpm test` unable to distinguish a
+  regression from load. Each was a test asserting wall-clock timing rather than
+  behaviour. `CrossProcessFireLock` used a 15 ms TTL with a real `sleep`, so any
+  scheduling pause between claiming the fresh marker and sweeping expired it
+  too; it now sets file mtimes and passes the injectable clock, with no sleep at
+  all. The workflows `fileChanged`-across-two-runners test raised its `vi.waitFor`
+  budget to 20 s while vitest's default TEST timeout stayed 10 s, so the generous
+  budget was dead code and the test died first; it now declares its own 40 s
+  timeout. `isolator-subprocess`'s cooperative-abort test asserted that the
+  production 150 ms grace was enough for a child to be scheduled AND flush, which
+  is a measurement of machine load; `abortGraceMs` is now injectable and the test
+  passes a generous value, asserting the mechanism while the production default
+  is unchanged. A repo-wide scan found no other test whose internal wait budget
+  exceeds its own timeout. `packages/sdk/src/cross-process-lock.test.ts`,
+  `packages/cli/src/setup/workflows.test.ts`, `packages/isolator-subprocess/src/`.
+
 - [med, tui/providers, RESOLVED 2026-07-23] Text-only models were still given
   the lazy skill index, so Claude Code imitated `load_skill(...)` as assistant
   text and ended the turn before doing the work. ReAct prompt composition now

--- a/packages/cli/src/setup/workflows.test.ts
+++ b/packages/cli/src/setup/workflows.test.ts
@@ -579,7 +579,11 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
       a.stop();
       b.stop();
     }
-  });
+    // Test timeout must exceed the waitFor budget above. It did not: the
+    // waitFor was raised to 20s to survive load, but vitest's default test
+    // timeout is 10s, so the test died first and the generous budget was dead
+    // code. That is the failure this test has been showing under load.
+  }, 40_000);
 
   it('stop() cancels a pending fileChanged debounce so it does not fire after teardown', async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-workflows-stopdebounce-'));

--- a/packages/isolator-subprocess/src/index.test.ts
+++ b/packages/isolator-subprocess/src/index.test.ts
@@ -395,7 +395,11 @@ describe('subprocess hardening', () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-abrt-'));
     const marker = path.join(dir, 'marker');
     try {
-      const iso = createSubprocessIsolator();
+      // Generous grace: the assertion is that a cooperative handler GETS to
+      // flush before the kill, not that 150 ms of wall clock is enough on a
+      // machine running the whole suite in parallel. With the default a child
+      // can spend the entire window just waiting to be scheduled.
+      const iso = createSubprocessIsolator({ abortGraceMs: 5_000 });
       const ctrl = new AbortController();
       const p = iso.run(
         baseCall('flushOnAbort', { marker }, {

--- a/packages/isolator-subprocess/src/index.ts
+++ b/packages/isolator-subprocess/src/index.ts
@@ -154,6 +154,13 @@ interface ResultFail {
 type ChildMessage = ResultOk | ResultFail | BrokerRequest;
 
 export interface SubprocessIsolatorOptions {
+  /**
+   * Grace window after posting `abort` before SIGTERM -> SIGKILL. Defaults to
+   * 150 ms. Raise it only where a slower cooperative flush is expected; the
+   * caller's promise rejects immediately either way, so this never adds
+   * latency to an abort.
+   */
+  readonly abortGraceMs?: number;
   /** Default wall-clock budget (ms) when caps.timeMs is omitted. Default 60_000. */
   readonly defaultTimeMs?: number;
   /**
@@ -231,6 +238,13 @@ const MAX_STDERR_BYTES = 64 * 1024;
  * timeout / host-abort) before the SIGTERM -> SIGKILL escalation. Lets a
  * cooperative handler observe `ctx.signal` and flush; the parent promise
  * still rejects immediately, so this never delays the caller.
+ *
+ * Overridable via {@link SubprocessIsolatorOptions.abortGraceMs} so a TEST can
+ * assert the MECHANISM (a cooperative handler does get to flush before the
+ * kill) without also asserting that 150 ms of wall clock is enough on whatever
+ * machine happens to be running it. Under a full parallel suite a child process
+ * can wait longer than that just to be scheduled, which made the assertion a
+ * measurement of load rather than of behaviour.
  */
 const ABORT_GRACE_MS = 150;
 
@@ -281,6 +295,7 @@ export function createSubprocessIsolator(opts: SubprocessIsolatorOptions = {}): 
   const maxInflightBrokerOps =
     opts.maxInflightBrokerOps ?? DEFAULT_MAX_INFLIGHT_BROKER_OPS;
   const nodePath = opts.nodePath ?? process.execPath;
+  const abortGraceMs = opts.abortGraceMs ?? ABORT_GRACE_MS;
 
   return {
     name: 'subprocess',
@@ -428,7 +443,7 @@ export function createSubprocessIsolator(opts: SubprocessIsolatorOptions = {}): 
               } catch {
                 // Child already closed stdin; fall through to the kill.
               }
-              const grace = setTimeout(killChild, ABORT_GRACE_MS);
+              const grace = setTimeout(killChild, abortGraceMs);
               grace.unref?.();
             } else {
               killChild();

--- a/packages/sdk/src/cross-process-lock.test.ts
+++ b/packages/sdk/src/cross-process-lock.test.ts
@@ -1,10 +1,8 @@
-import { mkdtemp, rm, readdir } from 'node:fs/promises';
+import { mkdtemp, rm, readdir, utimes } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import path from 'node:path';
+import path, { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CrossProcessFireLock } from './cross-process-lock.js';
-
-const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 describe('CrossProcessFireLock', () => {
   let dir: string;
@@ -40,23 +38,34 @@ describe('CrossProcessFireLock', () => {
   });
 
   it('reclaims a stale marker once its TTL elapses (crashed holder)', async () => {
-    const lock = new CrossProcessFireLock({ dir, ttlMs: 15 });
+    const ttlMs = 1_000;
+    const lock = new CrossProcessFireLock({ dir, ttlMs });
     expect(await lock.claim('k@1')).toBe(true);
     expect(await lock.claim('k@1')).toBe(false);
-    await sleep(40);
-    // The previous holder "crashed"; the marker is now stale and reclaimable.
-    expect(await lock.claim('k@1')).toBe(true);
+    // The previous holder "crashed": advance the CLOCK past the TTL rather than
+    // sleeping, so the test asserts the staleness rule and not the accuracy of
+    // a timer on a loaded machine.
+    expect(await lock.claim('k@1', Date.now() + ttlMs * 5)).toBe(true);
   });
 
+  // Age is set on the FILES and the clock is passed in, rather than produced by
+  // sleeping. Expiry is `now - mtime > ttlMs`, so a sleep-based version races
+  // the scheduler: any pause between claiming the fresh marker and sweeping
+  // that exceeds the TTL expires it too, and a short TTL makes that pause
+  // trivial to hit on a loaded machine.
   it('sweep removes expired markers and leaves fresh ones', async () => {
-    const lock = new CrossProcessFireLock({ dir, ttlMs: 15 });
+    const ttlMs = 1_000;
+    const lock = new CrossProcessFireLock({ dir, ttlMs });
     await lock.claim('old@1');
-    await sleep(40);
     await lock.claim('fresh@1');
-    const removed = await lock.sweep();
-    expect(removed).toBe(1);
-    const remaining = await readdir(dir);
-    expect(remaining).toEqual(['fresh@1.lock']);
+
+    const now = Date.now();
+    const stale = new Date(now - ttlMs * 5);
+    await utimes(join(dir, 'old@1.lock'), stale, stale);
+    await utimes(join(dir, 'fresh@1.lock'), new Date(now), new Date(now));
+
+    expect(await lock.sweep(now)).toBe(1);
+    expect(await readdir(dir)).toEqual(['fresh@1.lock']);
   });
 
   it('sanitizes unsafe key characters into a single marker file', async () => {


### PR DESCRIPTION
You asked for the tests to be deterministic. Here is what was actually wrong, found by reproduction rather than by reasoning about it.

All three asserted **wall-clock timing rather than behaviour**, so a local `pnpm test` could not tell a regression from a busy machine. That is exactly why I stopped trusting the local suite late in the previous session and deferred to CI.

**`CrossProcessFireLock` sweep** used a 15 ms TTL with a real `sleep`. Expiry is `now - mtime > ttlMs`, so any scheduling pause between claiming the *fresh* marker and sweeping it expired that one too and the count came back 2. The claim/sweep API already accepted an injectable clock, so the test now sets both markers' mtimes explicitly and passes a fixed `now`. No sleep, no dependence on timer accuracy. The neighbouring reclaim test had the same 15 ms/40 ms pairing and is now clock-driven too.

**The workflows "fires once across two concurrent runners" test** is the interesting one. It had *already* been given a 20 s `vi.waitFor` budget after an earlier flake, with a comment saying so. But vitest's default **test** timeout is 10 s, so the test died before that budget could ever be spent and the previous fix was dead code. That is the `Test timed out in 10000ms` I reported on #470. It now declares its own timeout.

I scanned the repo for the same shape (an in-test wait budget exceeding its enclosing test's timeout) and found **no other instance**, so this was one bug and not a class. Worth saying, because "we fixed the flaky test" usually means "we widened one number".

**`isolator-subprocess`'s cooperative-abort test** asserted that the production 150 ms grace is enough for a child process to be *scheduled* and flush a file. Under a full parallel suite a child can spend that entire window waiting for a core, so the assertion measured load. `abortGraceMs` is now an isolator option and the test passes a generous value: it still proves a cooperative handler gets to flush before the kill, and **the production default is unchanged at 150 ms**. I deliberately did not move the production constant to make a test pass.

Evidence:

```
workflows, before fix:  1 failure / 6 runs under CPU load
workflows, after fix:   0 failures / 8 runs under heavier load
full suite (--force):   2 of 3 runs failing before, 3 of 3 clean after
```

**Not fixed, and I would rather say so than pad the number:** `plugin-computer-control`'s screenshot test shells out to the real macOS capture utility. It failed once in three forced runs and I could not reproduce it in isolation under load, so I left it alone. A test that invokes the host's screen capture is environment-dependent by construction and wants a different remedy than a timing tweak.

Retires the corresponding `TECH_DEBT.md` entry.