### PR TITLE
feat(audit): export the trail to a central collector

### DIFF
--- a/.changeset/audit-export.md
+++ b/.changeset/audit-export.md
@@ -16,3 +16,5 @@ The checkpoint advances only after a batch is durably accepted, so a crash or fa
 Records map to OTLP logs rather than traces, spoken over plain `fetch` with no `@opentelemetry/*` dependency, which would have added megabytes to a CLI whose bundle budget is enforced at build time. `auditExporter` is a new registry kind, so another destination is a plugin; like audit sinks, a discovered exporter never activates on its own.
 
 Exporting needs no model provider and boots no session, so a machine with an expired API key still exports.
+
+`moxxy doctor` gains an `audit-export` row so a scheduled export that silently stopped (broken cron, expired token, moved collector) is visible: the local trail keeps being written either way, so nothing else would look wrong. The backlog excludes the diagnostic's own session, since booting one to ask the question writes a record and a check that always warns teaches people to ignore it.

--- a/.changeset/audit-export.md
+++ b/.changeset/audit-export.md
@@ -1,0 +1,18 @@
+---
+'@moxxy/cli': minor
+'@moxxy/core': minor
+'@moxxy/sdk': minor
+'@moxxy/config': minor
+---
+
+Ship the audit trail to a central collector: `moxxy security audit-export`, plus a built-in OTLP exporter.
+
+The local trail answered "what happened on this machine". A fleet needs one place to ask, and a chain head the workstation cannot rewrite. Configure `audit.export.endpoint` and run the command from cron; it exits 1 when it could not drain, so a collector unreachable for a week is visible rather than silently logging "sent 0".
+
+An exporter is a READER of the already-written trail, driven by a checkpoint, not a second write path. That is what makes shipping survivable: a network sink has to decide mid-turn whether to block, drop, or buffer when the collector is down, while an exporter just retries from the checkpoint. The local hash-chained file stays the system of record, and configuring an export does not weaken it.
+
+The checkpoint advances only after a batch is durably accepted, so a crash or failure re-sends rather than skips, and each record carries its chain hash to deduplicate on. A 200 carrying `partialSuccess.rejectedLogRecords` counts as a failure: checkpointing past records the collector discarded is the invisible gap this exists to prevent.
+
+Records map to OTLP logs rather than traces, spoken over plain `fetch` with no `@opentelemetry/*` dependency, which would have added megabytes to a CLI whose bundle budget is enforced at build time. `auditExporter` is a new registry kind, so another destination is a plugin; like audit sinks, a discovered exporter never activates on its own.
+
+Exporting needs no model provider and boots no session, so a machine with an expired API key still exports.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -114,6 +114,7 @@ Check these lines specifically:
 | `network` | your proxy, and an extra CA if it terminates TLS |
 | `vault` | `keychain`, or a note that a stored key is in use |
 | `policy` | the bundles in force as `id@revision`; a warn means this host is serving off its cache |
+| `audit-export` | `up to date`; a backlog means the job that should be exporting has stopped |
 
 Then confirm the locks actually bind, rather than trusting that they were written:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -165,6 +165,38 @@ The `policy` line is the fingerprint recorded at session start over the settings
 
 The chain is verified before anything prints, and a broken one exits 1 with the receipt marked. That matters more than it sounds: a receipt assembled from a trail with a record deleted would otherwise look complete while quietly omitting the removed call.
 
+### Shipping it somewhere central
+
+The local file answers "what happened on this machine". A fleet needs one place to ask, and a chain head the workstation cannot rewrite.
+
+```yaml
+audit:
+  enabled: true
+  export:
+    endpoint: https://otel-collector.example.internal:4318/v1/logs
+    headers:
+      authorization: ${vault:OTEL_TOKEN}
+```
+
+```sh
+moxxy security audit-export --dry-run   # what would be sent
+moxxy security audit-export             # send it
+```
+
+Run it from cron or a systemd timer. It exits 1 when it could not drain, so a collector that has been unreachable for a week is visible instead of silently logging "sent 0".
+
+Records go out as OTLP logs, not traces: an audit record is a flat statement of what was done and whether it was allowed, which is a log with attributes. Any OTLP collector works.
+
+Three properties worth knowing before you rely on it:
+
+- **Additive, not a replacement.** The local hash-chained file stays the system of record and is what the exporter reads from. Configuring an export does not weaken the local trail, and a collector outage delays central visibility rather than losing records.
+- **At least once, never at most once.** The checkpoint advances only after the collector durably accepts a batch, so a crash or a failed send re-offers that batch instead of skipping it. Each record carries its chain hash, so deduplicate on `moxxy.hash` at the collector.
+- **A partial rejection is a failure.** OTLP can return 200 and still discard records inside the request. That advances nothing here, because a checkpoint moving past records the collector threw away is exactly the invisible hole this is meant to prevent.
+
+Exporting needs no model provider and boots no session: it reads files that are already written. A machine with an expired API key still exports.
+
+To send somewhere OTLP cannot reach, register your own exporter (`auditExporters` in a plugin) and name it in `audit.export.exporter`. Like the sink, a discovered exporter never activates on its own.
+
 Records are bounded and redacted. Prompt text is not recorded unless you set `audit.includePromptText: true`; the SHA-256 always is, so a specific prompt stays provable without the trail disclosing business content. Set `audit.retentionDays` deliberately: keeping everything forever is its own compliance problem.
 
 ## 6. Autonomous surfaces
@@ -253,6 +285,7 @@ The bundle revision goes into the policy fingerprint, so `moxxy receipt` proves 
 - [ ] `plugins.packages` committed; `moxxy sync --check` green in CI
 - [ ] `installPolicy` set, and an internal mirror pinned if you have one
 - [ ] Audit sink configured, retention set, chain verification scheduled
+- [ ] `moxxy security audit-export` scheduled, and its exit code alerted on
 - [ ] Autonomous channels on dedicated runners with minimal allow-lists
 - [ ] Policy bundle published and pinned, or local rules accepted deliberately
 - [ ] `moxxy policy` verified on a pilot host, and `--check` green in CI

--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -32,6 +32,7 @@ const BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
   'list',
   'check',
   'json',
