### PR TITLE
feat(registry): authenticate to an internal plugin mirror

### DIFF
--- a/.changeset/enterprise-host-credentials.md
+++ b/.changeset/enterprise-host-credentials.md
@@ -1,0 +1,14 @@
+---
+'@moxxy/cli': minor
+'@moxxy/sdk': minor
+---
+
+Authenticate to an internal plugin registry.
+
+The install-policy work let an operator point at an internal mirror, but gave no way to authenticate to it, so a mirror behind SSO was unreachable. `hostCredentialName()` derives a canonical secret name from a host (`registry.example.internal` becomes `MOXXY_CREDENTIAL_REGISTRY_EXAMPLE_INTERNAL`), and the registry fetch sends it as a bearer token on both the index and its signature.
+
+The credential is resolved through whatever `SecretProvider` the machine has active, which is why there is no separate credential registry: a host credential is a named secret plus a convention, so the store an organisation already plugged in serves these too.
+
+Authentication decides only whether the index is reachable. The Ed25519 verification is unchanged and still decides whether the bytes are trusted, so an authenticated mirror serving an unsigned index is refused exactly like an anonymous one.
+
+`Session.resolveSecret` exposes the same resolver tool handlers get, so host-side callers go through the active provider instead of reaching past it to the local vault.

--- a/.changeset/vault-optional-passphrase.md
+++ b/.changeset/vault-optional-passphrase.md
@@ -1,0 +1,13 @@
+---
+'@moxxy/cli': minor
+---
+
+Stop demanding a vault passphrase on first run.
+
+The master key was resolved from `MOXXY_VAULT_PASSPHRASE`, then the OS keychain, then a cached key at `~/.moxxy/vault.key`, and finally an interactive passphrase prompt. On macOS the keychain means nobody is ever asked, but on a host without one, a container, a headless Linux box, CI, that prompt was the last resort and a hard stop on a non-TTY.
+
+A randomly generated 256-bit key now sits between the disk cache and the prompt. It gives the same protection against what this vault is actually for, which is a key leaking through config committed to git, a transcript, or a log. It does not protect against someone who can already read a `0600` file in the user's home; an OS keychain or a passphrase does raise that bar, and `moxxy doctor` now says so when a generated or file-backed key is in use.
+
+Generation only happens when the key can be **persisted**. A generated key that could not be stored is unrecoverable, so every secret written under it would be lost on the next run; there the prompt is better precisely because the user can reproduce it from memory.
+
+`vault.requirePassphrase: true` restores the old behaviour, and an operator can lock it from the system scope.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,6 +154,20 @@ Prefer the first two when writing an organisation's policy. `{ Read: { path: '/e
 
 Decision order: managed deny, then file deny, then managed allow, then file allow.
 
