### PR TITLE
feat: run receipts and signed policy bundles

### DIFF
--- a/.changeset/policy-bundles.md
+++ b/.changeset/policy-bundles.md
@@ -1,0 +1,16 @@
+---
+'@moxxy/cli': minor
+'@moxxy/config': minor
+'@moxxy/sdk': minor
+'@moxxy/plugin-plugins-admin': patch
+---
+
+Add signed policy bundles and `moxxy policy`.
+
+Permission rules could already be pushed from the system config, which works on one machine. Across a fleet every rule change became a file change on every host, and a host that missed one looked exactly like a host that got it. A bundle is a signed document published once and subscribed to by `policy.bundles`, carrying a revision that lands in the audit trail, so `moxxy receipt` proves which revision any past run executed under.
+
+A bundle carries permission rules and nothing else. Not `registryUrl`, not a key, not a proxy, not `security.enabled`, and one carrying any of them is rejected rather than quietly stripped. It arrives over the network, so the worst case for whoever controls that host stays "they can deny things and break the fleet" instead of "they can loosen us".
+
+Loading fails closed: a configured bundle that cannot be verified stops the session rather than running without the rules the machine is supposed to enforce. The last verified copy is cached and carries a session through an outage, re-verified against the pinned key on every read. A bad signature is never treated as unavailable, or anyone answering for the URL could pin a fleet to an old revision by serving garbage.
+
+`moxxy policy` shows the rules in force with each rule's origin; `--check` exits 1 when a host is serving off a stale cache. The Ed25519 verifier moved to `@moxxy/sdk` as `verifyEd25519`, since policy has to bind on a machine with no plugins installed and a control you can disable by uninstalling something is not a control.

--- a/.changeset/run-receipts.md
+++ b/.changeset/run-receipts.md
@@ -1,0 +1,13 @@
+---
+'@moxxy/cli': minor
+'@moxxy/core': minor
+'@moxxy/sdk': minor
+---
+
+Add `moxxy receipt <turnId>`: a verified account of one run assembled from the audit trail.
+
+The trail already recorded what happened, but answering "who ran this, what set it off, which rules were in force, and what did it cost" meant reading raw JSONL. A receipt is a projection over those records, so asking for one writes nothing.
+
+Two records were missing for this to be answerable, and both are now emitted when `audit.enabled` is set: a `policy` record at session start carrying a fingerprint over the settings that decide what the agent may do (counts and effective values only, no secrets or paths), and a `usage` record per provider response carrying token counts. The request and the reply stay in the event log where they belong.
+
+The enclosing chain is verified before a receipt prints. A broken chain marks the receipt and exits 1, so a receipt from a trail with a deleted record cannot look complete.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,5 +45,6 @@ We deliberately do not claim "sandboxed by default." If your threat model includ
 2. Keep autonomous channels on dedicated runners; keep their allow-lists minimal (never `['*']`).
 3. Don't put secrets in config or env when the vault can hold them — use `${vault:KEY}`.
 4. Rotate channel tokens periodically (`rotateChannelToken`; stale tokens warn after 90 days).
-5. Review `~/.moxxy/permissions.json` occasionally — prune allow rules you no longer need.
-6. Keep moxxy current (`moxxy update`); only the latest release line receives fixes.
+5. Enable `audit.enabled` where runs must be accountable after the fact; `moxxy receipt <turnId>` then explains any single run, and both it and `moxxy security audit-log` exit 1 on a broken chain.
+6. Review `~/.moxxy/permissions.json` occasionally — prune allow rules you no longer need.
+7. Keep moxxy current (`moxxy update`); only the latest release line receives fixes.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -182,6 +182,67 @@ permissions:
 
 Prefer `inputPathPrefix` and `inputGlob` over `inputMatches`: the latter is an unanchored regex, so `{ path: '/etc' }` means "contains /etc anywhere", which over-blocks as a deny and over-grants as an allow.
 
+## 7. Distribute policy as a signed bundle
+
+Section 6 pushes rules through `/etc/moxxy/config.yaml`, which is fine for one machine. Across a fleet every rule change becomes a file change on every host, and a host that missed one is indistinguishable from a host that got it.
+
+A policy bundle is a signed document you publish once and every machine subscribes to:
+
+```json
+{
+  "version": 1,
+  "id": "corp-baseline",
+  "revision": "2026-07-27.1",
+  "permissions": {
+    "deny": [{ "name": "Bash", "reason": "corp policy: no shell" }]
+  }
+}
+```
+
+Sign it with Ed25519, serve it and its detached `.sig` beside it, and pin the public key in config you control:
+
+```yaml
+policy:
+  bundles:
+    - id: corp-baseline
+      url: https://policy.example.internal/moxxy/corp-baseline.json
+      publicKey: |
+        -----BEGIN PUBLIC KEY-----
+        ...
+        -----END PUBLIC KEY-----
+```
+
+Pin the key in config, never take it from the bundle or its host: a key served next to the thing it authenticates proves nothing.
+
+### What a bundle may contain, and why so little
+
+Permission rules. Nothing else. Not `registryUrl`, not a key, not a proxy, not `security.enabled`, and a bundle carrying any of them is rejected rather than quietly stripped.
+
+The reason is the failure mode. A bundle arrives over the network, so the question that matters is what someone who takes over that host can do. Confined to permission rules, the answer is "deny things and break the fleet": loud, reversible, and safe. Let a bundle set `registryUrl` or a trust key and the answer becomes "redirect what every machine trusts", silently. Denial of service is a far better worst case than privilege escalation.
+
+### How it combines with your local rules
+
+Both land above `~/.moxxy/permissions.json`, and every deny is checked before any allow, so:
+
+| Situation | Winner |
+|---|---|
+| Local deny vs bundle allow | Local deny. You outrank a remote publisher. |
+| Bundle deny vs local allow | Bundle deny. Subscribing actually restricts. |
+| Either deny vs an "allow always" answer | The deny. Neither is removable at runtime. |
+
+### It fails closed
+
+A configured bundle that cannot be verified **stops the session**. That is the point: a host running without the rules it subscribes to, with nothing to show for it, is the condition the feature exists to prevent.
+
+The last verified copy is cached at `~/.moxxy/policy/` and carries a session through an outage, re-verified against your pinned key on every read so editing the cache buys nothing. A bad signature is never treated as "unavailable", or anyone who can answer for the URL could pin a fleet to an old revision forever by serving garbage.
+
+```sh
+moxxy policy            # rules in force, each with its origin
+moxxy policy --check    # exit 1 if this host is serving off a stale cache
+```
+
+The bundle revision goes into the policy fingerprint, so `moxxy receipt` proves which revision any past run executed under.
+
 ## Rollout checklist
 
 - [ ] `/etc/moxxy/config.yaml` placed, proxy and CA filled in
@@ -192,6 +253,8 @@ Prefer `inputPathPrefix` and `inputGlob` over `inputMatches`: the latter is an u
 - [ ] `installPolicy` set, and an internal mirror pinned if you have one
 - [ ] Audit sink configured, retention set, chain verification scheduled
 - [ ] Autonomous channels on dedicated runners with minimal allow-lists
+- [ ] Policy bundle published and pinned, or local rules accepted deliberately
+- [ ] `moxxy policy` verified on a pilot host, and `--check` green in CI
 - [ ] [threat-model.md](threat-model.md) and [data-flow.md](data-flow.md) reviewed by whoever signs off
 
 ## Upgrades

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -137,6 +137,33 @@ Exit code 1 on a broken chain, so a scheduled check can gate on it.
 
 This is tamper-**evident**, not tamper-proof: whoever can write the file can recompute the chain. It catches silent selective deletion, which is the realistic threat. For a chain head the workstation cannot rewrite, point `audit.sink` at a remote sink.
 
+### Accounting for a single run
+
+The trail answers "what happened on this machine". When someone asks about one specific run, usually because it did something surprising, use a receipt:
+
+```sh
+moxxy receipt <turnId>            # one run
+moxxy receipt --session <id>      # every run in a session
+moxxy receipt <turnId> --json     # to attach to a ticket
+```
+
+```
+  turn     t1
+  actor    os:alice@host
+  trigger  webhook:deploy
+  policy   6c59b147041aab80
+  tools    Read, Edit
+  denied   Bash: managed policy
+  tokens   1200 in / 340 out
+  chain verified
+```
+
+A receipt is a projection over the trail, not a second record, so asking for one writes nothing and cannot change what it reports. It answers the four questions asked after the fact: who acted, what set it off, which rules were in force, and what it cost.
+
+The `policy` line is the fingerprint recorded at session start over the settings that decide what the agent may do. Identical fingerprints on two runs prove they executed under the same rules; a differing one tells you the rules moved between them. It covers no secrets and no paths, only counts and effective values, so it is safe to paste into a ticket.
+
+The chain is verified before anything prints, and a broken one exits 1 with the receipt marked. That matters more than it sounds: a receipt assembled from a trail with a record deleted would otherwise look complete while quietly omitting the removed call.
+
 Records are bounded and redacted. Prompt text is not recorded unless you set `audit.includePromptText: true`; the SHA-256 always is, so a specific prompt stays provable without the trail disclosing business content. Set `audit.retentionDays` deliberately: keeping everything forever is its own compliance problem.
 
 ## 6. Autonomous surfaces

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -113,6 +113,7 @@ Check these lines specifically:
 | `identity` | `os:<user>@<host>`, not `unattributed` |
 | `network` | your proxy, and an extra CA if it terminates TLS |
 | `vault` | `keychain`, or a note that a stored key is in use |
+| `policy` | the bundles in force as `id@revision`; a warn means this host is serving off its cache |
 
 Then confirm the locks actually bind, rather than trusting that they were written:
 

--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -31,6 +31,7 @@ const BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
   'allow-scripts',
   'list',
   'check',