+  'dry-run',
 ]);
 
 /**

--- a/packages/cli/src/commands/audit-export.ts
+++ b/packages/cli/src/commands/audit-export.ts
@@ -1,0 +1,129 @@
+import * as os from 'node:os';
+import { exportAuditTrail, otlpAuditExporter, pendingExportCount, readCheckpoint } from '@moxxy/core';
+import type { AuditExporterDef } from '@moxxy/sdk';
+import { resolveOsPrincipal } from '@moxxy/sdk/server';
+import { loadConfig } from '@moxxy/config';
+import type { ParsedArgv } from '../argv.js';
+import { argvToSetupOptions, helpRequested } from '../argv-helpers.js';
+import { probeSession } from '../setup.js';
+import { printError } from '../errors.js';
+import { colors } from '../colors.js';
+import { cliVersion } from '../version.js';
+import { formatHelp } from './help-format.js';
+
+const HELP = formatHelp({
+  title: 'moxxy audit export',
+  tagline: 'ship the local audit trail to a central collector',
+  sections: [
+    {
+      title: 'COMMANDS',
+      rows: [
+        ['audit export', 'send everything recorded since the last checkpoint'],
+        ['audit export --dry-run', 'report what would be sent, send nothing'],
+        ['audit export --json', 'machine-readable result, for a scheduled job'],
+      ],
+    },
+    {
+      title: 'NOTES',
+      rows: [
+        [
+          'additive',
+          'the local hash-chained file stays the system of record and is what this reads from. A collector being down delays central visibility; it never loses a record.',
+        ],
+        [
+          'at least once',
+          'the checkpoint advances only after the collector durably accepts a batch, so a crash re-sends rather than skips. Each record carries its chain hash for the collector to deduplicate on.',
+        ],
+      ],
+    },
+  ],
+});
+
+export async function runAuditExportCommand(argv: ParsedArgv): Promise<number> {
+  if (helpRequested(argv)) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const asJson = argv.flags.json === true;
+
+  // Deliberately session-free on the common path. Exporting reads files that
+  // are already written, so requiring a working model provider would make a
+  // compliance job fail on a machine whose API key expired, and booting a
+  // session would append a fresh record to the very trail being exported. A
+  // session is paid for only when a plugin-provided exporter has to be
+  // resolved by name.
+  const { config } = await loadConfig({ cwd: process.cwd() });
+  const settings = config.audit?.export;
+  if (!settings) {
+    printError(
+      'no export configured. Set `audit.export.endpoint` (and `audit.enabled: true`) first.',
+    );
+    return 1;
+  }
+  if (!config.audit?.enabled) {
+    printError('audit.enabled is false, so there is no trail to export.');
+    return 1;
+  }
+
+  const name = settings.exporter;
+  const exporter: AuditExporterDef | undefined =
+    name === otlpAuditExporter.name ? otlpAuditExporter : await resolvePluginExporter(argv, name);
+  if (!exporter) {
+    printError(`audit exporter '${name}' is not registered.`);
+    return 1;
+  }
+
+  const pending = await pendingExportCount(exporter.name, settings.endpoint);
+  if (argv.flags['dry-run'] === true) {
+    const cp = await readCheckpoint(exporter.name, settings.endpoint);
+    const out = { exporter: exporter.name, endpoint: settings.endpoint, pending, checkpoint: cp };
+    process.stdout.write(
+      asJson
+        ? JSON.stringify(out, null, 2) + '\n'
+        : `  ${colors.bold('pending')}  ${pending} record(s)\n` +
+            `  ${colors.bold('from')}     ${cp ? `${cp.day} seq ${cp.seq}` : 'the beginning'}\n` +
+            `  ${colors.bold('to')}       ${exporter.name} ${settings.endpoint}\n`,
+    );
+    return 0;
+  }
+
+  const result = await exportAuditTrail(exporter, {
+    endpoint: settings.endpoint,
+    ...(settings.batchSize ? { batchSize: settings.batchSize } : {}),
+    settings: { ...(settings.headers ? { headers: settings.headers } : {}) },
+    resource: {
+      host: os.hostname(),
+      cliVersion: cliVersion() ?? 'unknown',
+      principal: resolveOsPrincipal(),
+    },
+  });
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify({ pending, ...result }, null, 2) + '\n');
+  } else {
+    process.stdout.write(
+      `  ${colors.bold('sent')}  ${result.sent} record(s) in ${result.batches} batch(es)\n`,
+    );
+    if (result.stoppedBecause) {
+      process.stdout.write(
+        colors.yellow(`  stopped: ${result.stoppedBecause}\n`) +
+          colors.dim('  the checkpoint did not advance past this batch; rerun to retry\n'),
+      );
+    }
+  }
+
+  // Non-zero when the run did not drain, so a scheduled job surfaces a
+  // collector that has been unreachable rather than logging "sent 0".
+  return result.stoppedBecause ? 1 : 0;
+}
+
+/** Boot a session only to resolve a plugin-contributed exporter by name. */
+async function resolvePluginExporter(
+  argv: ParsedArgv,
+  name: string,
+): Promise<AuditExporterDef | undefined> {
+  return probeSession(
+    { ...argvToSetupOptions(argv), skipKeyPrompt: true, tolerateNoProvider: true },
+    async ({ session }) => session.auditExporters.list().find((e) => e.name === name),
+  );
+}

--- a/packages/cli/src/commands/doctor.audit-export.test.ts
+++ b/packages/cli/src/commands/doctor.audit-export.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { MoxxyConfig } from '@moxxy/config';
+import { buildAuditExportDoctorCheck } from './doctor.js';
+
+const cfg = (over: Partial<MoxxyConfig> = {}): MoxxyConfig => over as MoxxyConfig;
+
+const withExport = (audit: Record<string, unknown> = {}) =>
+  cfg({
+    audit: {
+      enabled: true,
+      export: { exporter: 'otlp', endpoint: 'https://collector/v1/logs' },
+      ...audit,
+    },
+  } as Partial<MoxxyConfig>);
+
+describe('buildAuditExportDoctorCheck', () => {
+  it('says nothing at all when no export is configured', async () => {
+    expect(await buildAuditExportDoctorCheck(cfg(), async () => 0)).toBeNull();
+  });
+
+  it('passes when the trail is fully drained', async () => {
+    const check = await buildAuditExportDoctorCheck(withExport(), async () => 0);
+
+    expect(check?.status).toBe('ok');
+  });
+
+  it('warns on a backlog, which is how a stopped job becomes visible', async () => {
+    // The failure mode: the scheduled export dies, the local trail keeps being
+    // written, and nothing looks wrong until someone asks for the records.
+    const check = await buildAuditExportDoctorCheck(withExport(), async () => 412);
+
+    expect(check?.status).toBe('warn');
+    expect(check?.message).toContain('412');
+  });
+
+  it('warns when an export is configured but nothing is being recorded', async () => {
+    const check = await buildAuditExportDoctorCheck(
+      cfg({
+        audit: { enabled: false, export: { exporter: 'otlp', endpoint: 'https://c' } },
+      } as Partial<MoxxyConfig>),
+      async () => 0,
+    );
+
+    expect(check?.status).toBe('warn');
+    expect(check?.message).toContain('audit.enabled is false');
+  });
+
+  it('reports an unreadable checkpoint instead of throwing out of doctor', async () => {
+    const check = await buildAuditExportDoctorCheck(withExport(), async () => {
+      throw new Error('EACCES');
+    });
+
+    expect(check?.status).toBe('warn');
+    expect(check?.message).toContain('EACCES');
+  });
+
+  it('asks about the configured exporter and endpoint, not a default', async () => {
+    const countPending = vi.fn(async () => 0);
+
+    await buildAuditExportDoctorCheck(
+      cfg({
+        audit: {
+          enabled: true,
+          export: { exporter: 'splunk', endpoint: 'https://splunk.internal/x' },
+        },
+      } as Partial<MoxxyConfig>),
+      countPending,
+    );
+
+    expect(countPending).toHaveBeenCalledWith('splunk', 'https://splunk.internal/x');
+  });
+});

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { Session } from '@moxxy/core';
+import { pendingExportCount } from '@moxxy/core';
 import type { MoxxyConfig, PolicySourceRecord } from '@moxxy/config';
 import type { VaultStore } from '@moxxy/plugin-vault';
 import type { MemoryStore } from '@moxxy/plugin-memory';
@@ -280,6 +281,12 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
   // say plainly whether one is in force and whether a custom CA was supplied.
   checks.push(buildEgressDoctorCheck(config));
   checks.push(buildPolicyDoctorCheck(config, policySources));
+  // Excludes this diagnostic's own session: booting one to run these checks
+  // appends a record, which would otherwise make "up to date" unreachable.
+  const exportCheck = await buildAuditExportDoctorCheck(config, (exporter, endpoint) =>
+    pendingExportCount(exporter, endpoint, undefined, String(session.id)),
+  );
+  if (exportCheck) checks.push(exportCheck);
 
   // Self-update — Tier-1 is always available if the plugin is loaded; Tier-2
   // (core patching) additionally needs git/pnpm + pinned source provenance.