+### Secret vault
+
+Keys are encrypted at rest. Where the master key lives is resolved in order: `MOXXY_VAULT_PASSPHRASE`, the OS keychain, a cached key at `~/.moxxy/vault.key` (mode `0600`), and finally a **randomly generated** key that is persisted for next time.
+
+You are never asked to invent a passphrase. That used to be the last resort, which made first run a hard stop on any host without an OS keychain: a container, a headless Linux box, CI. A generated key gives the same protection against what this vault is actually for, which is a key leaking through config committed to git, a transcript, or a log. It does not protect against someone who can already read a `0600` file in your home directory. An OS keychain, or a passphrase, does raise that bar.
+
+```yaml
+vault:
+  # Demand a human-chosen passphrase instead of generating a key.
+  requirePassphrase: true
+```
+
+`moxxy doctor` reports which source is in use.
+
 ### Audit trail
 
 Distinct from the event log. The event log is the conversation: complete, replayable, local. The audit trail is the receipt: bounded, redacted, hash-chained, and safe to forward off the machine.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -127,7 +127,20 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
     return vault.sourceName;
   });
   if (vaultRes.ok) {
-    checks.push({ id: 'vault', status: 'ok', message: `unlocked via ${vaultRes.value}` });
+    // Name the posture, not just the mechanism. A generated key protects a key
+    // from leaking through config in git, a transcript, or a log, which is the
+    // threat this vault addresses; it does not protect against someone who can
+    // already read a 0600 file in this user's home. The OS keychain and a
+    // passphrase both raise that bar, so say so once rather than leaving the
+    // user to infer it from the word "file:".
+    const source = vaultRes.value;
+    const note =
+      source === 'generated' || source.startsWith('file:')
+        ? colors.dim(
+            ' (key stored beside the vault; an OS keychain or `vault.requirePassphrase: true` raises the bar)',
+          )
+        : '';
+    checks.push({ id: 'vault', status: 'ok', message: `unlocked via ${source}${note}` });
   } else {
     checks.push({
       id: 'vault',

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -20,7 +20,7 @@ import {
   undeclaredToolsWarning,
   type InstallCapabilityReport,
 } from '@moxxy/plugin-plugins-admin';
-import { isFirstPartyPackage } from '@moxxy/sdk';
+import { hostCredentialName, isFirstPartyPackage } from '@moxxy/sdk';
 import type { ParsedArgv } from '../argv.js';
 import { argvToSetupOptions, bootSession, hasBoolFlag, helpRequested } from '../argv-helpers.js';
 import { probeSession } from '../setup.js';
@@ -191,7 +191,10 @@ async function runInstall(argv: ParsedArgv): Promise<number> {
   const resolved =
     version || ref
       ? undefined
-      : await resolveInstallSource(target, policyCfg.registryUrl ? { url: policyCfg.registryUrl } : {});
+      : await resolveInstallSource(target, {
+          ...(policyCfg.registryUrl ? { url: policyCfg.registryUrl } : {}),
+          ...(policyCfg.token ? { token: policyCfg.token } : {}),
+        });
   const spec =
     resolved?.spec ??
     buildInstallSpec({
@@ -528,7 +531,7 @@ function errorMessage(err: unknown): string {
  */
 async function readInstallConfig(
   argv: ParsedArgv,
-): Promise<{ policy?: InstallPolicy; registryUrl?: string }> {
+): Promise<{ policy?: InstallPolicy; registryUrl?: string; token?: string }> {
   try {
     return await probeSession(
       argvToSetupOptions(argv, {
@@ -536,12 +539,24 @@ async function readInstallConfig(
         tolerateNoProvider: true,
         skipProviderActivation: true,
       }),
-      ({ config }) => ({
-        ...(isInstallPolicy(config.plugins?.installPolicy)
-          ? { policy: config.plugins.installPolicy }
-          : {}),
-        ...(config.plugins?.registryUrl ? { registryUrl: config.plugins.registryUrl } : {}),
-      }),
+      async ({ config, session }) => {
+        const registryUrl = config.plugins?.registryUrl;
+        // An internal mirror usually sits behind auth. The credential is a
+        // named secret under a host convention, resolved through whatever
+        // SecretProvider the machine has active, so this needs no notion of
+        // where secrets actually live.
+        const secretName = registryUrl ? hostCredentialName(registryUrl) : null;
+        const token = secretName
+          ? await session.resolveSecret?.(secretName).catch(() => null)
+          : null;
+        return {
+          ...(isInstallPolicy(config.plugins?.installPolicy)
+            ? { policy: config.plugins.installPolicy }
+            : {}),
+          ...(registryUrl ? { registryUrl } : {}),
+          ...(token ? { token } : {}),
+        };
+      },
     );
   } catch {
     // A probe failure must not silently DROP a restriction, so fail closed on

--- a/packages/cli/src/profiles.ts
+++ b/packages/cli/src/profiles.ts
@@ -59,6 +59,12 @@ plugins:
   # Point at your own mirror. Whatever it serves must still verify against the
   # key baked into the CLI, so this is a SOURCE decision, not a trust decision.
   # registryUrl: https://registry.example.internal/moxxy/index.json
+  #
+  # A mirror behind SSO needs a credential. Store it under the host convention
+  # and whatever SecretProvider this machine has active will serve it:
+  #   registry.example.internal -> MOXXY_CREDENTIAL_REGISTRY_EXAMPLE_INTERNAL
+  # Authentication only decides whether the index is REACHABLE; the Ed25519
+  # signature still decides whether it is trusted.
   isolator:
     # A real process boundary. 'inproc' is best-effort only and cannot contain
     # a hostile plugin; 'worker' is the lighter middle ground.

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -76,8 +76,11 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   });
   progress({ kind: 'config-loaded', sources: sources.length });
 
+  // `requirePassphrase` comes from the RAW config: the vault is what resolves
+  // `${vault:…}` placeholders, so it must exist before they can be resolved.
   const { plugin: vaultPlugin, vault } = buildVaultPlugin({
     disableKeytar: opts.disableKeytar,
+    ...(rawConfig.vault?.requirePassphrase ? { requirePassphrase: true } : {}),
     ...(opts.passphrasePrompt ? { passphrasePrompt: opts.passphrasePrompt } : {}),
   });
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -139,6 +139,21 @@ export const auditConfigSchema = z
   })
   .strict();
 
+/** Secret-vault behaviour. */
+export const vaultConfigSchema = z
+  .object({
+    /**
+     * Demand a human-chosen passphrase instead of generating a key.
+     *
+     * Off by default. A passphrase is a genuine increase in protection, but
+     * making it mandatory turned first run into a hard stop on any host without
+     * an OS keychain (a container, a headless box, CI). An operator who wants
+     * the stronger posture sets this and can lock it from the system scope.
+     */
+    requirePassphrase: z.boolean().optional(),
+  })
+  .strict();
+
 export const embeddingsConfigSchema = z.object({
   /**
    * 'tfidf' (default, zero deps) | 'openai' (text-embedding-3-*)
@@ -253,6 +268,7 @@ export const moxxyConfigSchema = z.object({
   security: securityConfigSchema.optional(),
   network: networkConfigSchema.optional(),
   audit: auditConfigSchema.optional(),
+  vault: vaultConfigSchema.optional(),
   channels: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
   permissions: permissionsConfigSchema.optional(),
   env: z.record(z.string(), z.string()).optional(),
@@ -287,6 +303,7 @@ export type WatcherMode = z.infer<typeof watcherModeSchema>;
 export type PermissionsConfig = z.infer<typeof permissionsConfigSchema>;
 export type NetworkConfig = z.infer<typeof networkConfigSchema>;
 export type AuditConfig = z.infer<typeof auditConfigSchema>;
+export type VaultConfig = z.infer<typeof vaultConfigSchema>;
 export type EmbeddingsConfig = z.infer<typeof embeddingsConfigSchema>;
 export type SecurityConfig = z.infer<typeof securityConfigSchema>;
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -143,6 +143,14 @@ export class Session implements ClientSession, SessionRuntime {
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
   readonly auditSinks: AuditSinkRegistry;
+  /**
+   * Resolve a named secret, through whatever SecretProvider the host wired.
+   * The same function tool handlers receive as `ctx.getSecret`; exposed here so
+   * a HOST-side caller (resolving a credential for an internal registry, say)
+   * goes through the active provider instead of reaching past it to the vault.
+   * Undefined when no resolver was supplied.
+   */
+  readonly resolveSecret?: (name: string) => Promise<string | null>;
   /** External secret stores. No core floor: the vault is a plugin, so the
    *  host registers it as the protected floor at boot. */
   readonly secretProviders: SecretProviderRegistry;
@@ -217,6 +225,7 @@ export class Session implements ClientSession, SessionRuntime {
       cwd: this.cwd,
       ...(opts.secretResolver ? { secretResolver: opts.secretResolver } : {}),
     });
+    if (opts.secretResolver) this.resolveSecret = opts.secretResolver;
     this.providers = new ProviderRegistry();
     this.modes = new ModeRegistry();
     this.compactors = new CompactorRegistry();

--- a/packages/plugin-plugins-admin/src/registry.test.ts
+++ b/packages/plugin-plugins-admin/src/registry.test.ts
@@ -573,3 +573,77 @@ describe('checkCapabilityManifest', () => {
     expect(checkCapabilityManifest({}, { timeMs: 500 }).capabilityMismatch).toBe(false);
   });
 });
+
+describe('authenticated registry mirror', () => {
+  let cacheDir: string;
+  beforeEach(() => {
+    // Own cache dir per test: a verified cache short-circuits the fetch, which
+    // would make the header assertions silently stop exercising anything.
+    cacheDir = mkdtempSync(path.join(os.tmpdir(), 'mox-reg-auth-'));
+  });
+  afterEach(() => rmSync(cacheDir, { recursive: true, force: true }));
+
+  const INDEX = JSON.stringify({ version: 1, generatedAt: '2026-01-01T00:00:00Z', entries: [] });
+
+  // A real Ed25519 public key: with the BAKED key empty (unprovisioned) the
+  // remote path is skipped entirely, so without this the fetch never happens
+  // and an `every()` assertion over an empty array passes vacuously. That is
+  // exactly how the first draft of these tests "passed".
+  const publicKeyPem = generateKeyPairSync('ed25519').publicKey.export({
+    type: 'spki',
+    format: 'pem',
+  }) as string;
+
+  const capturingFetch = () => {
+    const seen: Array<{ url: string; auth?: string }> = [];
+    const fetchImpl = async (url: string, init?: { headers?: Record<string, string> }) => {
+      seen.push({ url, ...(init?.headers?.authorization ? { auth: init.headers.authorization } : {}) });
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => new TextEncoder().encode(INDEX).buffer,
+        text: async () => 'not-a-real-signature',
+      };
+    };
+    return { seen, fetchImpl };
+  };
+
+  it('sends no authorization header when no token is configured', async () => {
+    const { seen, fetchImpl } = capturingFetch();
+    await fetchSignedRegistry({ fetch: fetchImpl as never, url: 'https://mirror.internal/i.json', publicKeyPem, cacheDir });
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every((r) => r.auth === undefined)).toBe(true);
+  });
+
+  // The signature lives beside the index, so a mirror that gates one gates the
+  // other; omitting the header on `.sig` would fail in a way that looks like a
+  // missing signature rather than like an auth problem.
+  it('sends the bearer token on BOTH the index and its signature', async () => {
+    const { seen, fetchImpl } = capturingFetch();
+    await fetchSignedRegistry({
+      fetch: fetchImpl as never,
+      url: 'https://mirror.internal/i.json',
+      token: 'tok-123',
+      publicKeyPem,
+      cacheDir,
+    });
+    expect(seen).toHaveLength(2);
+    expect(seen.map((r) => r.auth)).toEqual(['Bearer tok-123', 'Bearer tok-123']);
+    expect(seen.some((r) => r.url.endsWith('.sig'))).toBe(true);
+  });
+
+  // Authentication is about REACHING the mirror. It must not become a way to
+  // trust one: an authenticated mirror serving an unsigned index is refused
+  // exactly like an anonymous one.
+  it('still refuses a badly-signed index from an authenticated mirror', async () => {
+    const { fetchImpl } = capturingFetch();
+    const result = await fetchSignedRegistry({
+      fetch: fetchImpl as never,
+      url: 'https://mirror.internal/i.json',
+      token: 'tok-123',
+      publicKeyPem,
+      cacheDir,
+    });
+    expect(result.source).toBe('fallback');
+  });
+});

--- a/packages/plugin-plugins-admin/src/registry.ts
+++ b/packages/plugin-plugins-admin/src/registry.ts
@@ -226,7 +226,7 @@ export function parseRegistryIndex(bytes: Uint8Array): PluginRegistryIndex | und
  *  from search.ts's JSON-only `FetchLike`. */
 export type RegistryFetchLike = (
   url: string,
-  init?: { readonly signal?: AbortSignal },
+  init?: { readonly signal?: AbortSignal; readonly headers?: Record<string, string> },
 ) => Promise<{
   readonly ok: boolean;
   readonly status: number;
@@ -274,6 +274,16 @@ export interface FetchSignedRegistryOptions {
   readonly publicKeyPem?: string;
   /** Cancels in-flight fetches (combined with the internal 10s deadline). */
   readonly signal?: AbortSignal;
+  /**
+   * Bearer credential for an index that requires authentication, e.g. an
+   * internal mirror behind SSO. Resolved by the caller through the active
+   * SecretProvider, so this module needs no notion of where secrets live.
+   *
+   * Purely about REACHING the index. The Ed25519 verification below is
+   * unchanged and still decides whether the bytes are trusted: an authenticated
+   * mirror serving an unsigned index is refused exactly like an anonymous one.
+   */
+  readonly token?: string;
 }
 
 /**
@@ -310,9 +320,15 @@ export async function fetchSignedRegistry(
   let bytes: Uint8Array;
   let sig: string;
   try {
+    // Sent on BOTH requests: the signature lives beside the index, so a mirror
+    // that gates one gates the other, and omitting it on `.sig` would fail the
+    // fetch in a way that looks like a missing signature.
+    const init = opts.token
+      ? { signal, headers: { authorization: `Bearer ${opts.token}` } }
+      : { signal };
     const [indexRes, sigRes] = await Promise.all([
-      fetchImpl(url, { signal }),
-      fetchImpl(`${url}.sig`, { signal }),
+      fetchImpl(url, init),
+      fetchImpl(`${url}.sig`, init),
     ]);
     if (!indexRes.ok || !sigRes.ok) {
       return fallback(

--- a/packages/plugin-vault/src/index.ts
+++ b/packages/plugin-vault/src/index.ts
@@ -25,6 +25,9 @@ export interface BuildVaultPluginOptions {
   readonly passphrasePrompt?: () => Promise<string>;
   readonly envVar?: string;
   readonly disableKeytar?: boolean;
+  /** Demand a human-chosen passphrase instead of generating a key. Off by
+   *  default; see `CombinedKeySourceOptions.requirePassphrase`. */
+  readonly requirePassphrase?: boolean;
 }
 
 export function defaultVaultPath(): string {
@@ -39,6 +42,7 @@ export function buildVaultPlugin(opts: BuildVaultPluginOptions = {}): { plugin: 
       passphrasePrompt: opts.passphrasePrompt ?? defaultPrompt,
       envVar: opts.envVar,
       disableKeytar: opts.disableKeytar,
+      ...(opts.requirePassphrase ? { requirePassphrase: true } : {}),
     });
   const vault = new VaultStore({ filePath, keySource });
 

--- a/packages/plugin-vault/src/keysource.test.ts
+++ b/packages/plugin-vault/src/keysource.test.ts
@@ -171,7 +171,10 @@ describe('createCombinedKeySource', () => {
     expect(inKeytar).toBe(diskVal);
   });
 
-  it('interactive prompt is the last resort and persists to BOTH keytar and disk', async () => {
+  // The prompt is no longer the default last resort: a key is GENERATED
+  // instead, so a host without an OS keychain is not a hard stop. These cases
+  // opt back in, which is what `vault.requirePassphrase: true` does.
+  it('the prompt, when required, persists to BOTH keytar and disk', async () => {
     let prompts = 0;
     const src = createCombinedKeySource({
       passphrasePrompt: async () => {
@@ -179,6 +182,7 @@ describe('createCombinedKeySource', () => {
         return 'my-passphrase';
       },
       diskKeyPath,
+      requirePassphrase: true,
     });
     const salt = generateSalt();
     const key = await src.obtain(salt);
@@ -200,6 +204,7 @@ describe('createCombinedKeySource', () => {
       passphrasePrompt: async () => 'pw',
       disableKeytar: true,
       diskKeyPath,
+      requirePassphrase: true,
     });
     const key = await src.obtain(generateSalt());
     expect(src.name).toBe('passphrase');
@@ -215,6 +220,7 @@ describe('createCombinedKeySource', () => {
     const src = createCombinedKeySource({
       passphrasePrompt: async () => 'pw',
       diskKeyPath: false,
+      requirePassphrase: true,
     });
     const key = await src.obtain(generateSalt());
     expect(src.name).toBe('passphrase');
@@ -255,7 +261,7 @@ describe('createCombinedKeySource', () => {
     expect(onDisk).toBe(key.toString('base64'));
   });
 
-  it('falls through to the prompt when keytar throws and disk is empty', async () => {
+  it('falls through to the prompt when keytar throws, disk is empty, and a passphrase is required', async () => {
     keytarState.failGet = true; // keychain unavailable
     let prompted = false;
     const src = createCombinedKeySource({
@@ -264,6 +270,7 @@ describe('createCombinedKeySource', () => {
         return 'pw';
       },
       diskKeyPath,
+      requirePassphrase: true,
     });
     await src.obtain(generateSalt());
     expect(prompted).toBe(true);
@@ -281,5 +288,72 @@ describe('createStaticKeySource', () => {
     expect(await src.obtain(generateSalt())).toBe(key);
     // No persist hook on the static source.
     expect(src.persist).toBeUndefined();
+  });
+});
+
+describe('generated key (no passphrase demanded)', () => {
+  // The behaviour the whole change is for: a host with no OS keychain and no
+  // cached key used to hit a passphrase prompt, which is a hard stop on a
+  // non-TTY (a container, a headless box, CI).
+  it('generates and persists a key instead of prompting', async () => {
+    keytarState.failGet = true;
+    let prompted = false;
+    const src = createCombinedKeySource({
+      passphrasePrompt: async () => {
+        prompted = true;
+        return 'pw';
+      },
+      disableKeytar: true,
+      diskKeyPath,
+    });
+
+    const key = await src.obtain(generateSalt());
+
+    expect(prompted).toBe(false);
+    expect(src.name).toBe('generated');
+    expect(key.length).toBe(32);
+    expect((await fs.readFile(diskKeyPath, 'utf8')).trim()).toBe(key.toString('base64'));
+  });
+
+  // A generated key we cannot store is unrecoverable: every secret written
+  // under it would be lost on the next run. The prompt is better there
+  // precisely because the user can reproduce it from memory.
+  it('falls back to the prompt when the generated key cannot be persisted', async () => {
+    keytarState.failGet = true;
+    keytarState.failSet = true;
+    let prompted = false;
+    const src = createCombinedKeySource({
+      passphrasePrompt: async () => {
+        prompted = true;
+        return 'pw';
+      },
+      diskKeyPath: false, // no disk cache either: nowhere to keep it
+    });
+
+    await src.obtain(generateSalt());
+
+    expect(prompted).toBe(true);
+    expect(src.name).toBe('passphrase');
+  });
+
+  // A second run must reuse the stored key, or every previously-written secret
+  // becomes undecryptable.
+  it('reuses the generated key on the next run', async () => {
+    const first = createCombinedKeySource({
+      passphrasePrompt: async () => 'unused',
+      disableKeytar: true,
+      diskKeyPath,
+    });
+    const a = await first.obtain(generateSalt());
+
+    const second = createCombinedKeySource({
+      passphrasePrompt: async () => 'unused',
+      disableKeytar: true,
+      diskKeyPath,
+    });
+    const b = await second.obtain(generateSalt());
+
+    expect(b.toString('base64')).toBe(a.toString('base64'));
+    expect(second.name).toContain('file:');
   });
 });

--- a/packages/plugin-vault/src/keysource.ts
+++ b/packages/plugin-vault/src/keysource.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { writeFileAtomic, moxxyPath } from '@moxxy/sdk/server';
 import { deriveKeyAsync } from './crypto.js';
@@ -23,6 +24,14 @@ export interface MasterKeySource {
 
 export interface CombinedKeySourceOptions {
   readonly passphrasePrompt: () => Promise<string>;
+  /**
+   * Demand a human-chosen passphrase instead of generating a key. Off by
+   * default: a passphrase is a real increase in protection, but making it
+   * mandatory turned first run into a hard stop on any host without an OS
+   * keychain. An operator who wants the stronger posture sets
+   * `vault.requirePassphrase: true` (and can lock it from the system scope).
+   */
+  readonly requirePassphrase?: boolean;
   readonly envVar?: string;
   /**
    * Skip the OS keychain (`@napi-rs/keyring`) entirely, using only the disk
@@ -47,7 +56,9 @@ export interface CombinedKeySourceOptions {
  *   1. `MOXXY_VAULT_PASSPHRASE` env var (derive on each call — no persistence).
  *   2. OS keychain via `@napi-rs/keyring`.
  *   3. On-disk cached key at `~/.moxxy/vault.key` (mode 0600).
- *   4. Interactive passphrase prompt.
+ *   4. A randomly GENERATED key, persisted for next time.
+ *   5. Interactive passphrase prompt (only when a passphrase is required, or
+ *      when the generated key could not be persisted).
  *
  * The first successful prompt persists the derived key to BOTH the OS keychain
  * (if available) and the disk cache so subsequent runs are silent. The chosen
@@ -115,6 +126,28 @@ export function createCombinedKeySource(opts: CombinedKeySourceOptions): MasterK
         }
       }
 
+      // Nothing stored yet. Prefer GENERATING a key over demanding a
+      // passphrase: on a host with no OS keychain (a container, a headless
+      // Linux box) the prompt was a hard stop, and on a non-TTY it failed
+      // outright. A random 256-bit key gives the same protection against the
+      // threat this vault actually addresses, which is a key leaking through
+      // config in git, a transcript, or a log, rather than through a local
+      // attacker who can already read a 0600 file in the user's own home.
+      //
+      // Only when the key can be PERSISTED, though. A generated key we cannot
+      // store is unrecoverable, so every secret written under it would be lost
+      // on the next run; in that case the prompt is better precisely because
+      // the user can reproduce it from memory.
+      if (!opts.requirePassphrase) {
+        const generated = randomBytes(32);
+        const b64 = generated.toString('base64');
+        await persistKey(b64);
+        if (await keyIsRetrievableFrom(diskPath, b64, !opts.disableKeytar)) {
+          resolvedName = 'generated';
+          return generated;
+        }
+      }
+
       const passphrase = await opts.passphrasePrompt();
       resolvedName = 'passphrase';
       const key = await deriveKeyAsync(passphrase, salt);
@@ -125,6 +158,24 @@ export function createCombinedKeySource(opts: CombinedKeySourceOptions): MasterK
       await persistKey(key.toString('base64'));
     },
   };
+}
+
+/**
+ * Confirm a just-persisted key can actually be read back.
+ *
+ * `persistKey` is best-effort on both the keychain and the disk cache, so a
+ * silent failure would leave a generated key in memory only, and every secret
+ * written under it unrecoverable on the next run. Checking is the difference
+ * between "encrypted with a key we kept" and quiet data loss.
+ */
+async function keyIsRetrievableFrom(
+  diskPath: string | null,
+  expected: string,
+  useKeychain: boolean,
+): Promise<boolean> {
+  if (useKeychain && (await tryKeychainGet()) === expected) return true;
+  if (!diskPath) return false;
+  return (await tryDiskGet(diskPath)) === expected;
 }
 
 function resolveDiskPath(supplied: string | false | undefined): string | null {

--- a/packages/sdk/src/host-credential.test.ts
+++ b/packages/sdk/src/host-credential.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { hostCredentialName } from './secret-provider.js';
+
+describe('hostCredentialName', () => {
+  it('upper-snakes a host, mirroring the provider-key convention', () => {
+    expect(hostCredentialName('github.example.com')).toBe('MOXXY_CREDENTIAL_GITHUB_EXAMPLE_COM');
+  });
+
+  it('accepts a full URL and uses only its host', () => {
+    expect(hostCredentialName('https://registry.example.internal/moxxy/index.json')).toBe(
+      'MOXXY_CREDENTIAL_REGISTRY_EXAMPLE_INTERNAL',
+    );
+  });
+
+  // A credential belongs to the host, not to a socket, so the same secret
+  // serves the mirror whether or not the URL happens to name a port.
+  it('ignores the port', () => {
+    expect(hostCredentialName('registry.internal:8443')).toBe(hostCredentialName('registry.internal'));
+    expect(hostCredentialName('https://registry.internal:8443/x')).toBe(
+      hostCredentialName('registry.internal'),
+    );
+  });
+
+  it('collapses runs of non-alphanumerics and trims the edges', () => {
+    expect(hostCredentialName('my--host..internal')).toBe('MOXXY_CREDENTIAL_MY_HOST_INTERNAL');
+  });
+
+  it('handles an IPv6 literal', () => {
+    expect(hostCredentialName('https://[::1]:9000/x')).toBe('MOXXY_CREDENTIAL_1');
+  });
+
+  // Deriving a name from garbage would silently look up the wrong secret, which
+  // reads as "no credential configured" rather than as the typo it is.
+  it('returns null rather than a name derived from nonsense', () => {
+    for (const bad of ['', '   ', 'not a host', 'https://', '://x']) {
+      expect(hostCredentialName(bad)).toBeNull();
+    }
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -64,7 +64,7 @@ export type {
   SecretProviderScope,
   SecretProviderSession,
 } from './secret-provider.js';
-export { defineSecretProvider } from './secret-provider.js';
+export { defineSecretProvider, hostCredentialName } from './secret-provider.js';
 
 // Secret redaction for anything leaving the process.
 export {

--- a/packages/sdk/src/secret-provider.ts
+++ b/packages/sdk/src/secret-provider.ts
@@ -46,3 +46,39 @@ export interface SecretProviderDef {
 export function defineSecretProvider(def: SecretProviderDef): SecretProviderDef {
   return Object.freeze({ ...def });
 }
+
+/**
+ * The canonical secret name holding a credential for `host`.
+ *
+ * A host credential is a named secret plus a convention, which is exactly why
+ * there is no separate `CredentialProvider` registry: whatever store an
+ * organisation already plugged in for secrets serves these too.
+ *
+ * `github.example.com` becomes `MOXXY_CREDENTIAL_GITHUB_EXAMPLE_COM`. The
+ * derivation mirrors the provider-key convention (upper-snake, non-alphanumerics
+ * to `_`) so an operator who has seen one can predict the other, and a port is
+ * dropped because a credential belongs to the host, not to a socket.
+ *
+ * Accepts a bare host or a full URL; anything unparseable yields null rather
+ * than a name derived from garbage, so a caller cannot accidentally look up a
+ * secret keyed on a typo.
+ */
+export function hostCredentialName(hostOrUrl: string): string | null {
+  const raw = hostOrUrl.trim();
+  if (raw.length === 0) return null;
+  let host = raw;
+  if (raw.includes('://')) {
+    try {
+      host = new URL(raw).hostname;
+    } catch {
+      return null;
+    }
+  } else {
+    // Strip a port or a path if the caller passed `host:443/x`.
+    host = raw.split('/')[0]!.split(':')[0]!;
+  }
+  host = host.replace(/^\[|\]$/g, '').trim();
+  if (host.length === 0 || /\s/.test(host)) return null;
+  const slug = host.toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  return slug.length > 0 ? `MOXXY_CREDENTIAL_${slug}` : null;
+}


### PR DESCRIPTION
Wave 15, closing a gap I opened in #481: that change let an operator point `plugins.registryUrl` at an internal mirror but gave no way to authenticate to it, so a mirror behind SSO was simply unreachable.

`hostCredentialName()` derives a canonical secret name from a host (`registry.example.internal` → `MOXXY_CREDENTIAL_REGISTRY_EXAMPLE_INTERNAL`). Upper-snake, mirroring the provider-key convention so an operator who has seen one can predict the other. The port is dropped because a credential belongs to a host, not to a socket. An unparseable input yields `null` rather than a name derived from garbage, since looking up a secret keyed on a typo reads as "no credential configured" instead of as the typo it is.

The credential resolves through whatever `SecretProvider` the machine has active. **This is why there is still no separate credential registry:** a host credential is a named secret plus a convention, so the store an organisation already plugged in for secrets serves these too. That was the call I made when splitting #479 out, and it holds up.

The token goes on **both** the index and its `.sig`. The signature lives beside the index, so a mirror that gates one gates the other, and omitting the header on the signature would fail in a way that looks like a missing signature rather than an auth problem.

**Authentication decides only whether the index is reachable.** Ed25519 verification is untouched and still decides whether the bytes are trusted, so an authenticated mirror serving an unsigned index is refused exactly like an anonymous one. There is a test for that specifically, because "we authenticated to it" is the most tempting way to accidentally start trusting a source.

**Worth reading in the diff:** my first draft of these tests asserted headers with `seen.every(...)` over an array that was *always empty*, because the baked registry key is unprovisioned and the entire remote path is skipped without one. Both tests "passed" while exercising nothing. They now supply a generated key and their own cache dir, and assert the fetch actually happened before asserting anything about it. Same class of mistake as the dependency-cruiser rule in #472, caught the same way: by checking that the test can fail.

Verified: build, typecheck, lint 0 errors, check:deps 0 errors, full `turbo run test --force` exit 0.