### PR TITLE
test: make the screenshot and whisper suites deterministic

### DIFF
--- a/.changeset/hermetic-tests.md
+++ b/.changeset/hermetic-tests.md
@@ -1,0 +1,10 @@
+---
+'@moxxy/plugin-computer-control': patch
+'@moxxy/plugin-stt-whisper-codex': patch
+---
+
+Make two flaky tests deterministic.
+
+The screenshot test shelled out to the real macOS `screencapture`, so it needed a display, the host to be macOS, and Screen Recording permission. Worse, it accepted a thrown error as a pass, so on any machine lacking that permission (every CI runner) it verified nothing while still reporting green. The process layer is now faked, so the contract it exists to protect (returning `{ mediaType, base64 }` rather than a stringified blob the model cannot decode) is asserted on every platform, along with the capture-failure, byte-cap, platform-gate and temp-file-cleanup paths that had no cover at all.
+
+The whisper test harness closed its HTTP servers with `close()` alone, which stops new connections but leaves a keep-alive socket holding the callback pending. `closeAllConnections()` now runs first. This is the most likely mechanism behind the occasional "all tests pass, exit 1" on that package, but that failure never reproduced across roughly ten runs and CI, so it is hardening rather than a proven fix.

--- a/packages/plugin-computer-control/src/tools.test.ts
+++ b/packages/plugin-computer-control/src/tools.test.ts
@@ -77,40 +77,6 @@ describe('@moxxy/plugin-computer-control schemas', () => {
     }
   });
 
-  it('screenshot returns an image-shaped result ({ mediaType, base64 }), never a stringified blob', async () => {
-    // The SDK's tool_result projection emits a provider `image` ContentBlock
-    // ONLY when the result object carries a string `mediaType` + `base64`; any
-    // other shape falls through to JSON.stringify and reaches the model as
-    // undecodable base64 TEXT. Assert the handler honors that contract.
-    if (process.platform === 'darwin') {
-      // On a host without Screen Recording permission (typical CI) the handler
-      // throws a MoxxyError instead of capturing — also acceptable; the ONLY
-      // forbidden outcome is returning a (stringified) blob the model can't see.
-      let result: unknown;
-      try {
-        // Tiny region keeps the capture cheap and well under the byte cap.
-        result = await screenshotTool.handler(
-          { region: { x: 0, y: 0, width: 1, height: 1 } },
-          fakeCtx,
-        );
-      } catch (err) {
-        expect(err).toBeInstanceOf(MoxxyError);
-        return;
-      }
-      // Must be a structured object, NOT a string (a stringified blob).
-      expect(typeof result).toBe('object');
-      expect(result).not.toBeNull();
-      const r = result as { mediaType?: unknown; base64?: unknown };
-      expect(typeof r.mediaType).toBe('string');
-      expect(r.mediaType as string).toMatch(/^image\//);
-      expect(typeof r.base64).toBe('string');
-      expect((r.base64 as string).length).toBeGreaterThan(0);
-    } else {
-      // Non-darwin: ensureDarwin rejects before any capture — still never a blob.
-      await expect(screenshotTool.handler({}, fakeCtx)).rejects.toBeInstanceOf(MoxxyError);
-    }
-  });
-
   it('every tool is permission:prompt — never auto-allowed', () => {
     const all = [
       screenshotTool,

--- a/packages/plugin-computer-control/src/tools/screenshot.test.ts
+++ b/packages/plugin-computer-control/src/tools/screenshot.test.ts
@@ -1,0 +1,137 @@
+import { promises as fs } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MoxxyError } from '@moxxy/sdk';
+
+/**
+ * Hermetic cover for the screenshot handler.
+ *
+ * The previous test shelled out to the real `screencapture`, which made it
+ * depend on the host being macOS, having a display, and having been granted
+ * Screen Recording. Worse, it accepted a thrown MoxxyError as a pass, so on any
+ * machine without that permission (every CI runner) it verified nothing while
+ * still reporting green. Faking the process layer means the contract below is
+ * actually asserted, on every platform.
+ */
+const runProcess = vi.fn();
+const ensureDarwin = vi.fn();
+
+vi.mock('../shell.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../shell.js')>();
+  return {
+    ...actual,
+    ensureDarwin: (...args: unknown[]) => ensureDarwin(...args),
+    runProcess: (...args: unknown[]) => runProcess(...args),
+  };
+});
+
+const { screenshotTool } = await import('./screenshot.js');
+
+const ctx = { signal: new AbortController().signal } as never;
+
+/** Smallest thing that is unmistakably PNG bytes; content is never decoded. */
+const PNG = Buffer.from('89504e470d0a1a0a0000000d49484452', 'hex');
+
+const ok = { exitCode: 0, stdout: '', stderr: '', timedOut: false };
+
+/** Track every temp path either command was pointed at, to assert cleanup. */
+let touched: string[] = [];
+
+const workingTools = (outBytes: Buffer = PNG): void => {
+  runProcess.mockImplementation(async (cmd: string, args: string[]) => {
+    if (cmd === 'screencapture') {
+      const target = args[args.length - 1]!;
+      touched.push(target);
+      await fs.writeFile(target, PNG);
+      return ok;
+    }
+    if (cmd === 'sips') {
+      const out = args[args.indexOf('--out') + 1]!;
+      touched.push(out);
+      await fs.writeFile(out, outBytes);
+      return ok;
+    }
+    throw new Error(`unexpected command ${cmd}`);
+  });
+};
+
+beforeEach(() => {
+  touched = [];
+  ensureDarwin.mockReset();
+  runProcess.mockReset();
+});
+afterEach(async () => {
+  for (const f of touched) await fs.rm(f, { force: true });
+});
+
+describe('computer_screenshot', () => {
+  it('returns { mediaType, base64 }, the shape the model can actually see', async () => {
+    // Load-bearing: the SDK emits a provider `image` block only for exactly
+    // this shape. Anything else is JSON.stringify'd and reaches the model as
+    // base64 TEXT it cannot decode.
+    workingTools();
+
+    const result = (await screenshotTool.handler({}, ctx)) as Record<string, unknown>;
+
+    expect(typeof result).toBe('object');
+    // jpeg is the default: much smaller, and the model reads pixels not bytes.
+    expect(result.mediaType).toBe('image/jpeg');
+    expect(typeof result.base64).toBe('string');
+    expect(result.base64).toBe(PNG.toString('base64'));
+  });
+
+  it('reports image/png when png was asked for', async () => {
+    workingTools();
+
+    const result = (await screenshotTool.handler({ format: 'png' }, ctx)) as Record<
+      string,
+      unknown
+    >;
+
+    expect(result.mediaType).toBe('image/png');
+  });
+
+  it('passes a region through to screencapture as -R', async () => {
+    workingTools();
+
+    await screenshotTool.handler({ region: { x: 1, y: 2, width: 3, height: 4 } }, ctx);
+
+    const args = runProcess.mock.calls.find((c) => c[0] === 'screencapture')![1] as string[];
+    expect(args[args.indexOf('-R') + 1]).toBe('1,2,3,4');
+  });
+
+  it('refuses on a non-darwin host rather than shelling out anyway', async () => {
+    ensureDarwin.mockImplementation(() => {
+      throw new MoxxyError({ code: 'TOOL_ERROR', message: 'darwin only' });
+    });
+
+    await expect(screenshotTool.handler({}, ctx)).rejects.toBeInstanceOf(MoxxyError);
+    expect(runProcess).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a capture failure as a MoxxyError, naming the likely cause', async () => {
+    runProcess.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '', timedOut: false });
+
+    await expect(screenshotTool.handler({}, ctx)).rejects.toThrow(/screencapture failed/);
+  });
+
+  it('refuses an image that is still over the cap after compression', async () => {
+    // Rather than hand the model megabytes it cannot use, say what to lower.
+    workingTools(Buffer.alloc(6 * 1024 * 1024, 1));
+
+    await expect(screenshotTool.handler({}, ctx)).rejects.toThrow(/exceeded/);
+  });
+
+  it('leaves no temp file behind, on success or on failure', async () => {
+    workingTools();
+    await screenshotTool.handler({}, ctx);
+
+    runProcess.mockReset();
+    workingTools(Buffer.alloc(6 * 1024 * 1024, 1));
+    await screenshotTool.handler({}, ctx).catch(() => undefined);
+
+    expect(touched.length).toBeGreaterThan(0);
+    for (const f of touched) {
+      await expect(fs.access(f)).rejects.toThrow();
+    }
+  });
+});

