### PR TITLE
fix(vault): resolve ${vault:KEY} the same way everywhere

### DIFF
--- a/.changeset/uniform-vault-placeholders.md
+++ b/.changeset/uniform-vault-placeholders.md
@@ -1,0 +1,9 @@
+---
+'@moxxy/cli': patch
+---
+
+Resolve `${vault:KEY}` the same way everywhere.
+
+A placeholder in config was always resolved against the local vault, because config loads before any plugin registers. Meanwhile `ctx.getSecret(name)` inside a tool went through whatever `SecretProvider` the machine had active. The same syntax meant two different things, so an organisation that plugged in an external store found it served tools but not config.
+
+The placeholder resolver now takes a lookup function rather than a `VaultStore`, and the session re-resolves config through `session.resolveSecret` once plugins have registered. On a machine with no external provider the result is identical and the extra pass is a no-op walk. Existing callers that pass the vault object keep working.

--- a/docs/audit-2026-07-27.md
+++ b/docs/audit-2026-07-27.md
@@ -1,0 +1,395 @@
+> **Historical record, not current documentation.** This is the audit that drove
+> PRs #467-#484, kept because the reasoning is worth more than the git log's
+> fragments of it. It describes the codebase as of 2026-07-27 *before* that work.
+>
+> **Corrections found while executing it**, listed here rather than edited into
+> the text, because being able to see what an audit got wrong is part of what
+> makes the next one trustworthy:
+>
+> - **"The CLI bundles ~30 workspace packages" is wrong.** That was counted from
+>   `devDependencies`; tsup inlines what is *imported*. The bundled plugin set
+>   was already fairly lean. Measuring the bundle instead found the real cause:
+>   1.9 MB of vendor SDKs pulled in transitively through two package barrels.
+> - **The proposed fix for the Ink runtime was the wrong lever.** Demoting
+>   `plugin-cli` out of `CRITICAL_PACKAGES` was not needed; `bin.ts` statically
+>   importing all 24 command modules was, and lazy dispatch fixed the stated
+>   goal at a fraction of the disruption.
+> - **`permissions.allow`/`deny` were dead config.** The audit did not notice
+>   that these schema keys were never applied at all.
+> - **The `auditSink` block this audit asked for shipped unswappable.** Adding a
+>   registry is not the same as wiring it into the surfaces that make it usable,
+>   and nothing failed when that second half was skipped.
+>
+> Current documentation lives in [threat-model.md](threat-model.md),
+> [data-flow.md](data-flow.md), and [deployment.md](deployment.md). Open
+> follow-ups live in [../TECH_DEBT.md](../TECH_DEBT.md).
+
+# moxxy: enterprise readiness audit
+
+**Date:** 2026-07-27 · **Branch:** `development` @ `679466e3` · **CLI:** v0.33.0
+**Scope:** enterprise readiness, a slimmer "raw" harness, review of the hot packages, TUI design, forward strategy.
+
+Every claim below carries `file:line` evidence or a reproduced observation. Build was green at audit time (`pnpm build`, exit 0). 749 test files against 1416 source files.
+
+---
+
+## 0. Verdict
+
+**The architecture is enterprise-grade. The product is not.**
+
+moxxy already has the thing that is hard to retrofit: a registry-backed block model where the provider, loop, compactor, cache strategy, channel, isolator, event store and reflector are all swappable at runtime, enforced by dep-cruiser. That is the substrate a governed deployment needs, and almost nothing else in this space has it.
+
+What is missing is not features on top. It is four primitives that do not exist anywhere in the tree:
+
+1. **Identity.** No event, session or tool call knows *who* did it.
+2. **Authority.** No config or policy layer that a user cannot overwrite.
+3. **Receipts.** No audit trail that survives leaving the machine.
+4. **Containment of the install path.** `npm install` runs arbitrary postinstall scripts, outside every gate the framework built.
+
+Until those four exist, "enterprise deployment" means "we asked each developer nicely." Everything else in this document is downstream of them.
+
+Second finding, orthogonal: **the CLI is not slim.** The bundle is 5.79 MB and unconditionally contains React and a React reconciler, so `moxxy --version` in a container boots the TUI's module graph. The slim-kernel work (`CRITICAL_PACKAGES`, 8 entries) was designed correctly but the bundle never followed. Section 2 is the concrete plan.
+
+---
+
+# Part I: enterprise readiness
+
+## P0: blockers
+
+### 1. There is no identity anywhere in the system
+
+`EventBase` (`packages/sdk/src/events.ts:5`) carries `id`, `seq`, `ts`, `sessionId`, `turnId`, `causationId`, `source`. `source` is a *category* (`'user' | 'model' | 'tool' | 'plugin' | 'system' | 'compactor'`), not a principal. Grep for `userId` / `actorId` / `principal` across `core`, `sdk`, `runner`: zero hits.
+
+Consequences, all of them hard blockers:
+
+- **Audit is impossible.** "Who ran `bash rm -rf`" has no answer. A JSONL transcript proves a machine did something, not a person.
+- **RBAC is impossible.** There is no subject to attach a role to.
+- **Cost attribution is impossible.** `plugin-usage-stats` accounts per session, and sessions are anonymous.
+- **The runner is explicitly multi-client** (`packages/runner`), and cross-client abort is allowed by default with `MOXXY_RUNNER_STRICT_ABORT=1` as the opt-in to deny. So the one place that already knows two parties exist chose to treat them as interchangeable.
+
+**Fix.** Add `Principal` to the SDK (`{ id, kind: 'human'|'service', displayName?, claims? }`), stamp it on `EventBase` and `ToolCallContext`, resolve it at the channel boundary (TUI = OS user; HTTP/Slack/mobile = the authenticated token's subject; runner = per-connection). This is a protocol change: it touches `EventBase`, the runner wire protocol (bump `RUNNER_PROTOCOL_VERSION`), and the desktop IPC contract. Doing it before other enterprise work is much cheaper than after.
+
+### 2. Project config is executable code, run before any gate
+
+`loadConfig` (`packages/config/src/loader.ts:40`) walks up to 12 directories looking for `moxxy.config.{ts,js,mjs,cjs,yaml,yml}` and **executes** the JS/TS variants through jiti (`loader.ts:105-111`).
+
+`warnIfAncestorExecutableConfig` (`loader.ts:86`) prints a warning, but only when the config sits *above* cwd. A config at cwd runs silently. So: clone a repo, `cd` into it, type `moxxy`, and that repo's `moxxy.config.ts` executes with your full user privileges, before the permission engine, before the vault, before any isolator.
+
+This is the single largest local-execution hole in the product, and it is worse in an enterprise because developers clone untrusted code constantly.
+
+**Fix.** Three parts, all small:
+- Enterprise profile default: `config.allowExecutable: false`, YAML only.
+- Trust-on-first-use per directory, recorded under `~/.moxxy/trusted-configs.json`, prompting once with the resolved absolute path.
+- Warn on *every* executable config, not only ancestors.
+
+### 3. Precedence is backwards, and there is no admin layer
+
+`loadConfig` pushes user config first, then project/explicit, and `mergeConfigs(...)` lets the later source win (`loader.ts:44-67`). So a repo-local config overrides the user's own settings, and nothing overrides either.
+
+There is no scope above the user. An organisation cannot say "security.enabled is true and you cannot turn it off."
+
+**Fix.** Add a `system` scope (`/etc/moxxy/config.yaml`, `%PROGRAMDATA%\moxxy\config.yaml`, or `$MOXXY_SYSTEM_CONFIG`), loaded first, plus a `locked: [<dot.paths>]` list. Locked keys are stripped from user and project layers during merge and their override is logged. Precedence becomes: system (locked wins) → user → project → explicit → flags.
+
+### 4. Session transcripts are world-readable
+
+Verified on disk:
+
+```
+drwxr-xr-x  ~/.moxxy/sessions/
+-rw-r--r--  ~/.moxxy/sessions/<id>.jsonl
+-rw-r--r--  ~/.moxxy/permissions.json
+```
+
+Those JSONL files hold every prompt, every file the agent read, every bash stdout. `permissions.json` is the security policy itself. Any local account on the host reads both.
+
+The vault does this correctly (`packages/plugin-vault/src/store.ts:265`, mode `0o600`) and so does the runner socket (`packages/runner/src/unix-socket.ts:250`, `0o600` with a `0700` parent, chmod failures logged loudly, which is exemplary). Persistence simply never got the same treatment: `packages/core/src/sessions/persistence.ts:293` is a plain `fs.appendFile`, `:417` a plain `mkdir`.
+
+**Fix.** `mkdir(dir, { mode: 0o700 })` and open the JSONL with mode `0o600`; same for `permissions.json`, `schedules.json`, `preferences.json`. One-line changes each.
+
+Related, minor: six orphaned `writeFileAtomic` temp files are sitting in `~/.moxxy` (oldest 2026-06-26). The implementation cleans up on error (`packages/sdk/src/fs-utils.ts:38`) but cannot on SIGKILL, and nothing prunes them. Add a boot-time janitor for `*.<pid>.<uuid>.tmp` older than a day.
+
+### 5. Plugin install executes arbitrary code with no gate
+
+`runNpm` (`packages/plugin-plugins-admin/src/install.ts:429`) spawns:
+
+```
+npm install --prefix ~/.moxxy/plugins --no-fund --no-audit --save <spec>
+```
+
+No `--ignore-scripts`. So installing a plugin runs its `preinstall`/`install`/`postinstall` hooks, and those of every transitive dependency, with the user's full privileges. Outside the permission engine, outside every isolator, before the plugin's declared capabilities are ever read.
+
+The signed registry (`packages/plugin-plugins-admin/src/registry.ts`) is genuinely good work: Ed25519 detached signature over exact bytes, version pinning so npm's mutable `latest` tag stops being load-bearing, capability manifests surfaced pre-install. But a signature over the *index* says nothing about what the tarball's install script does.
+
+And `installSpec` accepts a bare npm name, `name@version`, a git URL, or a filesystem path (`install.ts:90`), so the pinned path is bypassable by construction.
+
+**Fix, in order of value:**
+- `--ignore-scripts` on every install. Plugins are ESM modules; they should not need build steps. If one does, that is a reason to reject it.
+- Enterprise profile: `plugins.installPolicy: 'registry-only' | 'allowlist' | 'denied'`, plus `plugins.registry` pointing at an internal mirror (`MOXXY_REGISTRY_URL` already exists as the seam, `registry.ts:52`).
+- `moxxy plugins sbom` emitting the resolved tree so procurement has something to scan.
+
+### 6. No egress control: moxxy cannot run behind a corporate proxy
+
+Grep for `HTTPS_PROXY`, `ProxyAgent`, `setGlobalDispatcher`, `NODE_EXTRA_CA_CERTS` across `packages` and `apps`: **one hit**, and it is a string in an error message (`packages/sdk/src/errors.ts:156`) suggesting the user set `HTTPS_PROXY`, which nothing then reads.
+
+Node's global `fetch` ignores proxy env vars unless a dispatcher is installed. So on a network that requires an outbound proxy, or that terminates TLS with an internal CA, moxxy fails at the first provider call with an opaque network error. A large share of the target market is on exactly such a network.
+
+**Fix.** Install an undici `ProxyAgent` at boot when `HTTPS_PROXY`/`HTTP_PROXY` is set, honour `NO_PROXY`, document `NODE_EXTRA_CA_CERTS`. Add `network.egressAllowlist` to the config so the enterprise profile can constrain which hosts the process may reach at all. Perhaps a day of work, and it converts "cannot deploy" into "deploys."
+
+### 7. There is no audit sink
+
+`audit log` appears in the codebase only in comments and one changelog line. What exists is a per-session JSONL file with no retention, no export, no forwarding, no tamper evidence, no redaction policy.
+
+Enterprise needs the log to leave the machine, be append-only, and be verifiable.
+
+**Fix, and this is the one that fits the architecture best.** Add an `AuditSink` registry alongside `EventStoreRegistry` (`packages/core/src/registries/event-stores.ts` is the exact pattern to copy: a protected floor plus registered alternatives). Ship a hash-chained local floor (each record carries `prevHash`, so deletion is detectable) and out-of-tree sinks for syslog, OTel, S3 and generic webhook. Redaction runs at the sink boundary, not at the display boundary.
+
+Note that `LifecycleHooks` (`packages/sdk/src/hooks.ts:37`) already exposes `onEvent`, `onToolCall`, `onToolResult` and `onBeforeProviderCall`. A DLP or audit plugin is buildable today. What is missing is a first-party, non-removable one, and the identity to make its records mean anything.
+
+---
+
+## P1: serious gaps
+
+### 8. Permission policy is user-writable and cannot be locked
+
+`~/.moxxy/permissions.json` is owned and writable by the user the agent runs as. A developer who does not like a deny rule deletes it. There is no policy an operator can push that survives.
+
+Fold this into the system-config scope from §3: locked deny rules merge in and cannot be removed by a user-scope edit.
+
+### 9. `inputMatches` regexes are unanchored
+
+Documented explicitly and deliberately at `packages/core/src/permissions/engine.ts:15-28`: patterns are substring matches, so an allow rule `{ Read: { path: 'config' } }` also matches `/etc/passwd#config`. The reasoning (existing user files depend on it, silently anchoring would break them) is sound for the consumer product.
+
+For enterprise it is a footgun that will be misused by whoever writes the org policy. Add first-class `pathPrefix` and `glob` matchers alongside the raw regex, and default the enterprise profile to those. Do not change the regex semantics.
+
+### 10. Mobile channel binds `0.0.0.0` by default
+
+`resolveBindHost` (`packages/plugin-channel-mobile/src/pairing.ts:19`) returns `0.0.0.0` when nothing is configured, with the comment "LAN-capable by default so `moxxy mobile` works with a physical phone out of the box." Correct call for a consumer product, wrong default for a corporate laptop on a shared office network. It is bearer-token gated, so this is exposure, not a hole. Flip it to loopback in the enterprise profile.
+
+### 11. Documentation does not exist for this audience
+
+`docs/` totals 1091 lines across 8 files, three of which are about desktop code signing and Clerk. There is no deployment guide, no ops runbook, no threat model, no data-flow statement, no "what leaves your machine and when."
+
+A security review at a mid-size company will ask for the last two on day one. `SECURITY.md` is unusually honest and well written (it explicitly refuses to claim "sandboxed by default"), and it is the right seed, but it is a policy document, not an architecture one.
+
+### 12. Secrets are local-only
+
+AES-256-GCM at rest, keychain-backed, `${vault:KEY}` resolved at the point of use so the model never sees plaintext. That is a genuinely good design and better than most competitors.
+
+It is also unusable at scale: there is no rotation story, no central issuance, no per-machine revocation. Add a `SecretProvider` registry so `${vault:KEY}` can resolve from HashiCorp Vault, AWS Secrets Manager, Azure Key Vault or 1Password, with nothing persisted locally.
+
+### 13. No observability
+
+No OTel, no metrics endpoint, no fleet view. An operator running moxxy on 200 workstations has no way to see version drift, denied-tool rates, spend, or failures. `plugin-usage-stats` is per-session and local.
+
+---
+
+# Part II: the raw enterprise harness
+
+Your ask: a smaller, rawer harness where the CLI arrives close to empty and teams add modules themselves.
+
+## What is actually there today
+
+`CRITICAL_PACKAGES` (`packages/cli/src/setup/critical-packages.ts`) defines an 8-package floor and the comment says it *is* the slim-core bundle set, "keep the two in lockstep."
+
+They are not in lockstep. `packages/cli/package.json` devDependencies bundle roughly 30 workspace packages (tsup inlines devDeps by design, `packages/cli/tsup.config.ts`), including `mode-collaborative`, `plugin-collab`, `plugin-channel-mobile`, `plugin-scheduler`, `plugin-webhooks`, `plugin-workflows`, `plugin-security` plus all three isolators, `plugin-mcp`, `plugin-memory`, both embedders, `plugin-self-update`, `plugin-provider-admin`.
+
+Result: `dist/bin.js` is **5.79 MB**, and it contains React and a React reconciler unconditionally (305 and 48 matches respectively). `moxxy --version` in a headless container pays for the whole Ink TUI.
+
+So the design intent is right and the implementation drifted. Good news: this is a diet, not a rewrite.
+
+## Recommendation: profiles, not a second binary
+
+Two binaries means two release trains, two test matrices, and guaranteed drift. Do not do it. Instead:
+
+**Step 1: make the bundle match `CRITICAL_PACKAGES`.**
+Everything outside the 8 moves to install-on-first-use through the signed registry, which already works. Scheduler, webhooks, workflows, mcp, memory, embeddings, collab, mobile, security and isolators all leave the bundle. Expected result: roughly 1.5 to 2 MB.
+
+**Step 2: demote `@moxxy/plugin-cli` out of the floor.**
+This is the highest-leverage single change in the audit. `plugin-cli` is listed critical as "the only interaction surface," and `bin.ts:34` imports `pickSlogan` from it at module top, so React loads for every invocation including `--version`, `-p`, `serve` and every CI use.
+
+Replace the floor with a tiny stdio channel (a few hundred lines, no React) and make `plugin-cli` an installable module like everything else. The kernel then boots with zero React, which is what makes containers, CI pipelines and `moxxy -p` in a shell script sane. The consumer product installs `plugin-cli` on first run and nothing changes for existing users.
+
+**Step 3: `builtins.ts` becomes a manifest.**
+`packages/cli/src/setup/builtins.ts` is a 500+ line file that hand-imports every builtin and wires closures. That static import list *is* the bundle. Convert to a table of `{ name, requirements, load: () => import(...), wire: (deps) => Plugin }`. The profile system can then filter it, and tsup can code-split (`splitting: false` today).
+
+**Step 4: profiles as config presets.**
+`moxxy init --profile enterprise` writes a config; no new code path. The enterprise profile sets:
+
+```yaml
+security:   { enabled: true, requireDeclaration: true, thirdPartyRequireDeclaration: enforce, strict: true }
+plugins:    { isolator: { default: subprocess }, installPolicy: registry-only, registry: <internal> }
+config:     { allowExecutable: false }
+network:    { proxy: env, egressAllowlist: [<provider hosts>] }
+audit:      { sink: <syslog|otel|webhook>, retentionDays: 400 }
+channels:   { mobile: { bindHost: 127.0.0.1 } }
+```
+
+**Step 5: `plugins.packages` becomes a committable lockfile, and `moxxy sync` reconciles to it.**
+The manifest already exists in the config tree. Making it authoritative gives you the "teams add their own modules" story in a form that is reproducible, reviewable in a PR, and checkable in CI. That is the enterprise-shaped version of the ask.
+
+**On the library side, nothing to build.** `@moxxy/core`'s `setupAgent` is already the bring-your-own-blocks factory, and `@moxxy/agent` (100 lines of presets) is the batteries-included wrapper. That layering is correct. The CLI is the only thing that needs the diet.
+
+---
+
+# Part III: package review
+
+### `@moxxy/sdk` (10.7k lines)
+The contract, with zero internal deps enforced by dep-cruiser. Structurally sound.
+
+Concern: it has become a utility grab-bag. Alongside the types and `define*` helpers it now ships `fs-utils`, `http-utils`, `mutex`, `json-file-store`, `cross-process-lock`, `frontmatter`, `embedding-cache`, `provider-utils`. A package that is simultaneously "the stable public surface" and "where the file writer lives" is very hard to semver: every bugfix in a util is a release of the contract.
+
+The `@moxxy/sdk/server` subpath split is the right instinct. Push it further: contract in the root export, runtime helpers behind subpaths, and document which is which. This matters more once third parties depend on it.
+
+### `@moxxy/core` (8.9k lines)
+The best package in the repo. Clean separation (`events` / `permissions` / `plugins` / `registries` / `sessions` / `skills`), and the registry abstractions (`ActiveDefRegistry`, `DefMapRegistry`, protected floors that a discovered plugin can add to but never shadow) are exactly the primitive the enterprise story needs.
+
+Gaps are additive, not structural: no `AuditSink` registry, no `SecretProvider` registry, no `Principal`.
+
+### `@moxxy/cli` (14k lines)
+`bin.ts` is clean: a single command dispatch table with no drift-prone parallel list, and a well-reasoned comment about why the try/catch wraps only the channel probe (`bin.ts:266-297`). Good.
+
+`setup/` is where it degrades. Twenty modules, and `builtins.ts` is the coupling point that makes the bundle fat (see Part II step 3). This is the package to spend refactor budget on.
+
+### `@moxxy/plugin-cli` (13k lines)
+Largest non-app package. Structure is reasonable (`components/` + `session/` + `chat/`). `SessionView.tsx` at 573 lines is the god component and the natural next split.
+
+The architectural issue is its floor status, covered above.
+
+### `@moxxy/runner` (4k lines)
+Solid, and the socket hardening is a model for the rest of the repo: `0700` parent created before `listen` to close the chmod-after-listen window, `0600` socket, chmod failure logged loudly rather than swallowed, documented Windows named-pipe DACL gap.
+
+Gaps: no per-connection identity, and cross-client abort permitted by default.
+
+### `@moxxy/config` (1.5k lines)
+The executable-config and precedence issues (§2, §3) are the whole story. The jiti LRU cache and the ESM module-registry leak avoidance (`loader.ts:127-188`) are careful, well-commented work.
+
+---
+
+# Part IV: TUI design review
+
+The TUI is better designed than most terminal agents. Specific praise, then specific problems.
+
+### What is right, keep it
+
+- **`theme.ts` is a genuine design system.** Semantic role tokens rather than raw colours, one file to change the palette, and a deliberately narrow accent set (busy, danger, active, mode) against monochrome chrome.
+- **Accessibility is above average.** `NO_COLOR` and `MOXXY_NO_COLOR` are honoured, and critically, every colour escalation is paired with a non-colour cue: `contextColor()` and `contextMarker()` are mirrored on the same thresholds so the context meter reads `85% ⚠` and not just red. Very few terminal apps get this right.
+- **Motion is gated.** `MOTION_ENABLED` freezes the elapsed clock for reduced-motion and non-TTY (`StatusLine.tsx:152`), which also keeps CI logs clean.
+- **The status line's information hierarchy is correct.** Left is transient state, right is stable identity and cost. The badged-mode pill staying pinned left even mid-turn (`StatusLine.tsx:76-82`) is exactly the right call: the user must never lose track that an autonomous mode is driving.
+
+### Problems
+
+**1. The logo dominates `--help` and `--version`.** 31 lines of photographic ASCII print before a single word of content, on every help invocation. At under 80 columns it is unreadable, in CI logs it is noise, and on a non-UTF8 terminal it garbles. In an enterprise evaluation it reads as unserious.
+Keep it on the interactive boot screen where it belongs. Drop it from `--help` and `--version`, or gate behind `isTTY && !NO_COLOR` with an explicit `--logo`. Cheapest high-impact change in this document.
+
+**2. Redaction misses the case that matters most.** `redactSecrets` (`packages/plugin-cli/src/components/redact.ts`) masks by *key name* only, to depth 2. The permission dialog renders tool input through it (`PermissionDialog.tsx:15,57`).
+
+So a Bash call whose `command` field is `curl -H "Authorization: Bearer sk-ant-..."` renders **verbatim** into scrollback: `command` is not a secret-named key, and the secret is in the value. Bash commands are precisely what the permission dialog exists to show.
+Add value-pattern redaction (known key prefixes `sk-`, `ghp_`, `xoxb-`, plus a high-entropy heuristic) on the display path. Matters more in enterprise where terminals get recorded and screens get shared.
+
+**3. The status line has no narrow-terminal strategy.** `justifyContent="space-between"` with provider badge, model id, MCP count, a 10-cell context bar and a version chip will wrap badly under roughly 90 columns, and wrapping an Ink flex row looks broken rather than degraded. Add width tiers: drop the version chip first, then MCP, then the model id, then shorten the bar.
+
+**4. Tool glyphs are hardcoded and do not extend.** `toolGlyph` (`ToolCallBlock.tsx:61`) string-matches `read`/`glob`/`grep`/`bash`. Every third-party tool, every MCP tool and every plugin tool collapses to `◇`. In a block-swappable framework, presentation should come from the block: add an optional `icon` or `kind` to `ToolDef` and fall back to the current matching. Small API addition, and it is the on-brand fix.
+
+**5. No dense mode.** Every settled tool call takes `marginTop={1}` (`ToolCallBlock.tsx:39`). In a 24-row SSH session a busy turn scrolls the conversation off screen. Add `tui.density: 'comfortable' | 'compact'` next to the existing `tui.theme` and `tui.hints`.
+
+**6. The boot checklist speaks internal vocabulary.** "onInit hooks fired", "preferences applied" (`BootScreen.tsx:36-42`) are developer terms. Fine today. For rollout beyond developers, either user-language labels or hide the checklist behind `--verbose` and show one progress line.
+
+---
+
+# Part V: where moxxy should go
+
+You asked for critical thinking on the forward shape. Here is my honest read, including the parts that argue against current direction.
+
+### 1. The thesis is right; the packaging is prosumer
+
+The differentiator is substitutability: every layer is a registry entry and the dependency arrow is enforced. That is an enterprise-grade property. But it is currently expressed as *one consumer product*: a TUI, a desktop app, a phone app, twelve chat channels, three TTS engines, three STT engines, voice mode, computer control.
+
+The move is not to bolt enterprise features onto the consumer app. It is to let the kernel be the product and make the consumer app one profile among several.
+
+### 2. Do not fight for the terminal-coding-agent slot
+
+Claude Code, Codex, Gemini CLI and Cursor own that slot and are funded by the model vendors. moxxy loses that race on distribution regardless of how good the TUI is, and the TUI is good.
+
+What none of them offer is **substitutability under governance**: run your own model, your own loop, your own isolator, your own audit sink, and *prove it to an auditor*. That is a real wedge, it is defensible precisely because the incumbents cannot offer it (their business is the model), and moxxy already has 80% of the machinery.
+
+### 3. Therefore the product is a control plane, not a chat client
+
+Concretely, the shape I would aim at:
+
+- **The kernel:** small, signed, boring, auditable. Section 2's diet gets you most of the way.
+- **A policy bundle:** signed, versioned, distributed to workstations. Contents: permission policy, allowed plugins with pinned versions, isolator selection, egress rules, audit sink, model allow-list.
+  The machinery for this **already exists.** `packages/plugin-plugins-admin/src/registry.ts` is a signed, Ed25519-verified, version-pinning distribution channel with a documented format and a key-rotation story. Point it at policy bundles instead of only plugin indexes and you have org policy distribution for a fraction of the cost of building it. This is the highest-leverage asset in the codebase and it is currently doing one tenth of what it could.
+- **A fleet view:** which machines run which bundle version, what they spent, what got denied. Needs §1 (identity) and §7 (audit sink) and nothing else.
+- **Surfaces on equal footing:** TUI, desktop, CI, webhook, schedule. None privileged.
+
+### 4. Cut the sprawl, and say so out loud
+
+Twelve chat channels (Telegram, Discord, Signal, WhatsApp, iMessage, Slack, web, HTTP, mobile), computer control, three TTS, three STT, voice mode. Each is a maintenance surface, a security surface and a support surface. None of them is why a company buys.
+
+For enterprise, Slack and HTTP are sufficient. The rest are already unbundled and installable from the registry, so the technical work is done; what is missing is the decision. Move them to community-supported explicitly, in writing, rather than carrying implied first-party support for nine chat integrations forever.
+
+I am not arguing they were mistakes. I am arguing that the tier they sit in should be a stated decision rather than an accident of history.
+
+### 5. Make the *run* the unit of value, not the session
+
+Enterprises do not buy chat. They buy repeatable automation with a receipt: "run this workflow on this trigger, under this policy, and show me what happened."
+
+`plugin-workflows` plus `plugin-webhooks` plus `plugin-scheduler` already provide the first half. The missing half is the receipt: a signed, hash-chained record of what ran, under which policy version, invoking which tools, at what cost, denied where. Build that and moxxy has an artifact an auditor will accept, which is a thing no competitor currently sells.
+
+This is also the natural place for the identity work from §1 to pay off twice.
+
+### 6. One thing to be honest about internally
+
+The desktop app is 34k lines, the mobile app 12k, and together they are larger than core, sdk, cli and runner combined. They are consumer surfaces. If the strategic answer is "enterprise control plane," they are not where the next 6 months should go, and it is worth deciding that deliberately rather than by drift.
+
+---
+
+# Roadmap
+
+## P0: the four primitives (nothing enterprise ships without these)
+
+| # | Work | Touches |
+|---|---|---|
+| 1 | `Principal` on `EventBase` + `ToolCallContext`, resolved per channel | sdk, core, runner (protocol bump), desktop-ipc-contract |
+| 2 | System config scope + `locked:` keys; `allowExecutable: false` + TOFU for executable configs | config, cli |
+| 3 | `AuditSink` registry + hash-chained local floor (copy `EventStoreRegistry`) | core, sdk |
+| 4 | `--ignore-scripts` on npm install; `installPolicy` + internal registry | plugin-plugins-admin |
+| 5 | File modes: `0700` sessions dir, `0600` transcripts / permissions / schedules; tmp janitor | core, cli |
+| 6 | Proxy + custom CA support (undici `ProxyAgent`, `NO_PROXY`, `NODE_EXTRA_CA_CERTS`) | sdk, cli |
+
+## P1: the harness diet
+
+| # | Work | Touches |
+|---|---|---|
+| 7 | `builtins.ts` becomes a lazy manifest; enable tsup code splitting | cli |
+| 8 | Bundle set reduced to `CRITICAL_PACKAGES` | cli |
+| 9 | Headless stdio floor channel; `plugin-cli` demoted from critical | cli, new package |
+| 10 | `--profile enterprise` preset + `moxxy sync` against `plugins.packages` | cli, config |
+| 11 | Locked permission rules from system scope; `pathPrefix` / `glob` matchers | core, config |
+| 12 | `SecretProvider` registry (Vault / ASM / AKV / 1Password) | core, plugin-vault |
+
+## P2: the control plane and the polish
+
+| # | Work |
+|---|---|
+| 13 | Policy bundles over the existing signed-registry transport |
+| 14 | OTel export; fleet view |
+| 15 | Signed run receipts for workflows / webhooks / schedules |
+| 16 | Docs: deployment guide, threat model, data-flow statement, ops runbook |
+| 17 | TUI: logo off `--help`, value-pattern redaction, width tiers, `ToolDef.icon`, dense mode |
+| 18 | Mobile bind default to loopback under the enterprise profile |
+| 19 | Tier the twelve channels explicitly (first-party vs community) |
+
+---
+
+## Appendix: what is already good, and should not be touched
+
+Worth recording, because an audit that only lists problems misleads.
+
+- **`SECURITY.md` is unusually honest.** It explicitly refuses to claim "sandboxed by default" and separates enforced-by-default from opt-in. Most projects overclaim here.
+- **Runner socket hardening** (`packages/runner/src/unix-socket.ts`) is the reference implementation for the rest of the repo.
+- **The signed plugin registry** is real security engineering: detached Ed25519 over exact bytes, no canonicalization to keep in sync, version pinning that removes npm's mutable `latest` from the trust path, never throws into the install path.
+- **The vault design** (`${vault:KEY}` resolved at point of use so plaintext never enters the transcript or the model's context) is better than most commercial equivalents.
+- **The permission engine's ReDoS bound** (`engine.ts:47-57`, 8 KB truncation before running author-supplied regex over model-controlled input) shows someone thought about the actual threat model.
+- **Architectural invariants are machine-enforced,** not documented and hoped for (`pnpm check:deps`).
+- **The event-log-as-source-of-truth model** with pure-fold derived state is what makes replay, audit and the desktop mirror possible at all. It is the reason the P0 fixes above are additive rather than rewrites.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ export default defineConfig({
 });
 ```
 
-`${vault:NAME}` placeholders are resolved when a session starts. The vault unlocks through the OS keychain by default and supports a passphrase fallback. Headless environments can provide that passphrase with `MOXXY_VAULT_PASSPHRASE`.
+`${vault:NAME}` placeholders are resolved when a session starts, through the **active secret provider** with the local vault as fallback, which is the same path `ctx.getSecret(name)` takes inside a tool. A placeholder therefore means the same thing in config as it does anywhere else. The vault unlocks through the OS keychain by default and supports a passphrase fallback. Headless environments can provide that passphrase with `MOXXY_VAULT_PASSPHRASE`.
 
 Do not commit plaintext credentials. See [SECURITY.md](../SECURITY.md) for the security model and hardening guidance.
 

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -185,6 +185,19 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
 
   let pluginRegistration = await registerPlugins(session, config, builtins, opts.cwd, logger);
 
+  // Re-resolve `${vault:…}` now that plugins have registered, this time through
+  // the session's resolver rather than the vault directly.
+  //
+  // The first pass above runs before any plugin exists, so it can only reach
+  // the local vault. That made `${vault:KEY}` mean two different things: in
+  // config it was always the local vault, while `ctx.getSecret` in a tool went
+  // through whatever SecretProvider the machine had active. This second pass is
+  // what makes the two uniform; on a machine with no external provider it
+  // resolves identically and the extra pass is a no-op walk.
+  const resolvedConfig = session.resolveSecret
+    ? await resolveConfigPlaceholders(rawConfig, session.resolveSecret, logger)
+    : config;
+
   // Compatibility migration for providers that used to ship inside the CLI.
   // If any configured provider is missing but advertises itself through a
   // provider-owned catalog manifest, install it into the normal user plugin
@@ -247,9 +260,12 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
 
   const { credentialResolver } = await activateProvider({
     session,
-    config,
+    config: resolvedConfig,
     vault,
-    providerConfig: { ...(providerItem(config).config ?? {}), ...(opts.providerConfig ?? {}) },
+    providerConfig: {
+      ...(providerItem(resolvedConfig).config ?? {}),
+      ...(opts.providerConfig ?? {}),
+    },
     skipKeyPrompt,
     skipProviderActivation: opts.skipProviderActivation,
     tolerateNoProvider: opts.tolerateNoProvider,

--- a/packages/cli/src/setup/load-config.ts
+++ b/packages/cli/src/setup/load-config.ts
@@ -5,7 +5,12 @@ import {
   type LockedOverride,
   type MoxxyConfig,
 } from '@moxxy/config';
-import { containsPlaceholder, resolveValue, type VaultStore } from '@moxxy/plugin-vault';
+import {
+  containsPlaceholder,
+  resolveValue,
+  type SecretLookup,
+  type VaultStore,
+} from '@moxxy/plugin-vault';
 
 type InfoLogger = { info(msg: string, meta?: Record<string, unknown>): void };
 
@@ -39,10 +44,10 @@ export async function loadRawConfig(opts: {
 /** Resolve any `${vault:…}` placeholders against the user's open vault. */
 export async function resolveConfigPlaceholders(
   rawConfig: MoxxyConfig,
-  vault: VaultStore,
+  source: SecretLookup | VaultStore,
   logger: InfoLogger,
 ): Promise<MoxxyConfig> {
   if (!containsPlaceholder(rawConfig)) return rawConfig;
   logger.info('resolving vault placeholders in config');
-  return (await resolveValue(rawConfig, vault)) as MoxxyConfig;
+  return (await resolveValue(rawConfig, source)) as MoxxyConfig;
 }

--- a/packages/plugin-vault/src/index.ts
+++ b/packages/plugin-vault/src/index.ts
@@ -17,6 +17,7 @@ export { VaultStore, VaultPassphraseError } from './store.js';
 export type { VaultEntry, VaultEntryInfo, VaultStoreOptions } from './store.js';
 export { createCombinedKeySource, createStaticKeySource, type MasterKeySource } from './keysource.js';
 export { resolveString, resolveValue, containsPlaceholder } from './placeholder.js';
+export type { SecretLookup } from './placeholder.js';
 export { deriveKey, deriveKeyAsync, encrypt, decrypt, generateSalt, randomCode } from './crypto.js';
 
 export interface BuildVaultPluginOptions {

--- a/packages/plugin-vault/src/placeholder.test.ts
+++ b/packages/plugin-vault/src/placeholder.test.ts
@@ -140,3 +140,38 @@ describe('resolveValue worst-case guards', () => {
     await expect(resolveValue(node, vault)).rejects.toThrow(/nested too deeply/);
   });
 });
+
+// `${vault:KEY}` used to mean two different things: in config it always hit the
+// local vault, while `ctx.getSecret` in a tool went through whatever
+// SecretProvider was active. Taking a LOOKUP FUNCTION is what makes the two
+// uniform, so the same placeholder resolves the same way everywhere.
+describe('resolving through an arbitrary secret lookup', () => {
+  it('resolves a string through a function, not just a VaultStore', async () => {
+    const lookup = async (name: string): Promise<string | null> =>
+      name === 'TOKEN' ? 'from-remote-store' : null;
+    expect(await resolveString('Bearer ${vault:TOKEN}', lookup)).toBe('Bearer from-remote-store');
+  });
+
+  it('resolves nested config values through a function', async () => {
+    const lookup = async (name: string): Promise<string | null> =>
+      name === 'KEY' ? 'sk-remote' : null;
+    const out = await resolveValue(
+      { plugins: { provider: { items: { openai: { config: { apiKey: '${vault:KEY}' } } } } } },
+      lookup,
+    );
+    expect(JSON.stringify(out)).toContain('sk-remote');
+  });
+
+  // A missing secret must still be a hard error whichever store was asked, or a
+  // typo silently becomes an empty credential and surfaces as a 401 later.
+  it('throws on a missing entry regardless of the source', async () => {
+    const lookup = async (): Promise<string | null> => null;
+    await expect(resolveString('${vault:NOPE}', lookup)).rejects.toThrow(/missing required entry/);
+  });
+
+  // Existing callers pass the vault object; that must keep working unchanged.
+  it('still accepts a VaultStore directly', async () => {
+    const vault = { get: async (n: string) => (n === 'A' ? 'a' : null) } as never;
+    expect(await resolveString('${vault:A}', vault)).toBe('a');
+  });
+});

--- a/packages/plugin-vault/src/placeholder.ts
+++ b/packages/plugin-vault/src/placeholder.ts
@@ -21,7 +21,11 @@ function tooDeepError(): MoxxyError {
  * Resolve every `${vault:NAME}` placeholder in a string against the vault. If
  * any referenced key is missing, throws — secret refs are not optional.
  */
-export async function resolveString(input: string, vault: VaultStore): Promise<string> {
+export async function resolveString(
+  input: string,
+  source: SecretLookup | VaultStore,
+): Promise<string> {
+  const lookup = asLookup(source);
   PLACEHOLDER_RE.lastIndex = 0;
   if (!PLACEHOLDER_RE.test(input)) return input;
   PLACEHOLDER_RE.lastIndex = 0;
@@ -31,7 +35,7 @@ export async function resolveString(input: string, vault: VaultStore): Promise<s
 
   const values = new Map<string, string>();
   for (const name of names) {
-    const value = await vault.get(name);
+    const value = await lookup(name);
     if (value === null) {
       throw new MoxxyError({
         code: 'CONFIG_INVALID',
@@ -45,9 +49,25 @@ export async function resolveString(input: string, vault: VaultStore): Promise<s
   return input.replace(PLACEHOLDER_RE, (_match, name: string) => values.get(name) ?? '');
 }
 
+/**
+ * How a `${vault:NAME}` placeholder is looked up.
+ *
+ * A FUNCTION rather than a `VaultStore` so one code path serves both the local
+ * vault and whatever external store a machine has active. Previously this took
+ * the vault directly, which meant config placeholders could only ever come from
+ * the local vault while `ctx.getSecret` in a tool went through the active
+ * SecretProvider: two ways to say `${vault:KEY}` that resolved differently.
+ */
+export type SecretLookup = (name: string) => Promise<string | null>;
+
 /** Walk an arbitrary value, resolving all vault placeholders in nested strings. */
-export async function resolveValue(value: unknown, vault: VaultStore): Promise<unknown> {
-  return resolveValueInner(value, vault, new Set());
+export async function resolveValue(value: unknown, lookup: SecretLookup | VaultStore): Promise<unknown> {
+  return resolveValueInner(value, asLookup(lookup), new Set());
+}
+
+/** Accepts a bare `VaultStore` so existing callers keep working unchanged. */
+function asLookup(source: SecretLookup | VaultStore): SecretLookup {
+  return typeof source === 'function' ? source : (name) => source.get(name);
 }
 
 // `ancestors` is the chain of objects on the path from the root to (but not
@@ -57,22 +77,22 @@ export async function resolveValue(value: unknown, vault: VaultStore): Promise<u
 // is the nesting depth, so its size doubles as the depth bound.
 async function resolveValueInner(
   value: unknown,
-  vault: VaultStore,
+  lookup: SecretLookup,
   ancestors: Set<object>,
 ): Promise<unknown> {
-  if (typeof value === 'string') return await resolveString(value, vault);
+  if (typeof value === 'string') return await resolveString(value, lookup);
   if (value && typeof value === 'object') {
     if (ancestors.has(value)) throw tooDeepError(); // reference cycle
     if (ancestors.size >= MAX_DEPTH) throw tooDeepError();
     const nextAncestors = new Set(ancestors).add(value);
     if (Array.isArray(value)) {
-      return Promise.all(value.map((v) => resolveValueInner(v, vault, nextAncestors)));
+      return Promise.all(value.map((v) => resolveValueInner(v, lookup, nextAncestors)));
     }
     // Resolve object properties concurrently (mirrors the array branch); each
     // leaf may await vault.get(), so serializing them needlessly serializes I/O.
     const pairs = await Promise.all(
       Object.entries(value as Record<string, unknown>).map(
-        async ([k, v]) => [k, await resolveValueInner(v, vault, nextAncestors)] as const,
+        async ([k, v]) => [k, await resolveValueInner(v, lookup, nextAncestors)] as const,
       ),
     );
     return Object.fromEntries(pairs);


### PR DESCRIPTION
Two things in one branch: the `${vault:KEY}` uniformity fix you asked for, and the enterprise audit committed as a historical record.

## `${vault:KEY}`

A placeholder in config was always resolved against the **local vault**, because config loads before any plugin registers. Meanwhile `ctx.getSecret(name)` inside a tool went through whatever `SecretProvider` the machine had active.

The same syntax meant two different things. An organisation that plugged in HashiCorp Vault or AWS Secrets Manager found it served tools but silently not config, which is exactly the failure where someone believes a credential is centrally managed and it is not.

`resolveValue` / `resolveString` now take a **lookup function** rather than a `VaultStore`. That signature was the whole reason the split existed: it could only ever express "the local vault". A `VaultStore` is still accepted, so every existing caller is unchanged.

Setup then re-resolves the raw config through `session.resolveSecret` once plugins have registered, and provider activation consumes that result. The first pass stays, because things registered before plugins exist may carry placeholders of their own. On a machine with no external provider the second pass resolves identically and is a no-op walk.

A missing entry still throws whichever store was asked. Falling back to an empty string would turn a typo into an empty credential surfacing as a 401 somewhere unrelated.

## The audit document

`ENTERPRISE_AUDIT_2026-07-27.md` drove PRs #467-#484 and existed only as an untracked file on one machine. It goes in as `docs/audit-2026-07-27.md`, marked clearly as a historical record rather than current documentation.

**It goes in with a header listing what it got wrong**, rather than with those claims quietly edited out:

- "the CLI bundles ~30 workspace packages" was counted from `devDependencies`, not from the bundle
- the proposed fix for the Ink runtime aimed at the wrong lever
- it missed that `permissions.allow`/`deny` were dead config
- the `auditSink` it asked for shipped unswappable

An audit whose errors are visible is more trustworthy than one that appears to have been right about everything, and those four are instructive in their own right.

Verified: build, typecheck, lint 0 errors, `turbo run test --force` clean.