+  'json',
 ]);
 
 /**

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -69,6 +69,7 @@ const SECTIONS: ReadonlyArray<{ readonly title: string; readonly rows: ReadonlyA
       ['config trust|untrust', 'approve an executable project config so it may run'],
       ['profile list|<name>', 'print a deployment baseline for the system config scope'],
       ['sync [--check]', 'reconcile installed plugins with the config manifest'],
+      ['receipt <turnId>', 'verified account of one run: actor, tools, denials, policy, cost'],
       ['memory list|audit|show|revert|prune-stale|path', 'curate long-term memory'],
       ['security audit|isolators|status', 'inspect plugin-security isolation state'],
       ['mcp list|enable|disable|remove|path', 'manage Model Context Protocol servers'],
@@ -243,6 +244,7 @@ const COMMANDS: Record<string, () => Promise<CommandHandler>> = {
   channels: async () => (await import('./commands/channels.js')).runChannelsCommand,
   profile: async () => (await import('./commands/profile.js')).runProfileCommand,
   sync: async () => (await import('./commands/sync.js')).runSyncCommand,
+  receipt: async () => (await import('./commands/receipt.js')).runReceiptCommand,
   'self-update': async () => (await import('./commands/self-update.js')).runSelfUpdateCommand,
 };
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -70,6 +70,7 @@ const SECTIONS: ReadonlyArray<{ readonly title: string; readonly rows: ReadonlyA
       ['profile list|<name>', 'print a deployment baseline for the system config scope'],
       ['sync [--check]', 'reconcile installed plugins with the config manifest'],
       ['receipt <turnId>', 'verified account of one run: actor, tools, denials, policy, cost'],
+      ['policy', 'what the agent may do here, and who decided it'],
       ['memory list|audit|show|revert|prune-stale|path', 'curate long-term memory'],
       ['security audit|isolators|status', 'inspect plugin-security isolation state'],
       ['mcp list|enable|disable|remove|path', 'manage Model Context Protocol servers'],
@@ -245,6 +246,7 @@ const COMMANDS: Record<string, () => Promise<CommandHandler>> = {
   profile: async () => (await import('./commands/profile.js')).runProfileCommand,
   sync: async () => (await import('./commands/sync.js')).runSyncCommand,
   receipt: async () => (await import('./commands/receipt.js')).runReceiptCommand,
+  policy: async () => (await import('./commands/policy.js')).runPolicyCommand,
   'self-update': async () => (await import('./commands/self-update.js')).runSelfUpdateCommand,
 };
 

--- a/packages/cli/src/commands/doctor.policy.test.ts
+++ b/packages/cli/src/commands/doctor.policy.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import type { MoxxyConfig, PolicySourceRecord } from '@moxxy/config';
+import { buildPolicyDoctorCheck } from './doctor.js';
+
+const cfg = (over: Partial<MoxxyConfig> = {}): MoxxyConfig => over as MoxxyConfig;
+
+const source = (over: Partial<PolicySourceRecord> = {}): PolicySourceRecord => ({
+  id: 'corp',
+  revision: 'r1',
+  url: 'https://policy.example/corp.json',
+  from: 'remote',
+  ...over,
+});
+
+describe('buildPolicyDoctorCheck', () => {
+  it('names the bundle and revision in force', () => {
+    const check = buildPolicyDoctorCheck(
+      cfg({ policy: { bundles: [{ id: 'corp', url: 'u', publicKey: 'k' }] } } as Partial<MoxxyConfig>),
+      [source()],
+    );
+
+    expect(check.status).toBe('ok');
+    expect(check.message).toContain('corp@r1');
+  });
+
+  it('warns when a bundle is serving off its cache', () => {
+    // The rules still apply, but this host is not demonstrably current, and an
+    // ok row would let the two be conflated.
+    const check = buildPolicyDoctorCheck(
+      cfg({ policy: { bundles: [{ id: 'corp', url: 'u', publicKey: 'k' }] } } as Partial<MoxxyConfig>),
+      [source({ from: 'cache', staleReason: 'http 503' })],
+    );
+
+    expect(check.status).toBe('warn');
+    expect(check.message).toContain('503');
+  });
+
+  it('counts local managed rules when no bundle is configured', () => {
+    const check = buildPolicyDoctorCheck(
+      cfg({ permissions: { deny: [{ name: 'Bash' }, { name: 'Write' }] } } as Partial<MoxxyConfig>),
+      [],
+    );
+
+    expect(check.status).toBe('ok');
+    expect(check.message).toContain('2 managed rule');
+  });
+
+  it('says so plainly when nothing is managed at all', () => {
+    const check = buildPolicyDoctorCheck(cfg(), []);
+
+    expect(check).toEqual({ id: 'policy', status: 'ok', message: 'no managed rules' });
+  });
+});

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { Session } from '@moxxy/core';
-import type { MoxxyConfig } from '@moxxy/config';
+import type { MoxxyConfig, PolicySourceRecord } from '@moxxy/config';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import type { MemoryStore } from '@moxxy/plugin-memory';
 import { checkVoiceCaptureAvailable } from '@moxxy/plugin-cli';
@@ -70,7 +70,7 @@ export async function runDoctorCommand(argv: ParsedArgv): Promise<number> {
     return emit(checks, asJson);
   }
 
-  const { session, config, configSources, vault, memory, pluginRegistration, persistence, audit } =
+  const { session, config, configSources, policySources, vault, memory, pluginRegistration, persistence, audit } =
     setupResult.value;
 
   try {
@@ -78,6 +78,7 @@ export async function runDoctorCommand(argv: ParsedArgv): Promise<number> {
       session,
       config,
       configSources,
+      policySources,
       vault,
       memory,
       pluginRegistration,
@@ -96,6 +97,7 @@ interface DoctorChecksDeps {
   readonly session: Session;
   readonly config: MoxxyConfig;
   readonly configSources: ReadonlyArray<ConfigSource>;
+  readonly policySources: ReadonlyArray<PolicySourceRecord>;
   readonly vault: VaultStore;
   /** Undefined on a slim boot without the memory plugin installed. */
   readonly memory: MemoryStore | undefined;
@@ -106,7 +108,7 @@ interface DoctorChecksDeps {
 }
 
 async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
-  const { session, config, configSources, vault, memory, pluginRegistration, checks, checkKeys, asJson } =
+  const { session, config, configSources, policySources, vault, memory, pluginRegistration, checks, checkKeys, asJson } =
     deps;
 
   // Config
@@ -277,6 +279,7 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
   // cause on a corporate host is a proxy that Node's global fetch ignores, so
   // say plainly whether one is in force and whether a custom CA was supplied.
   checks.push(buildEgressDoctorCheck(config));
+  checks.push(buildPolicyDoctorCheck(config, policySources));
 
   // Self-update — Tier-1 is always available if the plugin is loaded; Tier-2
   // (core patching) additionally needs git/pnpm + pinned source provenance.