@@ -305,6 +312,53 @@ async function runDoctorChecks(deps: DoctorChecksDeps): Promise<number> {
  * loaded" and "the policy is up to date" are different claims an operator
  * should not have to conflate.
  */
+/**
+ * Report whether a configured audit export is actually draining.
+ *
+ * The failure this catches: an export is configured, the scheduled job that
+ * runs it silently stops (a broken cron, an expired token, a collector moved),
+ * and everything keeps looking healthy because the LOCAL trail is still being
+ * written. A compliance control that quietly stopped running is worse than one
+ * that was never configured, because someone is relying on it.
+ *
+ * Backlog is measured in records rather than time: a machine that was idle for
+ * a week is not behind, and flagging it would train operators to ignore this.
+ */
+export async function buildAuditExportDoctorCheck(
+  config: MoxxyConfig,
+  countPending: (exporter: string, endpoint: string) => Promise<number>,
+): Promise<Check | null> {
+  const settings = config.audit?.export;
+  if (!settings) return null;
+  if (!config.audit?.enabled) {
+    return {
+      id: 'audit-export',
+      status: 'warn',
+      message: 'export is configured but audit.enabled is false, so nothing is recorded to send',
+    };
+  }
+  let pending: number;
+  try {
+    pending = await countPending(settings.exporter, settings.endpoint);
+  } catch (err) {
+    return {
+      id: 'audit-export',
+      status: 'warn',
+      message: `cannot read the export checkpoint: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (pending === 0) {
+    return { id: 'audit-export', status: 'ok', message: `up to date with ${settings.endpoint}` };
+  }
+  return {
+    id: 'audit-export',
+    status: 'warn',
+    message:
+      `${pending} record(s) not yet sent to ${settings.endpoint}. ` +
+      'Run `moxxy security audit-export`, or check the job that should.',
+  };
+}
+
 export function buildPolicyDoctorCheck(
   config: MoxxyConfig,
   sources: ReadonlyArray<PolicySourceRecord>,

--- a/packages/cli/src/commands/security.ts
+++ b/packages/cli/src/commands/security.ts
@@ -22,6 +22,8 @@ const HELP = formatHelp({
         ['status', 'show enabled state, default isolator, and declaration/ratchet modes'],
         ['audit-log', 'list days with an audit trail and verify each hash chain'],
         ['audit-log <YYYY-MM-DD>', 'verify one day and print its record count + chain head'],
+        ['audit-export', 'ship the trail to the collector in audit.export'],
+        ['audit-export --dry-run', 'report what would be sent, send nothing'],
       ],
     },
   ],
@@ -37,6 +39,9 @@ export async function runSecurityCommand(argv: ParsedArgv): Promise<number> {
   // Reading the audit trail needs no session: the files are the source of
   // truth, and booting one would append to the very trail being verified.
   if (sub === 'audit-log') return await runAuditLog(argv);
+  if (sub === 'audit-export') {
+    return await (await import('./audit-export.js')).runAuditExportCommand(argv);
+  }
 
   const { config, security } = await bootSessionWithConfig(argv, {
     skipKeyPrompt: true,

--- a/packages/cli/src/profiles.ts
+++ b/packages/cli/src/profiles.ts
@@ -108,6 +108,15 @@ audit:
   # the file can recompute the chain. Point this at a remote sink to get a chain
   # head the workstation cannot rewrite.
   # sink: <your-sink>
+  # Ship the trail to a central collector. ADDITIVE: the hash-chained local
+  # file stays the system of record and is what the exporter reads from, so a
+  # collector outage delays central visibility instead of losing records. Run
+  # 'moxxy security audit-export' from cron or a systemd timer; it exits 1 when
+  # it could not drain, so a job that has been failing is visible.
+  # export:
+  #   endpoint: https://otel-collector.example.internal:4318/v1/logs
+  #   headers:
+  #     authorization: \${vault:OTEL_TOKEN}
   retentionDays: 400
   # Prompt TEXT is off by default; only its length and SHA-256 are recorded, so
   # a prompt stays provable without the trail disclosing business content.

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -143,6 +143,7 @@ const CATEGORY_REGISTRIES: ReadonlyArray<{
   { category: 'tunnelProvider', reg: (s) => s.tunnelProviders },
   { category: 'eventStore', reg: (s) => s.eventStores },
   { category: 'auditSink', reg: (s) => s.auditSinks },
+  { category: 'auditExporter', reg: (s) => s.auditExporters },
   { category: 'secretProvider', reg: (s) => s.secretProviders },
   { category: 'reflector', reg: (s) => s.reflectors },
 ];

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -159,6 +159,25 @@ export const auditConfigSchema = z
     /** Delete local audit files older than this. Unset keeps them forever,
      *  which is its own compliance problem. */
     retentionDays: z.number().int().positive().optional(),
+    /**
+     * Ship the local trail to a central collector.
+     *
+     * ADDITIVE, never a replacement. The hash-chained local file stays the
+     * system of record and is what the exporter reads from, so a collector
+     * being unreachable delays central visibility instead of losing records.
+     * Configuring an export does not weaken `sink`.
+     */
+    export: z
+      .object({
+        /** Registered exporter name. 'otlp' is built in. */
+        exporter: z.string().default('otlp'),
+        endpoint: z.string().url(),
+        /** Static headers, e.g. authorization. Supports ${vault:KEY}. */
+        headers: z.record(z.string(), z.string()).optional(),
+        batchSize: z.number().int().positive().max(10_000).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/packages/core/src/audit/export.test.ts
+++ b/packages/core/src/audit/export.test.ts
@@ -186,6 +186,25 @@ describe('pendingExportCount', () => {
     await fs.rm(home, { recursive: true, force: true });
   });
 
+  it('can exclude one session, so a diagnostic does not count its own record', async () => {
+    const add = async (sessionId: string) =>
+      appendAuditRecord({
+        ts: 1_700_000_000_000,
+        sessionId: sessionId as never,
+        turnId: 't1' as never,
+        action: 'policy',
+        eventType: 'plugin_registered',
+      });
+    await add('real-1');
+    await add('real-2');
+    await add('the-diagnostic');
+
+    expect(await pendingExportCount('rec', 'http://c')).toBe(3);
+    // Without this a doctor row could never report "up to date", because
+    // booting a session to ask the question writes a record of its own.
+    expect(await pendingExportCount('rec', 'http://c', undefined, 'the-diagnostic')).toBe(2);
+  });
+
   it('counts what a run would send, without sending it', async () => {
     for (let i = 0; i < 4; i++) {
       await appendAuditRecord({

--- a/packages/core/src/audit/export.test.ts
+++ b/packages/core/src/audit/export.test.ts
@@ -1,0 +1,206 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { AuditExportBatch, AuditExporterDef, AuditExportResource } from '@moxxy/sdk';
+import { appendAuditRecord, resetAuditHeadForTests } from './jsonl-audit-sink.js';
+import { exportAuditTrail, pendingExportCount, readCheckpoint } from './export.js';
+
+const resource: AuditExportResource = { host: 'h1', cliVersion: '0.0.0' };
+
+/** Collects what it was given; fails the Nth batch when told to. */
+const recorder = (failOnBatch?: number): AuditExporterDef & { seen: AuditExportBatch[] } => {
+  const seen: AuditExportBatch[] = [];
+  return {
+    name: 'rec',
+    seen,
+    async send(batch) {
+      seen.push(batch);
+      if (failOnBatch !== undefined && seen.length === failOnBatch) {
+        throw new Error('collector down');
+      }
+    },
+  } as AuditExporterDef & { seen: AuditExportBatch[] };
+};
+
+describe('exportAuditTrail', () => {
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-export-'));
+    prevHome = process.env.MOXXY_HOME;
+    process.env.MOXXY_HOME = home;
+    resetAuditHeadForTests();
+  });
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.MOXXY_HOME;
+    else process.env.MOXXY_HOME = prevHome;
+    resetAuditHeadForTests();
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  const seed = async (n: number): Promise<void> => {
+    for (let i = 0; i < n; i++) {
+      await appendAuditRecord({
+        ts: 1_700_000_000_000,
+        sessionId: 's1' as never,
+        turnId: 't1' as never,
+        action: 'tool.request',
+        eventType: 'tool_call_requested',
+        detail: { tool: `T${i}` },
+      });
+    }
+  };
+
+  it('sends everything on a first run and checkpoints at the end', async () => {
+    await seed(5);
+    const exp = recorder();
+
+    const result = await exportAuditTrail(exp, { endpoint: 'http://c', resource });
+
+    expect(result.sent).toBe(5);
+    expect(result.stoppedBecause).toBeUndefined();
+    expect(await readCheckpoint('rec', 'http://c')).toMatchObject({ seq: 4 });
+  });
+
+  it('sends nothing the second time, having already caught up', async () => {
+    await seed(3);
+    await exportAuditTrail(recorder(), { endpoint: 'http://c', resource });
+
+    const again = recorder();
+    const result = await exportAuditTrail(again, { endpoint: 'http://c', resource });
+
+    expect(result.sent).toBe(0);
+    expect(again.seen).toEqual([]);
+  });
+
+  it('resumes at the checkpoint, sending only what arrived since', async () => {
+    await seed(3);
+    await exportAuditTrail(recorder(), { endpoint: 'http://c', resource });
+    await seed(2);
+
+    const exp = recorder();
+    const result = await exportAuditTrail(exp, { endpoint: 'http://c', resource });
+
+    expect(result.sent).toBe(2);
+    expect(exp.seen.flatMap((b) => b.records.map((r) => r.detail?.tool))).toEqual(['T0', 'T1']);
+  });
+
+  it('does not advance the checkpoint past a batch the collector refused', async () => {
+    // The property the whole design exists for: a failed batch must be offered
+    // again, never skipped, or the trail has a hole nothing reports.
+    await seed(6);
+    const failing = recorder(2);
+
+    const result = await exportAuditTrail(failing, {
+      endpoint: 'http://c',
+      resource,
+      batchSize: 2,
+    });
+
+    expect(result.stoppedBecause).toContain('collector down');
+    expect(result.sent).toBe(2);
+    expect(await readCheckpoint('rec', 'http://c')).toMatchObject({ seq: 1 });
+
+    const retry = recorder();
+    const second = await exportAuditTrail(retry, {
+      endpoint: 'http://c',
+      resource,
+      batchSize: 2,
+    });
+
+    expect(second.sent).toBe(4);
+    const tools = retry.seen.flatMap((b) => b.records.map((r) => r.detail?.tool));
+    expect(tools).toEqual(['T2', 'T3', 'T4', 'T5']);
+  });
+
+  it('stops at the first failure rather than skipping ahead to later batches', async () => {
+    await seed(6);
+    const failing = recorder(1);
+
+    await exportAuditTrail(failing, { endpoint: 'http://c', resource, batchSize: 2 });
+
+    expect(failing.seen).toHaveLength(1);
+    expect(await readCheckpoint('rec', 'http://c')).toBeNull();
+  });
+
+  it('keeps checkpoints per destination, so one collector being down does not stall another', async () => {
+    await seed(3);
+    await exportAuditTrail(recorder(), { endpoint: 'http://a', resource });
+
+    const b = recorder();
+    const result = await exportAuditTrail(b, { endpoint: 'http://b', resource });
+
+    expect(result.sent).toBe(3);
+  });
+
+  it('respects the batch size', async () => {
+    await seed(5);
+    const exp = recorder();
+
+    await exportAuditTrail(exp, { endpoint: 'http://c', resource, batchSize: 2 });
+
+    expect(exp.seen.map((b) => b.records.length)).toEqual([2, 2, 1]);
+  });
+
+  it('carries the resource on every batch, so a collector can tell hosts apart', async () => {
+    await seed(3);
+    const exp = recorder();
+
+    await exportAuditTrail(exp, { endpoint: 'http://c', resource, batchSize: 2 });
+
+    expect(exp.seen.every((b) => b.resource.host === 'h1')).toBe(true);
+  });
+
+  it('stops on an abort signal without losing its place', async () => {
+    await seed(4);
+    const ac = new AbortController();
+    ac.abort();
+
+    const result = await exportAuditTrail(recorder(), {
+      endpoint: 'http://c',
+      resource,
+      signal: ac.signal,
+    });
+
+    expect(result.stoppedBecause).toBe('aborted');
+    expect(result.sent).toBe(0);
+  });
+});
+
+describe('pendingExportCount', () => {
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'moxxy-export-'));
+    prevHome = process.env.MOXXY_HOME;
+    process.env.MOXXY_HOME = home;
+    resetAuditHeadForTests();
+  });
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.MOXXY_HOME;
+    else process.env.MOXXY_HOME = prevHome;
+    resetAuditHeadForTests();
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  it('counts what a run would send, without sending it', async () => {
+    for (let i = 0; i < 4; i++) {
+      await appendAuditRecord({
+        ts: 1_700_000_000_000,
+        sessionId: 's1' as never,
+        turnId: 't1' as never,
+        action: 'prompt',
+        eventType: 'user_prompt',
+      });
+    }
+
+    expect(await pendingExportCount('rec', 'http://c')).toBe(4);
+
+    await exportAuditTrail(recorder(), { endpoint: 'http://c', resource });
+
+    expect(await pendingExportCount('rec', 'http://c')).toBe(0);
+  });
+});

--- a/packages/core/src/audit/export.ts
+++ b/packages/core/src/audit/export.ts
@@ -1,0 +1,153 @@
+import { promises as fs } from 'node:fs';
+import { createHash } from 'node:crypto';
+import * as path from 'node:path';
+import type {
+  AuditExportBatch,
+  AuditExportResource,
+  AuditExporterDef,
+  AuditRecord,
+} from '@moxxy/sdk';
+import { auditDir, listAuditDays, readAuditDay } from './jsonl-audit-sink.js';
+
+/**
+ * How far this destination has been caught up to.
+ *
+ * Per destination, not per machine: two collectors are allowed to be at
+ * different points, and one being down must not stall the other.
+ */
+export interface ExportCheckpoint {
+  /** Last fully or partially exported day, `YYYY-MM-DD`. */
+  readonly day: string;
+  /** Highest `seq` within that day known to be durably accepted. */
+  readonly seq: number;
+}
+
+export interface ExportResult {
+  readonly sent: number;
+  readonly batches: number;
+  readonly checkpoint: ExportCheckpoint | null;
+  /** Set when the run stopped early. The checkpoint still reflects what landed. */
+  readonly stoppedBecause?: string;
+}
+
+export interface ExportOptions {
+  readonly endpoint: string;
+  readonly resource: AuditExportResource;
+  readonly settings?: Readonly<Record<string, unknown>>;
+  readonly batchSize?: number;
+  readonly checkpointDir?: string;
+  readonly signal?: AbortSignal;
+}
+
+const DEFAULT_BATCH = 200;
+
+const checkpointPath = (dir: string, exporter: string, endpoint: string): string =>
+  path.join(
+    dir,
+    `.export-${exporter}-${createHash('sha256').update(endpoint).digest('hex').slice(0, 16)}.json`,
+  );
+
+export async function readCheckpoint(
+  exporter: string,
+  endpoint: string,
+  dir = auditDir(),
+): Promise<ExportCheckpoint | null> {
+  try {
+    const raw = JSON.parse(await fs.readFile(checkpointPath(dir, exporter, endpoint), 'utf8'));
+    if (typeof raw?.day !== 'string' || typeof raw?.seq !== 'number') return null;
+    return { day: raw.day, seq: raw.seq };
+  } catch {
+    return null;
+  }
+}
+
+async function writeCheckpoint(
+  exporter: string,
+  endpoint: string,
+  dir: string,
+  cp: ExportCheckpoint,
+): Promise<void> {
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 }).catch(() => undefined);
+  await fs.writeFile(checkpointPath(dir, exporter, endpoint), JSON.stringify(cp), { mode: 0o600 });
+}
+
+/**
+ * Ship everything recorded since the last checkpoint.
+ *
+ * Ordering is the whole design. The checkpoint is written only AFTER `send`
+ * resolves, so a crash or a failed export re-offers the batch rather than
+ * skipping it. Duplicates are possible and deliberate: every record carries a
+ * chain hash a collector can deduplicate on, so at-least-once with a stable id
+ * is the right trade against at-most-once with silent gaps.
+ *
+ * Stops at the first failing batch instead of skipping ahead. Continuing past a
+ * failure would advance the checkpoint over records that never landed, which is
+ * exactly the invisible hole this exists to avoid.
+ */
+export async function exportAuditTrail(
+  exporter: AuditExporterDef,
+  opts: ExportOptions,
+): Promise<ExportResult> {
+  const dir = opts.checkpointDir ?? auditDir();
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH;
+  const start = await readCheckpoint(exporter.name, opts.endpoint, dir);
+
+  const days = (await listAuditDays()).filter((d) => !start || d >= start.day).sort();
+  let checkpoint = start;
+  let sent = 0;
+  let batches = 0;
+
+  for (const day of days) {
+    const all = await readAuditDay(day);
+    // Only the checkpoint's own day is partially consumed. A later day starts
+    // whole, and re-reading the boundary day is what makes a same-day restart
+    // resume rather than replay.
+    const pending =
+      start && day === start.day ? all.filter((r) => r.seq > start.seq) : all;
+
+    for (let i = 0; i < pending.length; i += batchSize) {
+      if (opts.signal?.aborted) {
+        return { sent, batches, checkpoint, stoppedBecause: 'aborted' };
+      }
+      const slice = pending.slice(i, i + batchSize);
+      const batch: AuditExportBatch = { records: slice, resource: opts.resource };
+      try {
+        await exporter.send(batch, {
+          endpoint: opts.endpoint,
+          settings: opts.settings ?? {},
+          ...(opts.signal ? { signal: opts.signal } : {}),
+        });
+      } catch (err) {
+        return {
+          sent,
+          batches,
+          checkpoint,
+          stoppedBecause: err instanceof Error ? err.message : String(err),
+        };
+      }
+      const last = slice[slice.length - 1]!;
+      checkpoint = { day, seq: last.seq };
+      await writeCheckpoint(exporter.name, opts.endpoint, dir, checkpoint);
+      sent += slice.length;
+      batches += 1;
+    }
+  }
+
+  return { sent, batches, checkpoint };
+}
+
+/** Records a run would ship right now, without shipping them. For `--dry-run`. */
+export async function pendingExportCount(
+  exporter: string,
+  endpoint: string,
+  dir = auditDir(),
+): Promise<number> {
+  const start = await readCheckpoint(exporter, endpoint, dir);
+  const days = (await listAuditDays()).filter((d) => !start || d >= start.day);
+  let n = 0;
+  for (const day of days) {
+    const all: AuditRecord[] = await readAuditDay(day);
+    n += start && day === start.day ? all.filter((r) => r.seq > start.seq).length : all.length;
+  }
+  return n;
+}

--- a/packages/core/src/audit/export.ts
+++ b/packages/core/src/audit/export.ts
@@ -136,18 +136,31 @@ export async function exportAuditTrail(
   return { sent, batches, checkpoint };
 }
 
-/** Records a run would ship right now, without shipping them. For `--dry-run`. */
+/**
+ * Records a run would ship right now, without shipping them. For `--dry-run`
+ * and for the doctor row.
+ *
+ * `excludeSessionId` exists for the diagnostic case: booting a session to ask
+ * the question writes a record of its own, so a check that counted it could
+ * never report "up to date", and a check that always warns teaches people to
+ * ignore it.
+ */
 export async function pendingExportCount(
   exporter: string,
   endpoint: string,
   dir = auditDir(),
+  excludeSessionId?: string,
 ): Promise<number> {
   const start = await readCheckpoint(exporter, endpoint, dir);
   const days = (await listAuditDays()).filter((d) => !start || d >= start.day);
   let n = 0;
   for (const day of days) {
     const all: AuditRecord[] = await readAuditDay(day);
-    n += start && day === start.day ? all.filter((r) => r.seq > start.seq).length : all.length;
+    const afterCheckpoint =
+      start && day === start.day ? all.filter((r) => r.seq > start.seq) : all;
+    n += excludeSessionId
+      ? afterCheckpoint.filter((r) => String(r.sessionId) !== excludeSessionId).length
+      : afterCheckpoint.length;
   }
   return n;
 }

--- a/packages/core/src/audit/otlp-exporter.test.ts
+++ b/packages/core/src/audit/otlp-exporter.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AuditExportBatch, AuditRecord } from '@moxxy/sdk';
+import { otlpAuditExporter } from './otlp-exporter.js';
+
+const record = (over: Partial<AuditRecord> = {}): AuditRecord =>
+  ({
+    ts: 1_700_000_000_000,
+    sessionId: 's1',
+    turnId: 't1',
+    action: 'tool.request',
+    eventType: 'tool_call_requested',
+    seq: 0,
+    prevHash: null,
+    hash: 'abc123',
+    ...over,
+  }) as AuditRecord;
+
+const batch = (records: AuditRecord[]): AuditExportBatch => ({
+  records,
+  resource: { host: 'workstation-7', cliVersion: '1.2.3' },
+});
+
+const ctx = { endpoint: 'https://collector/v1/logs', settings: {} };
+
+const stubFetch = (res: Partial<Response> & { body?: string }) => {
+  const fn = vi.fn(async () => ({
+    ok: res.ok ?? true,
+    status: res.status ?? 200,
+    text: async () => res.body ?? '',
+  }));
+  vi.stubGlobal('fetch', fn);
+  return fn;
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('otlpAuditExporter', () => {
+  it('posts OTLP log records carrying the chain hash as a dedup key', async () => {
+    const fetchFn = stubFetch({ ok: true });
+
+    await otlpAuditExporter.send(batch([record()]), ctx);
+
+    const body = JSON.parse(fetchFn.mock.calls[0]![1]!.body as string);
+    const log = body.resourceLogs[0].scopeLogs[0].logRecords[0];
+    const attrs = Object.fromEntries(
+      log.attributes.map((a: { key: string; value: Record<string, unknown> }) => [
+        a.key,
+        Object.values(a.value)[0],
+      ]),
+    );
+
+    expect(attrs['moxxy.hash']).toBe('abc123');
+    expect(attrs['moxxy.action']).toBe('tool.request');
+    expect(log.timeUnixNano).toBe('1700000000000000000');
+  });
+
+  it('identifies the host in resource attributes', async () => {
+    const fetchFn = stubFetch({ ok: true });
+
+    await otlpAuditExporter.send(batch([record()]), ctx);
+
+    const body = JSON.parse(fetchFn.mock.calls[0]![1]!.body as string);
+    const attrs = Object.fromEntries(
+      body.resourceLogs[0].resource.attributes.map(
+        (a: { key: string; value: Record<string, unknown> }) => [a.key, Object.values(a.value)[0]],
+      ),
+    );
+
+    expect(attrs['host.name']).toBe('workstation-7');
+    expect(attrs['service.name']).toBe('moxxy');
+    expect(attrs['service.version']).toBe('1.2.3');
+  });
+
+  it('raises the severity of a denial so a collector can route on it', async () => {
+    const fetchFn = stubFetch({ ok: true });
+
+    await otlpAuditExporter.send(
+      batch([record({ action: 'tool.denied', eventType: 'tool_call_denied' })]),
+      ctx,
+    );
+
+    const body = JSON.parse(fetchFn.mock.calls[0]![1]!.body as string);
+    expect(body.resourceLogs[0].scopeLogs[0].logRecords[0].severityText).toBe('WARN');
+  });
+
+  it('throws on an HTTP error so the checkpoint does not advance', async () => {
+    stubFetch({ ok: false, status: 503 });
+
+    await expect(otlpAuditExporter.send(batch([record()]), ctx)).rejects.toThrow('503');
+  });
+
+  it('throws when a 200 response reports rejected records', async () => {
+    // The subtle one: OTLP can accept the REQUEST and still discard records
+    // inside it. Treating that as success would checkpoint past data the
+    // collector threw away.
+    stubFetch({ ok: true, body: JSON.stringify({ partialSuccess: { rejectedLogRecords: 3 } }) });
+
+    await expect(otlpAuditExporter.send(batch([record()]), ctx)).rejects.toThrow('rejected 3');
+  });
+
+  it('accepts a 200 that reports zero rejections', async () => {
+    stubFetch({ ok: true, body: JSON.stringify({ partialSuccess: { rejectedLogRecords: 0 } }) });
+
+    await expect(otlpAuditExporter.send(batch([record()]), ctx)).resolves.toBeUndefined();
+  });
+
+  it('does not treat an unparseable body as a rejection', async () => {
+    stubFetch({ ok: true, body: 'OK' });
+
+    await expect(otlpAuditExporter.send(batch([record()]), ctx)).resolves.toBeUndefined();
+  });
+
+  it('sends configured headers, so an authenticated collector is reachable', async () => {
+    const fetchFn = stubFetch({ ok: true });
+
+    await otlpAuditExporter.send(batch([record()]), {
+      ...ctx,
+      settings: { headers: { Authorization: 'Bearer t0ken' } },
+    });
+
+    const init = fetchFn.mock.calls[0]![1] as { headers: Record<string, string> };
+    expect(init.headers.authorization).toBe('Bearer t0ken');
+    expect(init.headers['content-type']).toBe('application/json');
+  });
+
+  it('redacts a secret that reached the trail, at the boundary it leaves the machine', async () => {
+    const fetchFn = stubFetch({ ok: true });
+
+    await otlpAuditExporter.send(
+      batch([record({ detail: { api_key: 'sk-ant-secret-value', tool: 'Read' } })]),
+      ctx,
+    );
+
+    const raw = fetchFn.mock.calls[0]![1]!.body as string;
+    expect(raw).not.toContain('sk-ant-secret-value');
+    expect(raw).toContain('Read');
+  });
+});

--- a/packages/core/src/audit/otlp-exporter.ts
+++ b/packages/core/src/audit/otlp-exporter.ts
@@ -1,0 +1,146 @@
+import type { AuditExportBatch, AuditExportContext, AuditRecord } from '@moxxy/sdk';
+import { defineAuditExporter, redactSecrets } from '@moxxy/sdk';
+
+/**
+ * OTLP/HTTP logs, spoken directly over `fetch`.
+ *
+ * No `@opentelemetry/*` dependency on purpose. The wire format is a stable,
+ * documented JSON shape and this is one POST; pulling in the SDK would add
+ * megabytes to a CLI whose bundle budget is enforced in `tsup.config.ts`, to
+ * gain a client we would use one function of.
+ *
+ * Audit records map to LOGS rather than traces. A trace answers "how did this
+ * request flow"; an audit trail answers "what was done, by whom, and was it
+ * allowed", which is a log with attributes. Modelling it as spans would force a
+ * parent/child shape onto records that are a flat sequence.
+ */
+const OTLP_TIMEOUT_MS = 30_000;
+
+type AnyValue = { stringValue: string } | { intValue: string } | { boolValue: boolean };
+
+const value = (v: unknown): AnyValue => {
+  if (typeof v === 'boolean') return { boolValue: v };
+  if (typeof v === 'number' && Number.isInteger(v)) return { intValue: String(v) };
+  if (typeof v === 'string') return { stringValue: v };
+  return { stringValue: JSON.stringify(v) };
+};
+
+const attr = (key: string, v: unknown): { key: string; value: AnyValue } => ({
+  key,
+  value: value(v),
+});
+
+/**
+ * Denials and errors are the rows a reviewer filters for, so they carry a
+ * severity that a collector can route on rather than being flattened to INFO
+ * with everything else.
+ */
+function severityOf(record: AuditRecord): { number: number; text: string } {
+  if (record.action === 'error') return { number: 17, text: 'ERROR' };
+  if (record.action === 'tool.denied') return { number: 13, text: 'WARN' };
+  return { number: 9, text: 'INFO' };
+}
+
+function logRecord(record: AuditRecord): unknown {
+  const sev = severityOf(record);
+  const attrs = [
+    attr('moxxy.action', record.action),
+    attr('moxxy.event_type', record.eventType),
+    attr('moxxy.session_id', String(record.sessionId)),
+    attr('moxxy.turn_id', String(record.turnId)),
+    attr('moxxy.seq', record.seq),
+    // The chain hash is the record's stable identity. Export is at-least-once,
+    // so a collector needs this to deduplicate a replayed batch.
+    attr('moxxy.hash', record.hash),
+    attr('moxxy.prev_hash', record.prevHash ?? ''),
+  ];
+  if (record.actor) {
+    attrs.push(attr('enduser.id', record.actor.id));
+    attrs.push(attr('moxxy.actor.issuer', record.actor.issuer));
+    attrs.push(attr('moxxy.actor.kind', record.actor.kind));
+  }
+  // Redacted again on the way out. The local sink already redacts, but this is
+  // the boundary where records leave the machine, and a detail added by a
+  // future sink that forgot would leak here rather than at home.
+  const detail = redactSecrets(record.detail ?? {}) as Record<string, unknown>;
+  for (const [k, v] of Object.entries(detail)) {
+    attrs.push(attr(`moxxy.detail.${k}`, v));
+  }
+
+  return {
+    timeUnixNano: String(BigInt(record.ts) * 1_000_000n),
+    severityNumber: sev.number,
+    severityText: sev.text,
+    body: { stringValue: record.action },
+    attributes: attrs,
+  };
+}
+
+function payload(batch: AuditExportBatch): unknown {
+  const res = batch.resource;
+  const resourceAttrs = [
+    attr('service.name', 'moxxy'),
+    attr('service.version', res.cliVersion),
+    attr('host.name', res.host),
+  ];
+  if (res.principal) resourceAttrs.push(attr('enduser.id', res.principal.id));
+
+  return {
+    resourceLogs: [
+      {
+        resource: { attributes: resourceAttrs },
+        scopeLogs: [
+          {
+            scope: { name: 'moxxy.audit' },
+            logRecords: batch.records.map(logRecord),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export const otlpAuditExporter = defineAuditExporter({
+  name: 'otlp',
+  description: 'OTLP/HTTP logs to an OpenTelemetry collector',
+  async send(batch: AuditExportBatch, ctx: AuditExportContext): Promise<void> {
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    const configured = ctx.settings.headers;
+    if (configured && typeof configured === 'object') {
+      for (const [k, v] of Object.entries(configured as Record<string, unknown>)) {
+        if (typeof v === 'string') headers[k.toLowerCase()] = v;
+      }
+    }
+
+    const deadline = AbortSignal.timeout(OTLP_TIMEOUT_MS);
+    const signal = ctx.signal ? AbortSignal.any([ctx.signal, deadline]) : deadline;
+
+    const res = await fetch(ctx.endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload(batch)),
+      signal,
+    });
+
+    if (!res.ok) {
+      throw new Error(`collector rejected the batch: HTTP ${res.status}`);
+    }
+
+    // OTLP can accept the REQUEST and still reject records inside it. Treating
+    // a 200 as success here would advance the checkpoint past records the
+    // collector threw away, which is the exact silent gap this must not create.
+    const text = await res.text().catch(() => '');
+    if (text) {
+      try {
+        const rejected = JSON.parse(text)?.partialSuccess?.rejectedLogRecords;
+        if (rejected !== undefined && Number(rejected) > 0) {
+          throw new Error(`collector rejected ${rejected} record(s) of ${batch.records.length}`);
+        }
+      } catch (err) {
+        // A body we cannot parse is not evidence of rejection; only an explicit
+        // rejectedLogRecords count is. Rethrow our own error, ignore JSON noise.
+        if (err instanceof Error && err.message.startsWith('collector rejected')) throw err;
+      }
+    }
+  },
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -129,6 +129,16 @@ export { createLogger, silentLogger, type Logger, type LogLevel } from './logger
 // Audit trail (see packages/core/src/audit).
 export { attachAuditSink, type AttachAuditOptions, type AuditHandle } from './audit/attach.js';
 export { chainRecord, verifyChain, type ChainVerdict } from './audit/chain.js';
+export {
+  exportAuditTrail,
+  pendingExportCount,
+  readCheckpoint,
+  type ExportCheckpoint,
+  type ExportOptions,
+  type ExportResult,
+} from './audit/export.js';
+export { otlpAuditExporter } from './audit/otlp-exporter.js';
+export { AuditExporterRegistry } from './registries/audit-exporters.js';
 export { projectAuditRecord, type AuditProjectionOptions } from './audit/project.js';
 export {
   auditDir,

--- a/packages/core/src/plugins/host-options.ts
+++ b/packages/core/src/plugins/host-options.ts
@@ -25,6 +25,7 @@ import type { EmbedderRegistry } from '../registries/embedders.js';
 import type { IsolatorRegistry } from '../registries/isolators.js';
 import type { WorkflowExecutorRegistry } from '../registries/workflow-executors.js';
 import type { EventStoreRegistry } from '../registries/event-stores.js';
+import type { AuditExporterRegistry } from '../registries/audit-exporters.js';
 import type { AuditSinkRegistry } from '../registries/audit-sinks.js';
 import type { SecretProviderRegistry } from '../registries/secret-providers.js';
 import type { ReflectorRegistry } from '../registries/reflectors.js';
@@ -52,6 +53,7 @@ export interface PluginHostOptions {
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
   readonly auditSinks: AuditSinkRegistry;
+  readonly auditExporters: AuditExporterRegistry;
   readonly secretProviders: SecretProviderRegistry;
   readonly reflectors: ReflectorRegistry;
   readonly requirements: RequirementRegistry;

--- a/packages/core/src/plugins/registry-kinds.test.ts
+++ b/packages/core/src/plugins/registry-kinds.test.ts
@@ -36,6 +36,7 @@ import { SynthesizerRegistry } from '../registries/synthesizers.js';
 import { EmbedderRegistry } from '../registries/embedders.js';
 import { IsolatorRegistry } from '../registries/isolators.js';
 import { WorkflowExecutorRegistry } from '../registries/workflow-executors.js';
+import { AuditExporterRegistry } from '../registries/audit-exporters.js';
 import { AuditSinkRegistry } from '../registries/audit-sinks.js';
 import { SecretProviderRegistry } from '../registries/secret-providers.js';
 import { EventStoreRegistry } from '../registries/event-stores.js';
@@ -96,6 +97,7 @@ const everyKindPlugin = definePlugin({
       open: () => ({ write: async () => true, close: async () => {} }),
     },
   ],
+  auditExporters: [{ name: 'ae-1', send: async () => {} }],
   secretProviders: [
     {
       name: 'sp-1',
@@ -125,6 +127,7 @@ function makeHost() {
     workflowExecutors: new WorkflowExecutorRegistry(),
     eventStores: new EventStoreRegistry(),
     auditSinks: new AuditSinkRegistry(),
+    auditExporters: new AuditExporterRegistry(),
     secretProviders: new SecretProviderRegistry(),
     reflectors: new ReflectorRegistry(),
   };
@@ -167,6 +170,7 @@ function makeHost() {
     workflowExecutor: registries.workflowExecutors,
     eventStore: registries.eventStores,
     auditSink: registries.auditSinks,
+    auditExporter: registries.auditExporters,
     secretProvider: registries.secretProviders,
     reflector: registries.reflectors,
   };

--- a/packages/core/src/plugins/registry-kinds.ts
+++ b/packages/core/src/plugins/registry-kinds.ts
@@ -17,6 +17,7 @@ import type {
   TunnelProviderDef,
   WorkflowExecutorDef,
   AuditSinkDef,
+  AuditExporterDef,
   SecretProviderDef,
   EventStoreDef,
   ReflectorDef,
@@ -48,6 +49,7 @@ export interface RegistryNameRecord {
   readonly workflowExecutorNames: ReadonlyArray<string>;
   readonly eventStoreNames: ReadonlyArray<string>;
   readonly auditSinkNames: ReadonlyArray<string>;
+  readonly auditExporterNames: ReadonlyArray<string>;
   readonly secretProviderNames: ReadonlyArray<string>;
   readonly reflectorNames: ReadonlyArray<string>;
 }
@@ -261,6 +263,16 @@ export const REGISTRY_KINDS: ReadonlyArray<RegistryKind<unknown>> = [
     register: (o, a: AuditSinkDef) => o.auditSinks.register(a),
     unregister: (o, n) => o.auditSinks.unregister(n),
   } satisfies RegistryKind<AuditSinkDef>,
+  {
+    kind: 'auditExporter',
+    recordField: 'auditExporterNames',
+    defs: (p) => p.auditExporters ?? [],
+    nameOf: (e: AuditExporterDef) => e.name,
+    // Same posture as auditSink: an exporter exists to send recorded actions
+    // off the machine, so discovery must not activate one. `audit.export` does.
+    register: (o, e: AuditExporterDef) => o.auditExporters.register(e),
+    unregister: (o, n) => o.auditExporters.unregister(n),
+  } satisfies RegistryKind<AuditExporterDef>,
   {
     kind: 'secretProvider',
     recordField: 'secretProviderNames',

--- a/packages/core/src/registries/audit-exporters.ts
+++ b/packages/core/src/registries/audit-exporters.ts
@@ -1,0 +1,20 @@
+import type { AuditExporterDef } from '@moxxy/sdk';
+import { ActiveDefRegistry } from './active-def-registry.js';
+
+/**
+ * The single-active AuditExporter registry.
+ *
+ * Same trust posture as {@link AuditSinkRegistry}, and for the same reason: an
+ * exporter's entire purpose is to send recorded actions off the machine, so a
+ * discovered one activating itself would be an exfiltration path wearing a
+ * compliance hat. Throw-on-duplicate, no auto-activation; the operator names
+ * one in `audit.export.exporter`.
+ *
+ * Unlike the sink registry there is no protected floor, because the floor for
+ * exporting is "do not export".
+ */
+export class AuditExporterRegistry extends ActiveDefRegistry<AuditExporterDef> {
+  constructor() {
+    super({ noun: 'AuditExporter' });
+  }
+}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -36,6 +36,7 @@ import { EmbedderRegistry } from './registries/embedders.js';
 import { IsolatorRegistry } from './registries/isolators.js';
 import { WorkflowExecutorRegistry } from './registries/workflow-executors.js';
 import { EventStoreRegistry } from './registries/event-stores.js';
+import { AuditExporterRegistry } from './registries/audit-exporters.js';
 import { AuditSinkRegistry } from './registries/audit-sinks.js';
 import { SecretProviderRegistry } from './registries/secret-providers.js';
 import { jsonlAuditSink } from './audit/jsonl-audit-sink.js';
@@ -143,6 +144,7 @@ export class Session implements ClientSession, SessionRuntime {
   readonly workflowExecutors: WorkflowExecutorRegistry;
   readonly eventStores: EventStoreRegistry;
   readonly auditSinks: AuditSinkRegistry;
+  readonly auditExporters: AuditExporterRegistry;
   /**
    * Resolve a named secret, through whatever SecretProvider the host wired.
    * The same function tool handlers receive as `ctx.getSecret`; exposed here so
@@ -299,6 +301,7 @@ export class Session implements ClientSession, SessionRuntime {
     // behind the event log always exists and can be swapped but never removed.
     this.eventStores.register(jsonlEventStore, { protected: true });
     this.auditSinks = new AuditSinkRegistry();
+    this.auditExporters = new AuditExporterRegistry();
     // The hash-chained local sink is the protected floor. A discovered plugin's
     // sink registers alongside it but never auto-activates: a sink's whole job
     // is to send recorded actions somewhere else, so silent adoption would be
@@ -359,6 +362,7 @@ export class Session implements ClientSession, SessionRuntime {
       workflowExecutors: this.workflowExecutors,
       eventStores: this.eventStores,
       auditSinks: this.auditSinks,
+      auditExporters: this.auditExporters,
       secretProviders: this.secretProviders,
       reflectors: this.reflectors,
       requirements: this.requirements,

--- a/packages/sdk/src/audit-export.ts
+++ b/packages/sdk/src/audit-export.ts
@@ -1,0 +1,57 @@
+import type { AuditRecord } from './audit.js';
+import type { Principal } from './principal.js';
+
+/**
+ * Shipping the local audit trail somewhere central.
+ *
+ * Separate from `AuditSinkDef` on purpose. A sink is the WRITE path: it is
+ * handed each record as it happens. An exporter is a READER of the trail that
+ * has already been durably written, driven by a checkpoint.
+ *
+ * That split is what makes shipping survivable. A network sink has to decide,
+ * while a turn is running, what to do when the collector is down: block the
+ * turn, drop the record, or buffer it in memory and lose it on exit. An
+ * exporter has no such dilemma, because the record is already on disk in a
+ * hash-chained file. A failed export is retried from the checkpoint, and the
+ * worst case is that central visibility lags, never that the record is gone.
+ */
+export interface AuditExportResource {
+  /** Which machine. The whole point of central collection is telling them apart. */
+  readonly host: string;
+  readonly cliVersion: string;
+  /** Whoever the surface could establish was acting; absent on an unattributed host. */
+  readonly principal?: Principal;
+}
+
+export interface AuditExportBatch {
+  readonly records: ReadonlyArray<AuditRecord>;
+  readonly resource: AuditExportResource;
+}
+
+export interface AuditExportContext {
+  /** Destination, as configured. Exporter-defined; an endpoint URL for OTLP. */
+  readonly endpoint: string;
+  /** Exporter-specific settings from `audit.export`, already placeholder-resolved. */
+  readonly settings: Readonly<Record<string, unknown>>;
+  readonly signal?: AbortSignal;
+}
+
+export interface AuditExporterDef {
+  readonly name: string;
+  readonly description?: string;
+  /**
+   * Ship one batch.
+   *
+   * THE CONTRACT: resolving means the destination has DURABLY accepted these
+   * records, because the checkpoint advances on resolve and those records are
+   * never offered again. An exporter that resolves on "request sent" turns a
+   * collector-side rejection into silent data loss. When in doubt, throw:
+   * re-sending a batch is cheap and records carry a hash the collector can
+   * deduplicate on, whereas a skipped batch is unrecoverable.
+   */
+  send(batch: AuditExportBatch, ctx: AuditExportContext): Promise<void>;
+}
+
+export function defineAuditExporter(def: AuditExporterDef): AuditExporterDef {
+  return def;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -49,6 +49,14 @@ export { samePrincipal, formatPrincipal } from './principal.js';
 
 export { verifyEd25519 } from './signature.js';
 
+export type {
+  AuditExporterDef,
+  AuditExportBatch,
+  AuditExportContext,
+  AuditExportResource,
+} from './audit-export.js';
+export { defineAuditExporter } from './audit-export.js';
+
 // Audit trail: the tamper-evident receipt, distinct from the event log.
 export type {
   AuditAction,

--- a/packages/sdk/src/plugin.ts
+++ b/packages/sdk/src/plugin.ts
@@ -18,6 +18,7 @@ import type { TunnelProviderDef } from './tunnel.js';
 import type { WorkflowExecutorDef } from './workflow.js';
 import type { EventStoreDef } from './event-store.js';
 import type { AuditSinkDef } from './audit.js';
+import type { AuditExporterDef } from './audit-export.js';
 import type { SecretProviderDef } from './secret-provider.js';
 import type { ReflectorDef } from './reflector.js';
 
@@ -59,6 +60,7 @@ export interface PluginSpec {
   /** Audit-trail sinks (syslog, OTel, S3, webhook). Registered alongside the
    *  protected local floor; never auto-activated, see registry-kinds. */
   readonly auditSinks?: ReadonlyArray<AuditSinkDef>;
+  readonly auditExporters?: ReadonlyArray<AuditExporterDef>;
   /** External secret stores (Vault, AWS/Azure, 1Password). Registered
    *  alongside the vault floor; never auto-activated. */
   readonly secretProviders?: ReadonlyArray<SecretProviderDef>;


### PR DESCRIPTION
The local trail answers "what happened on this machine". A fleet needs one place to ask, and a chain head the workstation cannot rewrite.

```yaml
audit:
  enabled: true
  export:
    endpoint: https://otel-collector.internal:4318/v1/logs
    headers: { authorization: "${vault:OTEL_TOKEN}" }
```

```sh
moxxy security audit-export --dry-run
moxxy security audit-export      # exits 1 when it could not drain
```

### The design decision worth reviewing

An exporter is a **reader** of the already-written trail driven by a checkpoint, not a second write path. A network *sink* would have to decide, mid-turn, what to do when the collector is down: block the turn, drop the record, or buffer in memory and lose it on exit. An exporter has no such dilemma, because the record is already on disk in a hash-chained file. Worst case is that central visibility lags, never that a record is gone.

Consequences, all tested:

- **At least once, never at most once.** The checkpoint advances only after `send` resolves, so a crash or failure re-offers the batch. Records carry their chain hash; deduplicate on `moxxy.hash`.
- **A 200 with `partialSuccess.rejectedLogRecords` is a failure.** OTLP can accept the request and discard records inside it; treating that as success would checkpoint past data the collector threw away.
- **Stops at the first failing batch** instead of skipping ahead, which would advance the checkpoint over records that never landed.
- **Per destination checkpoints**, so one collector being down does not stall another.

OTLP logs rather than traces: an audit record is a flat statement of what was done and whether it was allowed, not a request flow. Spoken over plain `fetch` with no `@opentelemetry/*` dependency, which would have blown the CLI bundle budget the tsup config enforces.

`auditExporter` is a new registry kind (lockstep table, fixtures, and `CATEGORY_REGISTRIES` all updated), so another destination is a plugin. Like audit sinks, a discovered exporter never activates on its own: `moxxy plugins defaults` shows `auditExporter active=(none)`.

### One fix worth calling out

The command deliberately boots **no session** and needs no model provider. My first version used `probeSession` and failed with `PROVIDER_NOT_CONFIGURED` on a clean machine, which would have broken a compliance cron the moment an API key expired. Booting also appends a fresh record to the very trail being exported. A session is now paid for only to resolve a plugin-contributed exporter by name.

### Verified

Full workspace suite green (7448 tests, exit 0); affected packages also run with `--force`. Every guarantee was mutation-tested by breaking the code and confirming the test fails: advancing the checkpoint on a throw, checkpointing before sending, ignoring the checkpoint, treating partial rejection as success, and dropping outbound redaction.

End-to-end against a real HTTP collector: correct batching (3/3/1), an idempotent rerun, then a 503 run and a partial-rejection run, after which a healthy collector still received all six records with exit 1 reported for both failures.