--- a/packages/plugin-stt-whisper-codex/src/index.test.ts
+++ b/packages/plugin-stt-whisper-codex/src/index.test.ts
@@ -67,7 +67,14 @@ async function startServer(
   const addr = server.address() as AddressInfo;
   return {
     baseUrl: `http://127.0.0.1:${addr.port}`,
-    close: () => new Promise((resolve) => server.close(() => resolve())),
+    close: () =>
+      new Promise((resolve) => {
+        // `close()` alone only stops NEW connections; a keep-alive socket the
+        // client pool is still holding keeps the callback pending, which turns
+        // a finished test into a hung or non-zero-exit run at teardown.
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
   };
 }
 


### PR DESCRIPTION
The two tests I flagged as non-deterministic earlier and had not fixed.

### Screenshot

It shelled out to the real macOS `screencapture`: needed a mac, a display, and Screen Recording permission. The bigger problem was the shape of the assertion:

```js
try { result = await screenshotTool.handler(...) }
catch (err) { expect(err).toBeInstanceOf(MoxxyError); return }   // <- passes
```

On any host without that permission, which is every CI runner, it returned early and verified nothing while reporting green. So the contract it was written to protect (returning `{ mediaType, base64 }` rather than a stringified blob the model receives as undecodable base64 text) was checked on developer machines only.

The process layer is now faked, so that contract is asserted everywhere, along with four paths that previously had no cover: capture failure, the post-compression byte cap, the platform gate, and temp-file cleanup on both success and failure.

Mutation-checked, all five caught: returning a stringified blob, ignoring a non-zero `screencapture` exit, dropping the byte cap, leaking the capture temp file, and skipping the darwin gate. The first is precisely the regression the old test named and could not have caught in CI.

### Whisper

The harness closed its test HTTP servers with `close()` alone, which stops new connections but leaves a keep-alive socket holding the callback pending. `closeAllConnections()` now runs first.

Honest caveat: this is the most likely mechanism behind the occasional "all 19 tests pass, exit 1" I reported on this package, but **that failure never reproduced** across three solo runs, three via turbo, two full uncached workspace runs, and CI on three Node versions. So treat it as hardening a known flake class, not as a proven fix. I did not want to claim otherwise.

Full workspace suite green.