@@ -294,6 +297,40 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
  * corporate proxy without it produces `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, which
  * is otherwise a very unrewarding error to diagnose.
  */
+/**
+ * Report which signed policy bundles are in force.
+ *
+ * Warns rather than passes when a bundle is serving off its cache: the rules
+ * still apply, but this host is not demonstrably current, and "the policy
+ * loaded" and "the policy is up to date" are different claims an operator
+ * should not have to conflate.
+ */
+export function buildPolicyDoctorCheck(
+  config: MoxxyConfig,
+  sources: ReadonlyArray<PolicySourceRecord>,
+): Check {
+  const configured = config.policy?.bundles?.length ?? 0;
+  if (configured === 0) {
+    const local =
+      (config.permissions?.allow?.length ?? 0) + (config.permissions?.deny?.length ?? 0);
+    return {
+      id: 'policy',
+      status: 'ok',
+      message: local > 0 ? `${local} managed rule(s) from config` : 'no managed rules',
+    };
+  }
+  const stale = sources.filter((s) => s.from === 'cache');
+  const names = sources.map((s) => `${s.id}@${s.revision}`).join(', ');
+  if (stale.length > 0) {
+    return {
+      id: 'policy',
+      status: 'warn',
+      message: `${names} (serving from cache: ${stale[0]?.staleReason ?? 'remote unavailable'})`,
+    };
+  }
+  return { id: 'policy', status: 'ok', message: names };
+}
+
 export function buildEgressDoctorCheck(config: MoxxyConfig): Check {
   const settings = resolveEgressSettings(config);
   const ca = process.env.NODE_EXTRA_CA_CERTS;

--- a/packages/cli/src/commands/policy.ts
+++ b/packages/cli/src/commands/policy.ts
@@ -1,0 +1,162 @@
+import {
+  loadConfig,
+  loadPolicyBundles,
+  PolicyLoadError,
+  type PolicyBundleRule,
+} from '@moxxy/config';
+import type { ParsedArgv } from '../argv.js';
+import { helpRequested } from '../argv-helpers.js';
+import { printError } from '../errors.js';
+import { colors } from '../colors.js';
+import { formatHelp } from './help-format.js';
+import { policyFingerprint, policySummary } from '../setup/policy-fingerprint.js';
+
+const HELP = formatHelp({
+  title: 'moxxy policy',
+  tagline: 'what the agent may do here, and who decided it',
+  sections: [
+    {
+      title: 'COMMANDS',
+      rows: [
+        ['policy', 'the rules in force, each with its origin'],
+        ['policy --check', 'verify every configured bundle, change nothing'],
+        ['policy --json', 'machine-readable'],
+      ],
+    },
+    {
+      title: 'NOTES',
+      rows: [
+        [
+          'origins',
+          'a rule comes from your config or from a signed bundle. Both sit above ~/.moxxy/permissions.json and cannot be removed by an "allow always" answer.',
+        ],
+        [
+          'fail closed',
+          'a configured bundle that cannot be verified stops the session. Running without a policy you subscribe to is the condition this prevents.',
+        ],
+      ],
+    },
+  ],
+});
+
+interface RuleView {
+  readonly effect: 'allow' | 'deny';
+  readonly rule: PolicyBundleRule;
+  readonly origin: string;
+}
+
+export async function runPolicyCommand(argv: ParsedArgv): Promise<number> {
+  if (helpRequested(argv)) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  const { config } = await loadConfig({ cwd: process.cwd() });
+  const refs = config.policy?.bundles ?? [];
+
+  let loaded;
+  try {
+    loaded = await loadPolicyBundles(refs);
+  } catch (err) {
+    if (err instanceof PolicyLoadError) {
+      printError(err.message);
+      return 1;
+    }
+    throw err;
+  }
+
+  const rules: RuleView[] = [
+    ...(config.permissions?.deny ?? []).map((rule) => ({
+      effect: 'deny' as const,
+      rule,
+      origin: 'config',
+    })),
+    ...loaded.deny.map((rule) => ({ effect: 'deny' as const, rule, origin: 'bundle' })),
+    ...(config.permissions?.allow ?? []).map((rule) => ({
+      effect: 'allow' as const,
+      rule,
+      origin: 'config',
+    })),
+    ...loaded.allow.map((rule) => ({ effect: 'allow' as const, rule, origin: 'bundle' })),
+  ];
+
+  const summary = policySummary(config, loaded.sources);
+  const stale = loaded.sources.filter((s) => s.from === 'cache');
+
+  if (argv.flags.json === true) {
+    process.stdout.write(
+      JSON.stringify(
+        { fingerprint: policyFingerprint(summary), summary, sources: loaded.sources, rules },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(render(rules, loaded.sources, policyFingerprint(summary)));
+  }
+
+  // `--check` is for provisioning gates: a bundle serving off a stale cache
+  // means this host is not actually current, which a green exit would hide.
+  if (argv.flags.check === true && stale.length > 0) return 1;
+  return 0;
+}
+
+function render(
+  rules: ReadonlyArray<RuleView>,
+  sources: ReadonlyArray<{
+    id: string;
+    revision: string;
+    from: string;
+    url: string;
+    staleReason?: string;
+  }>,
+  fingerprint: string,
+): string {
+  const lines: string[] = [''];
+  lines.push(`  ${colors.bold('fingerprint')}  ${fingerprint.slice(0, 16)}`);
+  lines.push('');
+
+  lines.push(`  ${colors.bold('bundles')}`);
+  if (sources.length === 0) {
+    lines.push(colors.dim('    none configured'));
+  } else {
+    for (const s of sources) {
+      const mark = s.from === 'cache' ? colors.yellow(' (cached)') : '';
+      lines.push(`    ${s.id}@${s.revision}${mark}`);
+      lines.push(colors.dim(`      ${s.url}`));
+      if (s.staleReason) lines.push(colors.yellow(`      remote unavailable: ${s.staleReason}`));
+    }
+  }
+  lines.push('');
+
+  lines.push(`  ${colors.bold('rules')}`);
+  if (rules.length === 0) {
+    lines.push(colors.dim('    none. Every tool call falls through to the permission engine.'));
+  } else {
+    for (const r of rules) {
+      const effect = r.effect === 'deny' ? colors.red('deny ') : colors.green('allow');
+      const match = describeMatch(r.rule);
+      lines.push(
+        `    ${effect}  ${r.rule.name}${match}  ${colors.dim(`[${r.origin}]`)}` +
+          (r.rule.reason ? colors.dim(`  ${r.rule.reason}`) : ''),
+      );
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function describeMatch(rule: PolicyBundleRule): string {
+  const parts: string[] = [];
+  for (const [field, value] of Object.entries(rule.inputPathPrefix ?? {})) {
+    parts.push(`${field} under ${value}`);
+  }
+  for (const [field, value] of Object.entries(rule.inputGlob ?? {})) {
+    parts.push(`${field} matches ${value}`);
+  }
+  // Flagged explicitly: an unanchored regex reads like a prefix and is not one.
+  for (const [field, value] of Object.entries(rule.inputMatches ?? {})) {
+    parts.push(`${field} contains /${value}/`);
+  }
+  return parts.length > 0 ? ` (${parts.join(', ')})` : '';
+}

--- a/packages/cli/src/commands/receipt.integration.test.ts
+++ b/packages/cli/src/commands/receipt.integration.test.ts
@@ -1,0 +1,109 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appendAuditRecord, auditDir, resetAuditHeadForTests } from '@moxxy/core';
+import { parseArgv } from '../argv.js';
+import { runReceiptCommand } from './receipt.js';
+
+/**
+ * The guarantee worth an integration test: a receipt read back off disk must
+ * refuse to look complete after a record is removed. The unit tests cover the
+ * projection; only this covers the chain actually being checked on the way in.
+ */
+describe('moxxy receipt against a real trail', () => {
+  let home: string;
+  let prevHome: string | undefined;
+  let out: string[];
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-receipt-'));
+    prevHome = process.env.MOXXY_HOME;
+    process.env.MOXXY_HOME = home;
+    resetAuditHeadForTests();
+    out = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      out.push(String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (prevHome === undefined) delete process.env.MOXXY_HOME;
+    else process.env.MOXXY_HOME = prevHome;
+    resetAuditHeadForTests();
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  const seed = async (): Promise<void> => {
+    const actor = { id: 'alice@host', kind: 'human' as const, issuer: 'os' };
+    const base = { sessionId: 's1' as never, turnId: 't1' as never, actor };
+    await appendAuditRecord({
+      ...base,
+      ts: 1,
+      action: 'policy',
+      eventType: 'plugin_registered',
+      detail: { fingerprint: 'deadbeefcafe0000' },
+    });
+    for (const tool of ['Read', 'Bash', 'Write']) {
+      await appendAuditRecord({
+        ...base,
+        ts: 2,
+        action: 'tool.request',
+        eventType: 'tool_call_requested',
+        detail: { tool },
+      });
+    }
+    await appendAuditRecord({
+      ...base,
+      ts: 3,
+      action: 'usage',
+      eventType: 'provider_response',
+      detail: { inputTokens: 1200, outputTokens: 340 },
+    });
+  };
+
+  const dayFile = async (): Promise<string> => {
+    const dir = auditDir();
+    const [name] = await fs.readdir(dir);
+    return path.join(dir, name!);
+  };
+
+  it('assembles a verified receipt and exits 0', async () => {
+    await seed();
+
+    const code = await runReceiptCommand(parseArgv(['receipt', 't1', '--json']));
+
+    expect(code).toBe(0);
+    const receipt = JSON.parse(out.join(''));
+    expect(receipt.actor).toBe('os:alice@host');
+    expect(receipt.toolsRequested).toEqual(['Read', 'Bash', 'Write']);
+    expect(receipt.policyFingerprint).toBe('deadbeefcafe0000');
+    expect(receipt.tokens).toEqual({ input: 1200, output: 340 });
+    expect(receipt.chainVerified).toBe(true);
+  });
+
+  it('flags a removed record instead of reporting the surviving subset as whole', async () => {
+    await seed();
+    const file = await dayFile();
+    const lines = (await fs.readFile(file, 'utf8')).trim().split('\n');
+    // Drop the Bash request: silent selective deletion, the realistic threat.
+    await fs.writeFile(file, [...lines.slice(0, 2), ...lines.slice(3)].join('\n') + '\n');
+
+    const code = await runReceiptCommand(parseArgv(['receipt', 't1', '--json']));
+
+    const receipt = JSON.parse(out.join(''));
+    expect(receipt.toolsRequested).not.toContain('Bash');
+    expect(receipt.chainVerified).toBe(false);
+    // Non-zero so a compliance job gates on trustworthiness, not existence.
+    expect(code).toBe(1);
+  });
+
+  it('refuses rather than inventing an empty receipt for an unknown turn', async () => {
+    await seed();
+
+    expect(await runReceiptCommand(parseArgv(['receipt', 'no-such-turn']))).toBe(1);
+    expect(out.join('')).toBe('');
+  });
+});

--- a/packages/cli/src/commands/receipt.test.ts
+++ b/packages/cli/src/commands/receipt.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import type { AuditRecord } from '@moxxy/sdk';
+import { buildReceipt } from './receipt.js';
+
+function rec(over: Partial<AuditRecord>): AuditRecord {
+  return {
+    ts: 1_700_000_000_000,
+    sessionId: 's1',
+    turnId: 't1',
+    action: 'tool.request',
+    eventType: 'tool_call_requested',
+    seq: 0,
+    prevHash: '',
+    hash: '',
+    ...over,
+  } as AuditRecord;
+}
+
+describe('buildReceipt', () => {
+  it('reports the actor, the trigger origin and the policy in force', () => {
+    const policy = rec({
+      action: 'policy',
+      detail: { fingerprint: 'abc123', securityEnabled: true },
+    });
+    const records = [
+      rec({
+        action: 'prompt',
+        eventType: 'user_prompt',
+        actor: { id: 'alice@host', kind: 'human', issuer: 'os' },
+        detail: { origin: 'webhook:deploy' },
+      }),
+    ];
+
+    const r = buildReceipt('t1', records, policy, true);
+
+    expect(r.actor).toBe('os:alice@host');
+    expect(r.trigger).toBe('webhook:deploy');
+    expect(r.policyFingerprint).toBe('abc123');
+  });
+
+  it('names an unattributed run rather than inventing an actor', () => {
+    const r = buildReceipt('t1', [rec({ detail: { tool: 'Read' } })], undefined, true);
+
+    expect(r.actor).toBe('unattributed');
+    expect(r.policyFingerprint).toBeNull();
+  });
+
+  it('separates what was requested from what was denied, and counts failures', () => {
+    const records = [
+      rec({ detail: { tool: 'Read' } }),
+      rec({ detail: { tool: 'Write' } }),
+      rec({
+        action: 'tool.denied',
+        eventType: 'tool_call_denied',
+        detail: { tool: 'Bash', reason: 'managed policy' },
+      }),
+      rec({ action: 'tool.result', eventType: 'tool_result', detail: { ok: false } }),
+      rec({ action: 'tool.result', eventType: 'tool_result', detail: { ok: true } }),
+    ];
+
+    const r = buildReceipt('t1', records, undefined, true);
+
+    expect(r.toolsRequested).toEqual(['Read', 'Write']);
+    expect(r.denials).toEqual([{ tool: 'Bash', reason: 'managed policy' }]);
+    expect(r.failures).toBe(1);
+  });
+
+  it('sums token cost across every provider response in the run', () => {
+    const usage = (i: number, o: number) =>
+      rec({
+        action: 'usage',
+        eventType: 'provider_response',
+        detail: { inputTokens: i, outputTokens: o },
+      });
+
+    const r = buildReceipt('t1', [usage(1000, 200), usage(500, 80)], undefined, true);
+
+    expect(r.tokens).toEqual({ input: 1500, output: 280 });
+  });
+
+  it('carries the chain verdict so a receipt cannot look complete when it is not', () => {
+    const records = [rec({ detail: { tool: 'Read' } })];
+
+    expect(buildReceipt('t1', records, undefined, true).chainVerified).toBe(true);
+    expect(buildReceipt('t1', records, undefined, false).chainVerified).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/receipt.ts
+++ b/packages/cli/src/commands/receipt.ts
@@ -1,0 +1,175 @@
+import type { AuditRecord } from '@moxxy/sdk';
+import { listAuditDays, readAuditDay, verifyChain } from '@moxxy/core';
+import type { ParsedArgv } from '../argv.js';
+import { helpRequested, stringFlag } from '../argv-helpers.js';
+import { printError } from '../errors.js';
+import { colors } from '../colors.js';
+import { formatHelp } from './help-format.js';
+
+const HELP = formatHelp({
+  title: 'moxxy receipt',
+  tagline: 'assemble a verified account of one run from the audit trail',
+  sections: [
+    {
+      title: 'COMMANDS',
+      rows: [
+        ['receipt <turnId>', 'the account of one turn or triggered run'],
+        ['receipt --session <id>', 'every run in a session'],
+        ['receipt <turnId> --json', 'machine-readable, for attaching to a ticket'],
+      ],
+    },
+    {
+      title: 'NOTES',
+      rows: [
+        [
+          'derived',
+          'a receipt is a projection over the audit trail, not a second record. Nothing is written when you ask for one, so asking cannot change what happened.',
+        ],
+        [
+          'verified',
+          'the enclosing chain is checked before anything is printed. A receipt from a broken chain says so instead of quietly reporting a subset.',
+        ],
+      ],
+    },
+  ],
+});
+
+interface Receipt {
+  readonly turnId: string;
+  readonly sessionId: string;
+  readonly startedAt: string;
+  readonly endedAt: string;
+  readonly actor: string;
+  readonly trigger: string;
+  readonly policyFingerprint: string | null;
+  readonly toolsRequested: ReadonlyArray<string>;
+  readonly denials: ReadonlyArray<{ readonly tool: string; readonly reason: string }>;
+  readonly failures: number;
+  readonly tokens: { readonly input: number; readonly output: number };
+  readonly chainVerified: boolean;
+  readonly recordCount: number;
+}
+
+export async function runReceiptCommand(argv: ParsedArgv): Promise<number> {
+  if (helpRequested(argv)) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const sessionFilter = stringFlag(argv, 'session');
+  const turnId = argv.positional[0];
+  if (!turnId && !sessionFilter) {
+    printError('receipt requires a turn id, or --session <id>');
+    return 2;
+  }
+
+  const days = await listAuditDays();
+  if (days.length === 0) {
+    printError('no audit trail found. Enable it with `audit.enabled: true`.');
+    return 1;
+  }
+
+  // Verify each day's chain BEFORE selecting records. A receipt assembled from
+  // a broken chain would look complete while silently omitting whatever was
+  // removed, which is worse than refusing.
+  const all: AuditRecord[] = [];
+  let chainVerified = true;
+  for (const day of days) {
+    const records = await readAuditDay(day);
+    if (!verifyChain(records).ok) chainVerified = false;
+    all.push(...records);
+  }
+
+  const matching = all.filter((r) =>
+    sessionFilter ? r.sessionId === sessionFilter : r.turnId === turnId,
+  );
+  if (matching.length === 0) {
+    printError(
+      `no audit records for ${sessionFilter ? `session ${sessionFilter}` : `turn ${turnId}`}. ` +
+        'Retention may have pruned them, or the run predates `audit.enabled`.',
+    );
+    return 1;
+  }
+
+  const policy = all.find((r) => r.action === 'policy' && r.sessionId === matching[0]!.sessionId);
+  const byTurn = new Map<string, AuditRecord[]>();
+  for (const r of matching) {
+    const bucket = byTurn.get(r.turnId);
+    if (bucket) bucket.push(r);
+    else byTurn.set(r.turnId, [r]);
+  }
+
+  const receipts = [...byTurn.entries()].map(([id, records]) =>
+    buildReceipt(id, records, policy, chainVerified),
+  );
+
+  if (argv.flags.json === true) {
+    process.stdout.write(JSON.stringify(receipts.length === 1 ? receipts[0] : receipts, null, 2) + '\n');
+  } else {
+    for (const r of receipts) process.stdout.write(render(r));
+  }
+  // Exit non-zero on a broken chain so a compliance job can gate on the
+  // receipt's trustworthiness, not merely on its existence.
+  return chainVerified ? 0 : 1;
+}
+
+export function buildReceipt(
+  turnId: string,
+  records: ReadonlyArray<AuditRecord>,
+  policy: AuditRecord | undefined,
+  chainVerified: boolean,
+): Receipt {
+  const detail = (r: AuditRecord): Record<string, unknown> => r.detail ?? {};
+  const first = records[0]!;
+  const tools = records.filter((r) => r.action === 'tool.request');
+  const denials = records
+    .filter((r) => r.action === 'tool.denied')
+    .map((r) => ({
+      tool: String(detail(r).tool ?? detail(r).callId ?? 'unknown'),
+      reason: String(detail(r).reason ?? 'unspecified'),
+    }));
+  const usage = records.filter((r) => r.action === 'usage');
+  const prompt = records.find((r) => r.action === 'prompt');
+
+  return {
+    turnId,
+    sessionId: first.sessionId,
+    startedAt: new Date(records[0]!.ts).toISOString(),
+    endedAt: new Date(records[records.length - 1]!.ts).toISOString(),
+    // An unattributed run is itself worth reporting: it means the surface could
+    // not establish who was acting.
+    actor: first.actor ? `${first.actor.issuer}:${first.actor.id}` : 'unattributed',
+    trigger: prompt ? String(detail(prompt).origin ?? 'human') : 'unknown',
+    policyFingerprint: policy ? String(detail(policy).fingerprint ?? '') || null : null,
+    toolsRequested: tools.map((r) => String(detail(r).tool ?? 'unknown')),
+    denials,
+    failures: records.filter((r) => r.action === 'tool.result' && detail(r).ok === false).length,
+    tokens: {
+      input: usage.reduce((n, r) => n + Number(detail(r).inputTokens ?? 0), 0),
+      output: usage.reduce((n, r) => n + Number(detail(r).outputTokens ?? 0), 0),
+    },
+    chainVerified,
+    recordCount: records.length,
+  };
+}
+
+function render(r: Receipt): string {
+  const rows: Array<readonly [string, string]> = [
+    ['turn', r.turnId],
+    ['session', r.sessionId],
+    ['when', `${r.startedAt} to ${r.endedAt}`],
+    ['actor', r.actor],
+    ['trigger', r.trigger],
+    ['policy', r.policyFingerprint ? r.policyFingerprint.slice(0, 16) : '(not recorded)'],
+    ['tools', r.toolsRequested.length > 0 ? r.toolsRequested.join(', ') : '(none)'],
+    ['denied', r.denials.length > 0 ? r.denials.map((d) => `${d.tool}: ${d.reason}`).join('; ') : '(none)'],
+    ['failed', String(r.failures)],
+    ['tokens', `${r.tokens.input} in / ${r.tokens.output} out`],
+    ['records', String(r.recordCount)],
+  ];
+  const width = Math.max(...rows.map(([k]) => k.length));
+  const body = rows.map(([k, v]) => `  ${colors.bold(k.padEnd(width))}  ${v}`).join('\n');
+  const chain = r.chainVerified
+    ? colors.dim('  chain verified')
+    : colors.red('  CHAIN BROKEN: this receipt may be missing records');
+  return `${body}\n${chain}\n\n`;
+}

--- a/packages/cli/src/profiles.ts
+++ b/packages/cli/src/profiles.ts
@@ -70,6 +70,33 @@ plugins:
     # a hostile plugin; 'worker' is the lighter middle ground.
     default: subprocess
 
+# Signed policy bundles this host subscribes to. The alternative is editing
+# permission rules on every machine, where a host that missed a change looks
+# exactly like one that got it; a bundle carries a revision, and that revision
+# lands in the audit trail so every run says which rules it ran under.
+#
+# A bundle carries permission rules and NOTHING else: no registry URL, no keys,
+# no proxy, no security toggles. It arrives over the network, so the worst case
+# for whoever controls that host must stay "they can deny things and break the
+# fleet", which is loud and reversible, rather than "they can loosen us".
+#
+# Fails CLOSED. A configured bundle that cannot be verified stops the session
+# rather than running without the rules this machine is supposed to enforce.
+# The last verified copy is cached and carries a session through an outage;
+# 'moxxy policy --check' exits 1 when a host is serving off that cache.
+#
+# policy:
+#   bundles:
+#     - id: corp-baseline
+#       url: https://policy.example.internal/moxxy/corp-baseline.json
+#       # The publisher's Ed25519 SPKI PEM, pinned HERE and never taken from
+#       # the bundle or its host: a key served next to what it authenticates
+#       # proves nothing.
+#       publicKey: |
+#         -----BEGIN PUBLIC KEY-----
+#         ...
+#         -----END PUBLIC KEY-----
+
 config:
   # Never execute a project's moxxy.config.ts. Only YAML data is loaded.
   allowExecutable: false

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -10,7 +10,12 @@ import {
   silentLogger,
 } from '@moxxy/core';
 import type { Plugin } from '@moxxy/sdk';
-import { buildConfigPlugin, loadConfig as loadMergedConfig, loadDisabledProviders } from '@moxxy/config';
+import {
+  buildConfigPlugin,
+  loadConfig as loadMergedConfig,
+  loadDisabledProviders,
+  loadPolicyBundles,
+} from '@moxxy/config';
 import { BUILTIN_SKILLS_DIR_RESOLVED } from './setup/builtin-skills-dir.js';
 import { buildVaultPlugin } from '@moxxy/plugin-vault';
 import type { MemoryStore } from '@moxxy/plugin-memory';
@@ -113,9 +118,15 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   let sessionRef: Session | undefined;
   const secretResolver = buildSecretResolver(() => sessionRef, vault, opts.cwd);
 
+  // Loaded BEFORE the session so a machine that cannot obtain the policy it
+  // subscribes to never reaches the point of running a turn. Throws
+  // PolicyLoadError, which the caller reports rather than degrading past.
+  const policy = await loadPolicyBundles(config.policy?.bundles ?? []);
+
   const session = await buildSession({
     cwd: opts.cwd,
     config,
+    bundledRules: { allow: policy.allow, deny: policy.deny },
     resolver: opts.resolver,
     resumeSessionId: opts.resumeSessionId,
     sessionId: opts.sessionId,
@@ -317,7 +328,7 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
   const persistence = attachSessionPersistence(session, opts.cwd, opts.disableSessionPersistence);
   // Separate from persistence on purpose: the trail must survive an operator
   // turning session persistence off, and it records a different, smaller thing.
-  const audit = attachAudit(session, config);
+  const audit = attachAudit(session, config, policy.sources);
 
   // The memory plugin (when installed/enabled) published its store as the
   // 'memory' service during onInit; a slim boot without it leaves this

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -339,6 +339,7 @@ export async function setupSessionWithConfig(opts: SetupOptions): Promise<SetupR
     session,
     config,
     configSources: sources,
+    policySources: policy.sources,
     vault,
     memory,
     scheduler,

--- a/packages/cli/src/setup/audit.ts
+++ b/packages/cli/src/setup/audit.ts
@@ -6,7 +6,7 @@ import {
   type AuditHandle,
   type Session,
 } from '@moxxy/core';
-import type { MoxxyConfig } from '@moxxy/config';
+import type { MoxxyConfig, PolicySourceRecord } from '@moxxy/config';
 import { policyFingerprint, policySummary } from './policy-fingerprint.js';
 
 /**
@@ -18,7 +18,11 @@ import { policyFingerprint, policySummary } from './policy-fingerprint.js';
  *
  * Returns null when auditing is off, so callers can skip teardown entirely.
  */
-export function attachAudit(session: Session, config: MoxxyConfig): AuditHandle | null {
+export function attachAudit(
+  session: Session,
+  config: MoxxyConfig,
+  policySources: ReadonlyArray<PolicySourceRecord> = [],
+): AuditHandle | null {
   const audit = config.audit;
   if (!audit?.enabled) return null;
 
@@ -43,7 +47,7 @@ export function attachAudit(session: Session, config: MoxxyConfig): AuditHandle 
   // Record the policy in force, once, before anything else is audited. A trail
   // that says what was done but not what the rules were leaves the reviewer's
   // first question unanswerable.
-  const summary = policySummary(config);
+  const summary = policySummary(config, policySources);
   void appendAuditRecord({
     ts: Date.now(),
     sessionId: session.id,

--- a/packages/cli/src/setup/audit.ts
+++ b/packages/cli/src/setup/audit.ts
@@ -1,4 +1,5 @@
 import {
+  appendAuditRecord,
   attachAuditSink,
   jsonlAuditSink,
   pruneAuditDays,
@@ -6,6 +7,7 @@ import {
   type Session,
 } from '@moxxy/core';
 import type { MoxxyConfig } from '@moxxy/config';
+import { policyFingerprint, policySummary } from './policy-fingerprint.js';
 
 /**
  * Wire the audit trail for a session, when the operator asked for one.
@@ -37,6 +39,20 @@ export function attachAudit(session: Session, config: MoxxyConfig): AuditHandle 
     logger: session.logger,
     ...(audit.includePromptText ? { includePromptText: true } : {}),
   });
+
+  // Record the policy in force, once, before anything else is audited. A trail
+  // that says what was done but not what the rules were leaves the reviewer's
+  // first question unanswerable.
+  const summary = policySummary(config);
+  void appendAuditRecord({
+    ts: Date.now(),
+    sessionId: session.id,
+    turnId: 'session' as never,
+    action: 'policy',
+    eventType: 'plugin_registered',
+    ...(session.principal ? { actor: session.principal } : {}),
+    detail: { fingerprint: policyFingerprint(summary), ...summary },
+  }).catch(() => undefined);
 
   // Retention runs detached: pruning month-old files must not delay boot, and
   // failing to prune is not a reason to refuse to audit.

--- a/packages/cli/src/setup/build-session.ts
+++ b/packages/cli/src/setup/build-session.ts
@@ -11,11 +11,16 @@ import {
   type Logger,
 } from '@moxxy/core';
 import { MoxxyError, type MoxxyEvent, type PermissionResolver, type SessionId } from '@moxxy/sdk';
-import type { MoxxyConfig } from '@moxxy/config';
+import type { MoxxyConfig, PolicyBundleRule } from '@moxxy/config';
 
 export interface BuildSessionArgs {
   readonly cwd: string;
   readonly config: MoxxyConfig;
+  /** Rules from verified policy bundles, layered with the config's own. */
+  readonly bundledRules?: {
+    readonly allow: ReadonlyArray<PolicyBundleRule>;
+    readonly deny: ReadonlyArray<PolicyBundleRule>;
+  };
   readonly resolver?: PermissionResolver;
   readonly resumeSessionId?: string;
   /**
@@ -54,9 +59,14 @@ export async function buildSession(args: BuildSessionArgs): Promise<Session> {
   // file, not by answering "allow always", not by deleting the file.
   // Previously these config keys existed in the schema and were silently
   // ignored, so there was no way to push a rule at all.
+  // Local config first, then signed bundles. Order is presentational for deny
+  // (any match denies) but the layering that matters is already guaranteed by
+  // the engine: every deny in this layer is checked before any allow in it, so
+  // a local operator's deny beats a remote bundle's allow without needing to
+  // rank the two sources against each other.
   permissionEngine.setImmutableRules({
-    allow: args.config.permissions?.allow ?? [],
-    deny: args.config.permissions?.deny ?? [],
+    allow: [...(args.config.permissions?.allow ?? []), ...(args.bundledRules?.allow ?? [])],
+    deny: [...(args.config.permissions?.deny ?? []), ...(args.bundledRules?.deny ?? [])],
   });
 
   // The effective session id: an explicit `--resume <id>` (errors if missing),

--- a/packages/cli/src/setup/policy-fingerprint.test.ts
+++ b/packages/cli/src/setup/policy-fingerprint.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import type { MoxxyConfig } from '@moxxy/config';
+import { policySummary, policyFingerprint } from './policy-fingerprint.js';
+
+const cfg = (over: Partial<MoxxyConfig> = {}): MoxxyConfig => over as MoxxyConfig;
+
+describe('policySummary', () => {
+  it('reports effective defaults, not the literal absence of a key', () => {
+    const s = policySummary(cfg());
+
+    expect(s.securityEnabled).toBe(false);
+    expect(s.thirdPartyRequireDeclaration).toBe('warn');
+    expect(s.isolator).toBe('inproc');
+    expect(s.allowExecutableConfig).toBe(true);
+    expect(s.installPolicy).toBe('open');
+  });
+
+  it('records rule counts rather than the rules, which can name internal paths', () => {
+    const s = policySummary(
+      cfg({
+        permissions: {
+          allow: [{ name: 'Read' }],
+          deny: [{ name: 'Bash' }, { name: 'Write' }],
+        },
+      } as Partial<MoxxyConfig>),
+    );
+
+    expect(s.managedAllowRules).toBe(1);
+    expect(s.managedDenyRules).toBe(2);
+    expect(JSON.stringify(s)).not.toContain('Bash');
+  });
+
+  it('records that egress is pinned, not where it points', () => {
+    const pinned = policySummary(cfg({ network: { proxy: 'http://u:p@proxy.corp:3128' } } as Partial<MoxxyConfig>));
+
+    expect(pinned.proxyPinned).toBe(true);
+    expect(JSON.stringify(pinned)).not.toContain('proxy.corp');
+    expect(policySummary(cfg({ network: { proxy: 'env' } } as Partial<MoxxyConfig>)).proxyPinned).toBe(false);
+    expect(policySummary(cfg({ network: { proxy: 'off' } } as Partial<MoxxyConfig>)).proxyPinned).toBe(false);
+  });
+});
+
+describe('policyFingerprint', () => {
+  it('is stable across key insertion order, so a round-tripped summary still matches', () => {
+    const a = policySummary(cfg({ security: { enabled: true }, audit: { enabled: true } } as Partial<MoxxyConfig>));
+    // A summary that reached us through some other path: a JSON round-trip, a
+    // remote sink, a caller that spread the fields in its own order. Same
+    // policy, different insertion order, and the fingerprint has to agree or
+    // comparing two runs stops meaning anything.
+    const reordered = Object.fromEntries(
+      Object.entries(a).reverse(),
+    ) as unknown as typeof a;
+
+    expect(Object.keys(reordered)).not.toEqual(Object.keys(a));
+    expect(policyFingerprint(reordered)).toBe(policyFingerprint(a));
+  });
+
+  it('changes when a setting that decides what the agent may do changes', () => {
+    const base = policyFingerprint(policySummary(cfg()));
+
+    const differs = [
+      cfg({ security: { enabled: true } } as Partial<MoxxyConfig>),
+      cfg({ config: { allowExecutable: false } } as Partial<MoxxyConfig>),
+      cfg({ plugins: { installPolicy: 'registry-only' } } as Partial<MoxxyConfig>),
+      cfg({ plugins: { isolator: { default: 'subprocess' } } } as Partial<MoxxyConfig>),
+      cfg({ permissions: { deny: [{ name: 'Bash' }] } } as Partial<MoxxyConfig>),
+    ];
+
+    for (const c of differs) {
+      expect(policyFingerprint(policySummary(c))).not.toBe(base);
+    }
+  });
+
+  it('does not churn on preferences that cannot affect what was permitted', () => {
+    const base = policyFingerprint(policySummary(cfg()));
+    const withPrefs = policySummary(
+      cfg({ model: 'some-other-model', theme: 'dark' } as unknown as Partial<MoxxyConfig>),
+    );
+
+    expect(policyFingerprint(withPrefs)).toBe(base);
+  });
+});

--- a/packages/cli/src/setup/policy-fingerprint.ts
+++ b/packages/cli/src/setup/policy-fingerprint.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import type { MoxxyConfig } from '@moxxy/config';
+import type { MoxxyConfig, PolicySourceRecord } from '@moxxy/config';
 
 /**
  * A fingerprint of the security-relevant configuration in force.
@@ -32,9 +32,19 @@ export interface PolicySummary {
   readonly managedDenyRules: number;
   /** Whether egress is pinned, not to where. */
   readonly proxyPinned: boolean;
+  /**
+   * Signed bundles in force, as `id@revision`. The revision is the point: two
+   * runs under bundle `corp-baseline` are not comparable unless they ran the
+   * same revision of it, and without this the fingerprint would call a rule
+   * change no change at all.
+   */
+  readonly policyBundles: ReadonlyArray<string>;
 }
 
-export function policySummary(config: MoxxyConfig): PolicySummary {
+export function policySummary(
+  config: MoxxyConfig,
+  sources: ReadonlyArray<PolicySourceRecord> = [],
+): PolicySummary {
   const proxy = config.network?.proxy;
   return {
     securityEnabled: config.security?.enabled ?? false,
@@ -49,6 +59,7 @@ export function policySummary(config: MoxxyConfig): PolicySummary {
     managedAllowRules: config.permissions?.allow?.length ?? 0,
     managedDenyRules: config.permissions?.deny?.length ?? 0,
     proxyPinned: typeof proxy === 'string' && proxy !== 'env' && proxy !== 'off',
+    policyBundles: sources.map((s) => `${s.id}@${s.revision}`).sort(),
   };
 }
 

--- a/packages/cli/src/setup/policy-fingerprint.ts
+++ b/packages/cli/src/setup/policy-fingerprint.ts
@@ -1,0 +1,68 @@
+import { createHash } from 'node:crypto';
+import type { MoxxyConfig } from '@moxxy/config';
+
+/**
+ * A fingerprint of the security-relevant configuration in force.
+ *
+ * An audit trail without this says what was done but not what the rules WERE at
+ * the time, and "was this allowed under the policy that applied then" is the
+ * first question asked when reviewing a past run. Recording the whole config
+ * would put site secrets and irrelevant preferences into the trail, so a
+ * fingerprint plus a small human-readable summary is the useful middle: enough
+ * to prove two runs executed under the same rules, and to see at a glance which
+ * rules those were.
+ */
+
+/**
+ * The settings that decide what the agent may DO. Preferences (theme, model
+ * choice, skills directories) are deliberately absent: including them would
+ * make the fingerprint churn on changes that cannot affect what was permitted,
+ * and a fingerprint that changes for irrelevant reasons stops being evidence.
+ */
+export interface PolicySummary {
+  readonly securityEnabled: boolean;
+  readonly requireDeclaration: boolean;
+  readonly thirdPartyRequireDeclaration: string;
+  readonly isolator: string;
+  readonly allowExecutableConfig: boolean;
+  readonly installPolicy: string;
+  readonly auditEnabled: boolean;
+  /** Counts only. The rules themselves can name internal paths. */
+  readonly managedAllowRules: number;
+  readonly managedDenyRules: number;
+  /** Whether egress is pinned, not to where. */
+  readonly proxyPinned: boolean;
+}
+
+export function policySummary(config: MoxxyConfig): PolicySummary {
+  const proxy = config.network?.proxy;
+  return {
+    securityEnabled: config.security?.enabled ?? false,
+    requireDeclaration: config.security?.requireDeclaration ?? false,
+    // 'warn' is the plugin-side default while security is enabled, so report
+    // the EFFECTIVE value rather than the literal absence of a key.
+    thirdPartyRequireDeclaration: config.security?.thirdPartyRequireDeclaration ?? 'warn',
+    isolator: config.plugins?.isolator?.default ?? 'inproc',
+    allowExecutableConfig: config.config?.allowExecutable ?? true,
+    installPolicy: config.plugins?.installPolicy ?? 'open',
+    auditEnabled: config.audit?.enabled ?? false,
+    managedAllowRules: config.permissions?.allow?.length ?? 0,
+    managedDenyRules: config.permissions?.deny?.length ?? 0,
+    proxyPinned: typeof proxy === 'string' && proxy !== 'env' && proxy !== 'off',
+  };
+}
+
+/**
+ * SHA-256 over the summary, with keys emitted in a fixed order.
+ *
+ * Fixed order rather than `JSON.stringify`'s insertion order for the same
+ * reason the audit chain uses one: two configs with identical policy must
+ * fingerprint identically, or comparing two runs becomes meaningless the moment
+ * one of them round-tripped through a different serializer.
+ */
+export function policyFingerprint(summary: PolicySummary): string {
+  const ordered = Object.entries(summary)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => [k, v] as const);
+  return createHash('sha256').update(JSON.stringify(ordered)).digest('hex');
+}

--- a/packages/cli/src/setup/policy-layering.test.ts
+++ b/packages/cli/src/setup/policy-layering.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { PermissionEngine } from '@moxxy/core';
+import type { PolicyBundleRule } from '@moxxy/config';
+
+/**
+ * The layering `buildSession` relies on when it concatenates config rules and
+ * signed-bundle rules into one immutable layer.
+ *
+ * Concatenating is only safe because the engine checks every deny in the layer
+ * before any allow in it, which makes a local operator's deny beat a remote
+ * publisher's allow without ranking the two sources against each other. If that
+ * order ever changed, a bundle could grant past a local deny, so it is asserted
+ * here rather than assumed.
+ */
+const merge = (
+  config: { allow?: PolicyBundleRule[]; deny?: PolicyBundleRule[] },
+  bundle: { allow?: PolicyBundleRule[]; deny?: PolicyBundleRule[] },
+) => ({
+  allow: [...(config.allow ?? []), ...(bundle.allow ?? [])],
+  deny: [...(config.deny ?? []), ...(bundle.deny ?? [])],
+});
+
+const call = (name: string) => ({ name, input: {} }) as never;
+
+describe('config and bundle rules layered together', () => {
+  it('a bundle deny binds', () => {
+    const engine = new PermissionEngine();
+    engine.setImmutableRules(merge({}, { deny: [{ name: 'Bash', reason: 'corp policy' }] }));
+
+    expect(engine.check(call('Bash'))).toEqual({ mode: 'deny', reason: 'corp policy' });
+  });
+
+  it('a local deny beats a bundle allow for the same tool', () => {
+    const engine = new PermissionEngine();
+    engine.setImmutableRules(
+      merge({ deny: [{ name: 'Bash', reason: 'local' }] }, { allow: [{ name: 'Bash' }] }),
+    );
+
+    expect(engine.check(call('Bash'))).toEqual({ mode: 'deny', reason: 'local' });
+  });
+
+  it('a bundle deny beats a local allow, so subscribing actually restricts', () => {
+    const engine = new PermissionEngine();
+    engine.setImmutableRules(
+      merge({ allow: [{ name: 'Bash' }] }, { deny: [{ name: 'Bash', reason: 'corp' }] }),
+    );
+
+    expect(engine.check(call('Bash'))).toEqual({ mode: 'deny', reason: 'corp' });
+  });
+
+  it('an allow-always answer cannot remove a bundle deny', async () => {
+    const engine = new PermissionEngine();
+    engine.setImmutableRules(merge({}, { deny: [{ name: 'Bash' }] }));
+    await engine.addAllow({ name: 'Bash' });
+
+    expect(engine.check(call('Bash'))?.mode).toBe('deny');
+  });
+
+  it('leaves the engine untouched when no bundle is configured', () => {
+    const engine = new PermissionEngine();
+    engine.setImmutableRules(merge({}, {}));
+
+    expect(engine.getImmutableRules()).toEqual({ allow: [], deny: [] });
+    expect(engine.check(call('Read'))).toBeNull();
+  });
+});

--- a/packages/cli/src/setup/types.ts
+++ b/packages/cli/src/setup/types.ts
@@ -2,7 +2,7 @@ import type { ConfigSource } from './load-config.js';
 import type { AuditHandle } from '@moxxy/core';
 import type { EventStoreSession, Session } from '@moxxy/core';
 import type { PermissionResolver } from '@moxxy/sdk';
-import type { MoxxyConfig } from '@moxxy/config';
+import type { MoxxyConfig, PolicySourceRecord } from '@moxxy/config';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import type { MemoryStore } from '@moxxy/plugin-memory';
 import type { SchedulerPoller, ScheduleStore } from '@moxxy/plugin-scheduler';
@@ -98,6 +98,8 @@ export type BootStep =
   | { kind: 'ready' };
 
 export interface SetupResult {
+  /** Signed policy bundles that were verified for this session. */
+  readonly policySources: ReadonlyArray<PolicySourceRecord>;
   readonly session: Session;
   readonly config: MoxxyConfig;
   readonly configSources: ReadonlyArray<ConfigSource>;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -83,3 +83,21 @@ export {
   type SetConfigValueOptions,
   type SetConfigValueResult,
 } from './config-writer.js';
+
+export {
+  policyBundleSchema,
+  verifyPolicyBundle,
+  type PolicyBundle,
+  type PolicyBundleRule,
+  type PolicyBundleFailure,
+  type PolicyBundleResult,
+} from './policy-bundle.js';
+export {
+  loadPolicyBundles,
+  PolicyLoadError,
+  type LoadedPolicy,
+  type LoadPolicyOptions,
+  type PolicySourceRecord,
+} from './policy-source.js';
+export { policyBundleRefSchema, policyConfigSchema } from './schema.js';
+export type { PolicyBundleRef, PolicyConfig } from './schema.js';

--- a/packages/config/src/policy-bundle.test.ts
+++ b/packages/config/src/policy-bundle.test.ts
@@ -1,0 +1,113 @@
+import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+import { describe, it, expect } from 'vitest';
+import { verifyPolicyBundle, type PolicyBundle } from './policy-bundle.js';
+
+const keys = () => {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  return {
+    pem: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    sign: (bytes: Uint8Array) => cryptoSign(null, Buffer.from(bytes), privateKey).toString('base64'),
+  };
+};
+
+const bundle = (over: Partial<PolicyBundle> = {}): Uint8Array =>
+  new Uint8Array(
+    Buffer.from(
+      JSON.stringify({
+        version: 1,
+        id: 'corp-baseline',
+        revision: '2026-07-27.1',
+        permissions: { deny: [{ name: 'Bash', reason: 'managed policy' }] },
+        ...over,
+      }),
+    ),
+  );
+
+describe('verifyPolicyBundle', () => {
+  it('accepts a bundle signed by the pinned key', () => {
+    const k = keys();
+    const bytes = bundle();
+
+    const r = verifyPolicyBundle(bytes, k.sign(bytes), k.pem, 'corp-baseline');
+
+    expect(r.ok).toBe(true);
+    expect(r.bundle?.revision).toBe('2026-07-27.1');
+    expect(r.bundle?.permissions?.deny).toEqual([{ name: 'Bash', reason: 'managed policy' }]);
+  });
+
+  it('rejects a bundle signed by a different key', () => {
+    const mine = keys();
+    const theirs = keys();
+    const bytes = bundle();
+
+    const r = verifyPolicyBundle(bytes, theirs.sign(bytes), mine.pem);
+
+    expect(r.ok).toBe(false);
+    expect(r.failure).toBe('bad-signature');
+  });
+
+  it('rejects bytes altered after signing', () => {
+    const k = keys();
+    const bytes = bundle();
+    const sig = k.sign(bytes);
+    const tampered = bundle({ permissions: { deny: [] } });
+
+    expect(verifyPolicyBundle(tampered, sig, k.pem).ok).toBe(false);
+  });
+
+  it('rejects a validly signed bundle that is not the one this host subscribes to', () => {
+    const k = keys();
+    // Same publisher, different document: a signature proves who wrote it, not
+    // which of their documents it is. Without the id check a publisher's other
+    // bundle could be served here.
+    const bytes = bundle({ id: 'other-team-baseline' });
+
+    const r = verifyPolicyBundle(bytes, k.sign(bytes), k.pem, 'corp-baseline');
+
+    expect(r.ok).toBe(false);
+    expect(r.failure).toBe('id-mismatch');
+  });
+
+  it('refuses a bundle that tries to carry anything but permission rules', () => {
+    const k = keys();
+    // The whole point of the format: loosening security must not be reachable
+    // from a document that arrives over the network.
+    for (const extra of [
+      { security: { enabled: false } },
+      { plugins: { registryUrl: 'https://evil.example/index.json' } },
+      { network: { proxy: 'http://evil.example:3128' } },
+      { audit: { enabled: false } },
+    ]) {
+      const bytes = bundle(extra as Partial<PolicyBundle>);
+      const r = verifyPolicyBundle(bytes, k.sign(bytes), k.pem);
+
+      expect(r.ok, `${Object.keys(extra)[0]} must be refused`).toBe(false);
+      expect(r.failure).toBe('schema');
+    }
+  });
+
+  it('refuses a body too large to be a set of rules, before parsing it', () => {
+    const k = keys();
+    const huge = new Uint8Array(2 * 1024 * 1024);
+
+    const r = verifyPolicyBundle(huge, k.sign(huge), k.pem);
+
+    expect(r.ok).toBe(false);
+    expect(r.failure).toBe('too-large');
+  });
+
+  it('refuses a future format version rather than reading part of it', () => {
+    const k = keys();
+    const bytes = bundle({ version: 2 as 1 });
+
+    expect(verifyPolicyBundle(bytes, k.sign(bytes), k.pem).failure).toBe('schema');
+  });
+
+  it('treats an empty signature or key as a failure, never as a skip', () => {
+    const k = keys();
+    const bytes = bundle();
+
+    expect(verifyPolicyBundle(bytes, '', k.pem).failure).toBe('bad-signature');
+    expect(verifyPolicyBundle(bytes, k.sign(bytes), '').failure).toBe('bad-signature');
+  });
+});

--- a/packages/config/src/policy-bundle.ts
+++ b/packages/config/src/policy-bundle.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+import { verifyEd25519 } from '@moxxy/sdk';
+import { permissionRuleSchema } from './schema.js';
+
+/**
+ * A signed, versioned set of permission rules an operator distributes to a
+ * fleet.
+ *
+ * The problem it solves: pushing rules through `/etc/moxxy/config.yaml` works
+ * on one machine, but across a fleet it means every rule change is a file
+ * change on every host, and a machine that missed the change is
+ * indistinguishable from one that received it. A bundle is fetched, signature
+ * verified, and its version recorded in the audit trail, so "which rules was
+ * this host running" has an answer.
+ *
+ * WHAT A BUNDLE MAY CONTAIN IS DELIBERATELY NARROW.
+ *
+ * It carries permission rules and nothing else. It cannot set `registryUrl`,
+ * a public key, an audit sink, a proxy, or `security.enabled`. The reason is
+ * the failure mode: a bundle arrives over the network, so the interesting
+ * question is what someone who compromises the bundle host can do. Confined to
+ * permission rules, the worst case is that they deny things and break the
+ * fleet, which is loud, reversible, and fails safe. Let a bundle touch
+ * `registryUrl` or a trust key and the worst case becomes redirecting every
+ * machine's trust, silently. Denial of service is a much better worst case than
+ * privilege escalation, and this schema is where that is enforced.
+ */
+export const policyBundleSchema = z.object({
+  /** Bumped by this format, not by the publisher. Refuse what we cannot read. */
+  version: z.literal(1),
+  /** Identifies the bundle for humans and for the audit trail. */
+  id: z.string().min(1).max(200),
+  /** The publisher's own revision. Surfaced in `moxxy policy` and receipts. */
+  revision: z.string().min(1).max(64),
+  description: z.string().max(1000).optional(),
+  permissions: z
+    .object({
+      allow: z.array(permissionRuleSchema).max(1000).optional(),
+      deny: z.array(permissionRuleSchema).max(1000).optional(),
+    })
+    .optional(),
+});
+
+/**
+ * Strict, so a bundle carrying anything outside the contract is REJECTED
+ * rather than quietly stripped. Stripping would let a publisher believe they
+ * had set `security.enabled` while the field silently did nothing, and it
+ * would make "what can a bundle do" a question about this parser's defaults
+ * instead of about the schema. `version` is a literal, so extending the format
+ * later is a version bump, which is the right cost for a security document.
+ */
+export const strictPolicyBundleSchema = policyBundleSchema.strict();
+
+export type PolicyBundle = z.infer<typeof policyBundleSchema>;
+export type PolicyBundleRule = z.infer<typeof permissionRuleSchema>;
+
+/** A real bundle is rules, not a payload. Refuse absurd bodies before parsing. */
+const MAX_BUNDLE_BYTES = 1024 * 1024;
+
+export type PolicyBundleFailure =
+  | 'too-large'
+  | 'unparseable'
+  | 'schema'
+  | 'bad-signature'
+  | 'id-mismatch';
+
+export interface PolicyBundleResult {
+  readonly ok: boolean;
+  readonly bundle?: PolicyBundle;
+  readonly failure?: PolicyBundleFailure;
+  readonly detail?: string;
+}
+
+/**
+ * Verify then parse. Order matters: nothing is parsed until the signature over
+ * the received bytes checks out, so a malformed or hostile document never
+ * reaches the schema, let alone the permission engine.
+ */
+export function verifyPolicyBundle(
+  bytes: Uint8Array,
+  signatureB64: string,
+  publicKeyPem: string,
+  expectedId?: string,
+): PolicyBundleResult {
+  if (bytes.byteLength > MAX_BUNDLE_BYTES) {
+    return { ok: false, failure: 'too-large', detail: `${bytes.byteLength} bytes` };
+  }
+  if (!verifyEd25519(bytes, signatureB64, publicKeyPem)) {
+    return { ok: false, failure: 'bad-signature', detail: 'signature did not verify' };
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(Buffer.from(bytes).toString('utf8'));
+  } catch {
+    return { ok: false, failure: 'unparseable', detail: 'not valid JSON' };
+  }
+
+  const parsed = strictPolicyBundleSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, failure: 'schema', detail: parsed.error.issues[0]?.message ?? 'invalid' };
+  }
+
+  // A valid signature proves the publisher wrote this document. It does not
+  // prove it is the document this host was configured to receive: without this
+  // check, one signed bundle could be served in place of another from the same
+  // publisher, which is a downgrade the signature alone will not catch.
+  if (expectedId !== undefined && parsed.data.id !== expectedId) {
+    return {
+      ok: false,
+      failure: 'id-mismatch',
+      detail: `configured for '${expectedId}', served '${parsed.data.id}'`,
+    };
+  }
+
+  return { ok: true, bundle: parsed.data };
+}

--- a/packages/config/src/policy-source.test.ts
+++ b/packages/config/src/policy-source.test.ts
@@ -1,0 +1,168 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadPolicyBundles, PolicyLoadError } from './policy-source.js';
+
+const URL_A = 'https://policy.example/corp.json';
+
+const keys = () => {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  return {
+    pem: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    sign: (b: Uint8Array) => cryptoSign(null, Buffer.from(b), privateKey).toString('base64'),
+  };
+};
+
+const body = (revision: string, deny: string[] = ['Bash']): Uint8Array =>
+  new Uint8Array(
+    Buffer.from(
+      JSON.stringify({
+        version: 1,
+        id: 'corp',
+        revision,
+        permissions: { deny: deny.map((name) => ({ name })) },
+      }),
+    ),
+  );
+
+/** A fetch that serves `bytes`/`sig`, or fails every request when given null. */
+const serving = (pairs: Record<string, { bytes: Uint8Array; sig: string } | null>) =>
+  (async (url: string) => {
+    const base = url.endsWith('.sig') ? url.slice(0, -4) : url;
+    const entry = pairs[base];
+    if (!entry) return { ok: false, status: 503, arrayBuffer: async () => new ArrayBuffer(0), text: async () => '' };
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => entry.bytes.buffer.slice(entry.bytes.byteOffset, entry.bytes.byteOffset + entry.bytes.byteLength) as ArrayBuffer,
+      text: async () => entry.sig,
+    };
+  }) as never;
+
+describe('loadPolicyBundles', () => {
+  let cacheDir: string;
+  const k = keys();
+  const ref = { id: 'corp', url: URL_A, publicKey: k.pem };
+
+  beforeEach(async () => {
+    cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-policy-'));
+  });
+  afterEach(async () => {
+    await fs.rm(cacheDir, { recursive: true, force: true });
+  });
+
+  it('returns nothing when no bundle is configured, without touching the network', async () => {
+    const loaded = await loadPolicyBundles([], { cacheDir, fetch: serving({}) });
+
+    expect(loaded.deny).toEqual([]);
+    expect(loaded.sources).toEqual([]);
+  });
+
+  it('fetches, verifies and reports the revision in force', async () => {
+    const bytes = body('r1');
+    const loaded = await loadPolicyBundles([ref], {
+      cacheDir,
+      fetch: serving({ [URL_A]: { bytes, sig: k.sign(bytes) } }),
+    });
+
+    expect(loaded.deny).toEqual([{ name: 'Bash' }]);
+    expect(loaded.sources).toEqual([
+      { id: 'corp', revision: 'r1', url: URL_A, from: 'remote' },
+    ]);
+  });
+
+  it('refuses to start when the bundle is unreachable and was never cached', async () => {
+    // The condition the feature exists to prevent: a host running without the
+    // rules it subscribes to, and no way to tell from the outside.
+    await expect(
+      loadPolicyBundles([ref], { cacheDir, fetch: serving({ [URL_A]: null }) }),
+    ).rejects.toBeInstanceOf(PolicyLoadError);
+  });
+
+  it('carries on from a verified cache when the remote is down, and says so', async () => {
+    const bytes = body('r1');
+    await loadPolicyBundles([ref], {
+      cacheDir,
+      fetch: serving({ [URL_A]: { bytes, sig: k.sign(bytes) } }),
+    });
+
+    const offline = await loadPolicyBundles([ref], {
+      cacheDir,
+      fetch: serving({ [URL_A]: null }),
+    });
+
+    expect(offline.deny).toEqual([{ name: 'Bash' }]);
+    expect(offline.sources[0]?.from).toBe('cache');
+    expect(offline.sources[0]?.staleReason).toContain('503');
+  });
+
+  it('discards a cache that was edited on disk', async () => {
+    const bytes = body('r1');
+    await loadPolicyBundles([ref], {
+      cacheDir,
+      fetch: serving({ [URL_A]: { bytes, sig: k.sign(bytes) } }),
+    });
+
+    // Rewrite the cached rules while keeping the signature that covered the
+    // originals. A local edit must be worth nothing.
+    const [file] = await fs.readdir(cacheDir);
+    const cached = JSON.parse(await fs.readFile(path.join(cacheDir, file!), 'utf8'));
+    cached.bytes = Buffer.from(body('r1', [])).toString('base64');
+    await fs.writeFile(path.join(cacheDir, file!), JSON.stringify(cached));
+
+    await expect(
+      loadPolicyBundles([ref], { cacheDir, fetch: serving({ [URL_A]: null }) }),
+    ).rejects.toBeInstanceOf(PolicyLoadError);
+  });
+
+  it('does not fall back to cache when the remote serves a badly signed bundle', async () => {
+    const good = body('r1');
+    await loadPolicyBundles([ref], {
+      cacheDir,
+      fetch: serving({ [URL_A]: { bytes: good, sig: k.sign(good) } }),
+    });
+
+    // Otherwise anyone who can answer for the URL pins the fleet to an old
+    // revision indefinitely by serving garbage.
+    const attacker = keys();
+    const forged = body('r2', ['nothing']);
+    await expect(
+      loadPolicyBundles([ref], {
+        cacheDir,
+        fetch: serving({ [URL_A]: { bytes: forged, sig: attacker.sign(forged) } }),
+      }),
+    ).rejects.toBeInstanceOf(PolicyLoadError);
+  });
+
+  it('merges rules from several bundles', async () => {
+    const urlB = 'https://policy.example/team.json';
+    const a = body('r1', ['Bash']);
+    const b = new Uint8Array(
+      Buffer.from(
+        JSON.stringify({
+          version: 1,
+          id: 'team',
+          revision: 'r9',
+          permissions: { allow: [{ name: 'Read' }] },
+        }),
+      ),
+    );
+
+    const loaded = await loadPolicyBundles(
+      [ref, { id: 'team', url: urlB, publicKey: k.pem }],
+      {
+        cacheDir,
+        fetch: serving({
+          [URL_A]: { bytes: a, sig: k.sign(a) },
+          [urlB]: { bytes: b, sig: k.sign(b) },
+        }),
+      },
+    );
+
+    expect(loaded.deny).toEqual([{ name: 'Bash' }]);
+    expect(loaded.allow).toEqual([{ name: 'Read' }]);
+    expect(loaded.sources.map((s) => s.id)).toEqual(['corp', 'team']);
+  });
+});

--- a/packages/config/src/policy-source.ts
+++ b/packages/config/src/policy-source.ts
@@ -1,0 +1,174 @@
+import { promises as fs } from 'node:fs';
+import { createHash } from 'node:crypto';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { PolicyBundle, PolicyBundleRule } from './policy-bundle.js';
+import { verifyPolicyBundle } from './policy-bundle.js';
+import type { PolicyBundleRef } from './schema.js';
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+export interface PolicySourceRecord {
+  readonly id: string;
+  readonly revision: string;
+  readonly url: string;
+  readonly from: 'remote' | 'cache';
+  /** Set when the remote was unusable and the cached copy carried the session. */
+  readonly staleReason?: string;
+}
+
+export interface LoadedPolicy {
+  readonly allow: ReadonlyArray<PolicyBundleRule>;
+  readonly deny: ReadonlyArray<PolicyBundleRule>;
+  readonly sources: ReadonlyArray<PolicySourceRecord>;
+}
+
+export class PolicyLoadError extends Error {
+  constructor(
+    readonly url: string,
+    readonly reason: string,
+  ) {
+    super(
+      `policy bundle ${url} could not be loaded: ${reason}. ` +
+        'Refusing to start: a machine configured for a policy must not run without it. ' +
+        'Remove it from `policy.bundles` to run without this policy deliberately.',
+    );
+    this.name = 'PolicyLoadError';
+  }
+}
+
+type FetchLike = (url: string, init?: { signal?: AbortSignal }) => Promise<{
+  ok: boolean;
+  status: number;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+}>;
+
+export interface LoadPolicyOptions {
+  readonly fetch?: FetchLike;
+  readonly cacheDir?: string;
+  readonly now?: () => number;
+}
+
+const cacheFileFor = (dir: string, url: string): string =>
+  path.join(dir, `${createHash('sha256').update(url).digest('hex').slice(0, 32)}.json`);
+
+/**
+ * Fetch, verify and merge every configured policy bundle.
+ *
+ * Fails CLOSED, which is the one place this deliberately diverges from the
+ * plugin registry. The registry degrades to "you cannot install right now",
+ * an inconvenience. A policy that fails to load degrades to "this host runs
+ * without the rules it was configured to enforce", which is the exact
+ * condition the feature exists to prevent, and it would be invisible. So an
+ * unreachable bundle with no verified cache aborts startup rather than
+ * quietly widening what the agent may do.
+ */
+export async function loadPolicyBundles(
+  refs: ReadonlyArray<PolicyBundleRef>,
+  opts: LoadPolicyOptions = {},
+): Promise<LoadedPolicy> {
+  const allow: PolicyBundleRule[] = [];
+  const deny: PolicyBundleRule[] = [];
+  const sources: PolicySourceRecord[] = [];
+  if (refs.length === 0) return { allow, deny, sources };
+
+  const cacheDir = opts.cacheDir ?? path.join(os.homedir(), '.moxxy', 'policy');
+  await fs.mkdir(cacheDir, { recursive: true, mode: 0o700 }).catch(() => undefined);
+
+  for (const ref of refs) {
+    const cachePath = cacheFileFor(cacheDir, ref.url);
+    const remote = await fetchBundle(ref, opts);
+
+    let bundle: PolicyBundle | undefined = remote.bundle;
+    let from: 'remote' | 'cache' = 'remote';
+    let staleReason: string | undefined;
+
+    if (bundle) {
+      await writeCache(cachePath, remote.bytes!, remote.sig!);
+    } else {
+      // The cached bytes are re-verified against the configured key on every
+      // read, so a cache an attacker can write is worth no more than one they
+      // cannot: tampering fails the signature and the bundle is discarded.
+      const cached = await readVerifiedCache(cachePath, ref);
+      if (!cached) throw new PolicyLoadError(ref.url, remote.reason ?? 'unavailable');
+      bundle = cached;
+      from = 'cache';
+      staleReason = remote.reason;
+    }
+
+    allow.push(...(bundle.permissions?.allow ?? []));
+    deny.push(...(bundle.permissions?.deny ?? []));
+    sources.push({
+      id: bundle.id,
+      revision: bundle.revision,
+      url: ref.url,
+      from,
+      ...(staleReason ? { staleReason } : {}),
+    });
+  }
+
+  return { allow, deny, sources };
+}
+
+async function fetchBundle(
+  ref: PolicyBundleRef,
+  opts: LoadPolicyOptions,
+): Promise<{ bundle?: PolicyBundle; bytes?: Uint8Array; sig?: string; reason?: string }> {
+  const fetchImpl = opts.fetch ?? (globalThis.fetch as unknown as FetchLike | undefined);
+  if (!fetchImpl) return { reason: 'no fetch implementation available' };
+
+  const deadline = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+  let bytes: Uint8Array;
+  let sig: string;
+  try {
+    const [bodyRes, sigRes] = await Promise.all([
+      fetchImpl(ref.url, { signal: deadline }),
+      fetchImpl(`${ref.url}.sig`, { signal: deadline }),
+    ]);
+    if (!bodyRes.ok || !sigRes.ok) {
+      return { reason: `http ${bodyRes.status} / sig ${sigRes.status}` };
+    }
+    bytes = new Uint8Array(await bodyRes.arrayBuffer());
+    sig = (await sigRes.text()).trim();
+  } catch (err) {
+    if (deadline.aborted) return { reason: `fetch exceeded ${FETCH_TIMEOUT_MS}ms` };
+    return { reason: err instanceof Error ? err.message : String(err) };
+  }
+
+  const result = verifyPolicyBundle(bytes, sig, ref.publicKey, ref.id);
+  if (!result.ok || !result.bundle) {
+    // A bad signature is never treated as "unavailable": falling back to cache
+    // here would let anyone who can answer for the URL pin a fleet to an old
+    // policy forever by serving garbage.
+    throw new PolicyLoadError(ref.url, `${result.failure}: ${result.detail ?? ''}`.trim());
+  }
+  return { bundle: result.bundle, bytes, sig };
+}
+
+async function writeCache(cachePath: string, bytes: Uint8Array, sig: string): Promise<void> {
+  const payload = JSON.stringify({ bytes: Buffer.from(bytes).toString('base64'), sig });
+  await fs.writeFile(cachePath, payload, { mode: 0o600 }).catch(() => undefined);
+}
+
+async function readVerifiedCache(
+  cachePath: string,
+  ref: PolicyBundleRef,
+): Promise<PolicyBundle | undefined> {
+  try {
+    const raw = JSON.parse(await fs.readFile(cachePath, 'utf8')) as {
+      bytes?: string;
+      sig?: string;
+    };
+    if (typeof raw.bytes !== 'string' || typeof raw.sig !== 'string') return undefined;
+    const result = verifyPolicyBundle(
+      new Uint8Array(Buffer.from(raw.bytes, 'base64')),
+      raw.sig,
+      ref.publicKey,
+      ref.id,
+    );
+    return result.ok ? result.bundle : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -14,7 +14,7 @@ export const watcherModeSchema = z.enum(['auto', 'manual', 'off']);
  * means "contains /etc anywhere", which over-blocks as a deny and over-grants
  * as an allow.
  */
-const permissionRuleSchema = z.object({
+export const permissionRuleSchema = z.object({
   name: z.string(),
   inputMatches: z.record(z.string(), z.string()).optional(),
   inputPathPrefix: z.record(z.string(), z.string()).optional(),
@@ -33,6 +33,29 @@ export const permissionsConfigSchema = z.object({
   allow: z.array(permissionRuleSchema).optional(),
   deny: z.array(permissionRuleSchema).optional(),
 });
+
+/**
+ * A signed policy bundle this host subscribes to.
+ *
+ * The public key is pinned HERE, in config the operator controls, and never
+ * taken from the bundle or its host. A key served alongside the thing it
+ * authenticates proves nothing: whoever can replace the bundle can replace the
+ * key with it.
+ */
+export const policyBundleRefSchema = z.object({
+  /** Expected bundle id. A signature proves who wrote it, not which one it is. */
+  id: z.string().min(1),
+  url: z.string().url(),
+  /** SPKI PEM of the publisher's Ed25519 key. */
+  publicKey: z.string().min(1),
+});
+
+export const policyConfigSchema = z.object({
+  bundles: z.array(policyBundleRefSchema).max(32).optional(),
+});
+
+export type PolicyBundleRef = z.infer<typeof policyBundleRefSchema>;
+export type PolicyConfig = z.infer<typeof policyConfigSchema>;
 
 export const securityConfigSchema = z.object({
   /**
@@ -271,6 +294,7 @@ export const moxxyConfigSchema = z.object({
   vault: vaultConfigSchema.optional(),
   channels: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
   permissions: permissionsConfigSchema.optional(),
+  policy: policyConfigSchema.optional(),
   env: z.record(z.string(), z.string()).optional(),
   /** TUI presentation preferences (read at TUI boot; edited via /settings). */
   tui: z

--- a/packages/core/src/audit/project.ts
+++ b/packages/core/src/audit/project.ts
@@ -94,6 +94,19 @@ function detailOf(
     case 'plugin_registered':
     case 'plugin_unregistered':
       return { plugin: event.pluginId };
+    case 'provider_response':
+      // Counts only. The request and the reply are conversation and belong in
+      // the event log; what an auditor needs here is what it cost and to whom.
+      return {
+        provider: event.provider,
+        model: event.model,
+        ...(event.inputTokens !== undefined ? { inputTokens: event.inputTokens } : {}),
+        ...(event.outputTokens !== undefined ? { outputTokens: event.outputTokens } : {}),
+        ...(event.cacheReadTokens !== undefined ? { cacheReadTokens: event.cacheReadTokens } : {}),
+        ...(event.cacheCreationTokens !== undefined
+          ? { cacheCreationTokens: event.cacheCreationTokens }
+          : {}),
+      };
     case 'error':
       return { message: cap(redactSecretText(event.message)) };
     default:

--- a/packages/plugin-plugins-admin/src/registry.ts
+++ b/packages/plugin-plugins-admin/src/registry.ts
@@ -69,10 +69,9 @@
  * index can be replayed.
  */
 
-import { createPublicKey, verify as cryptoVerify } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { z, type CapabilitySpec } from '@moxxy/sdk';
+import { verifyEd25519, z, type CapabilitySpec } from '@moxxy/sdk';
 import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
 import { INSTALLABLE_PLUGIN_CATALOG, resolveCatalogEntry, type PluginCatalogEntry } from './catalog.js';
 import { NPM_NAME_RE } from './shared.js';
@@ -195,13 +194,7 @@ export function verifyRegistryIndex(
   sigB64: string,
   publicKeyPem: string,
 ): boolean {
-  if (!publicKeyPem || !sigB64) return false;
-  try {
-    const key = createPublicKey(publicKeyPem);
-    return cryptoVerify(null, Buffer.from(bytes), key, Buffer.from(sigB64, 'base64'));
-  } catch {
-    return false;
-  }
+  return verifyEd25519(bytes, sigB64, publicKeyPem);
 }
 
 /** Parse + schema-check verified index bytes. Undefined on anything off. */

--- a/packages/sdk/src/audit.ts
+++ b/packages/sdk/src/audit.ts
@@ -20,6 +20,10 @@ import type { Principal } from './principal.js';
 /** What kind of thing happened. Coarser than `MoxxyEventType` on purpose: an
  *  auditor reasons about categories of action, not about the loop's internals. */
 export type AuditAction =
+  /** The security-relevant config in force, recorded once per session. Without
+   *  it a trail says what was done but not what the rules were at the time,
+   *  which is the first question asked when reviewing a past run. */
+  | 'policy'
   | 'prompt'
   | 'tool.request'
   | 'tool.approved'
@@ -30,6 +34,10 @@ export type AuditAction =
   | 'plugin.registered'
   | 'plugin.unregistered'
   | 'abort'
+  /** Token counts for one provider call. Metadata only, never content, which
+   *  is what makes cost attribution auditable without the trail carrying the
+   *  conversation. */
+  | 'usage'
   | 'error'
   | 'other';
 
@@ -119,6 +127,7 @@ const AUDITED: Partial<Record<MoxxyEventType, AuditAction>> = {
   plugin_registered: 'plugin.registered',
   plugin_unregistered: 'plugin.unregistered',
   abort: 'abort',
+  provider_response: 'usage',
   error: 'error',
 };
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -47,6 +47,8 @@ export type { EventLogReader } from './log.js';
 export type { Principal } from './principal.js';
 export { samePrincipal, formatPrincipal } from './principal.js';
 
+export { verifyEd25519 } from './signature.js';
+
 // Audit trail: the tamper-evident receipt, distinct from the event log.
 export type {
   AuditAction,

--- a/packages/sdk/src/signature.ts
+++ b/packages/sdk/src/signature.ts
@@ -1,0 +1,34 @@
+import { createPublicKey, verify as cryptoVerify } from 'node:crypto';
+
+/**
+ * Ed25519 detached-signature verification over exact bytes.
+ *
+ * Lives in the SDK rather than beside its first caller because two different
+ * things now depend on it, and one of them is policy. Policy has to bind on a
+ * machine with no plugins installed at all, so the verifier it uses cannot sit
+ * inside a plugin: a control that a user can disable by uninstalling something
+ * is not a control.
+ *
+ * Verifies over the bytes as received, never over a re-serialisation of the
+ * parsed object. Canonicalising first would let two different documents share a
+ * signature whenever the parser and the serialiser disagree about anything,
+ * which is how signature-verification bypasses usually happen.
+ *
+ * Returns false rather than throwing on a malformed key or signature: to a
+ * caller "this did not verify" and "this could not be parsed" warrant the same
+ * response, and a throw here would tempt a try/catch that swallows both into a
+ * success path.
+ */
+export function verifyEd25519(
+  bytes: Uint8Array,
+  signatureB64: string,
+  publicKeyPem: string,
+): boolean {
+  if (!publicKeyPem || !signatureB64) return false;
+  try {
+    const key = createPublicKey(publicKeyPem);
+    return cryptoVerify(null, Buffer.from(bytes), key, Buffer.from(signatureB64, 'base64'));
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Two related commits, best reviewed in order. Together they answer "which rules was this host running, and what did any given run actually do under them".

### 1. `moxxy receipt <turnId>`

A verified account of one run, projected out of the audit trail. Nothing is written when you ask for one.

```
  turn     t1
  actor    os:alice@host
  trigger  webhook:deploy
  policy   6c59b147041aab80
  tools    Read, Edit
  denied   Bash: managed policy
  tokens   1200 in / 340 out
  chain verified
```

Two records had to exist first, both only when `audit.enabled`: a `policy` record per session carrying a fingerprint over the settings that decide what the agent may do (counts and effective values, no secrets or paths), and a `usage` record per provider response with token counts. Request and reply stay in the event log.

The chain is verified before anything prints; a broken chain marks the receipt and exits 1. A test deletes a middle record and asserts exactly that.

### 2. Signed policy bundles + `moxxy policy`

Rules could already be pushed from the system config, fine for one machine. Across a fleet every change was a file change on every host, and a host that missed one looked like one that got it. A bundle is signed, published once, subscribed to via `policy.bundles`, and its revision feeds the fingerprint above, so a receipt proves which revision a past run used.

**A bundle carries permission rules and nothing else.** Not `registryUrl`, not a key, not a proxy, not `security.enabled`, and one carrying any of them is rejected rather than stripped. It arrives over the network, so the worst case for whoever controls that host has to stay "they can deny things and break the fleet" instead of "they can loosen us". That is the main thing to push back on if you disagree.

Fails closed: a configured bundle that cannot be verified stops the session. The last verified copy is cached and carries a session through an outage, re-verified against the pinned key on every read. A bad signature is never treated as "unavailable", or anyone answering for the URL could pin a fleet to an old revision by serving garbage.

Layering, guaranteed by the engine checking every deny in the immutable layer before any allow in it: local deny beats bundle allow (you outrank a remote publisher), bundle deny beats local allow (subscribing actually restricts), and neither is removable by an "allow always" answer.

`verifyEd25519` moved to `@moxxy/sdk` and the plugin registry now delegates to it, since policy must bind on a machine with no plugins installed.

### Verified

Full workspace suite green (7421 tests, exit 0); affected packages also run with `--force` to defeat turbo cache. Every new security property was mutation-tested by breaking the code and confirming the test fails: fail-open instead of fail-closed, bad-signature falling back to cache, skipping cache re-verification, dropping the expected-id check, and a non-strict schema. Two of those checks caught vacuous assertions I had written.

End-to-end against a real Ed25519-signed bundle over HTTP: fresh load, offline-from-cache, `--check` exiting 1 on a stale cache, tampered body refused, and a real session refusing to boot without its policy.

One `@moxxy/cli` turbo task failed once during a five-package parallel run and did not reproduce in seven subsequent runs (three solo, two parallel, plus the full workspace). I could not identify it and am not claiming it is fixed.