### PR TITLE
feat: ToolDef.icon and tui.density

### DIFF
--- a/.changeset/tool-icon-tui-density.md
+++ b/.changeset/tool-icon-tui-density.md
@@ -1,0 +1,24 @@
+---
+'@moxxy/sdk': minor
+'@moxxy/core': minor
+'@moxxy/config': minor
+'@moxxy/cli': minor
+'@moxxy/plugin-cli': minor
+'@moxxy/tools-builtin': minor
+'@moxxy/plugin-browser': patch
+'@moxxy/plugin-terminal': patch
+'@moxxy/plugin-computer-control': patch
+'@moxxy/client-core': patch
+---
+
+Add `ToolDef.icon` and `tui.density`.
+
+**Tool icons.** A surface could only guess a tool's icon from its NAME, via a heuristic that recognised the handful of built-ins it was written against, so every plugin-contributed tool drew the same wrench with no way for its author to say otherwise. Tools now declare `icon`, the session snapshot carries it, and the desktop renders the declared choice with the old heuristic kept as a fallback.
+
+The vocabulary is closed (`ToolIcon`) rather than a free string: surfaces render wildly differently, and a name no surface owns would fall back everywhere, making the field decorative. A fixed set means each surface maps it exhaustively, and the desktop's map is typed as a total `Record` so adding a member fails to compile instead of silently drawing a wrench. That fired during development, when `copy` was rejected and `clipboard` was added deliberately.
+
+The desktop reads the map from one `session.info` fetch held in context, because a transcript can hold hundreds of tool rows and a fetching hook per row would mean hundreds of identical IPC calls per screen.
+
+**Transcript density.** `tui.density: comfortable | compact` sits next to `tui.theme` and `tui.hints`, and is togglable from `/settings`. `compact` drops the blank line between transcript entries, which is what a short split pane needs: on 24 rows, half the screen is otherwise separator. Default is unchanged. All 18 separators across the chat components route through one helper, with a test that fails naming any component that hardcodes one again, since a single stray separator would make compact look half-broken rather than absent.
+
+Also hardens `useActionCatalog`: `api()` throws synchronously when no transport is configured, which the hook's promise `.catch` could not see. Unguarded that escaped the effect and took down whatever rendered the consumer, so a component that merely enriched its output made a configured transport a hard requirement for rendering. It now degrades to the `loaded: false` state it already models.

--- a/apps/desktop/src/chat/SkillGroupView.tsx
+++ b/apps/desktop/src/chat/SkillGroupView.tsx
@@ -7,6 +7,8 @@ import {
 } from '@moxxy/chat-model';
 import { isFileDiffDisplay, type FileDiffDisplay } from '@moxxy/sdk/tool-display';
 import { Icon, type IconName } from '@moxxy/desktop-ui';
+import type { ToolIcon } from '@moxxy/sdk';
+import { useToolIcon } from './ToolIconContext';
 import { ActivityRow } from './ActivityRow';
 import { FileDiffBlock } from './blocks/FileDiffBlock';
 import { preStyle, pretty } from './blocks/block-shared';
@@ -50,7 +52,45 @@ export function statusOf(outcome: ToolCallBlockData['outcome']): 'running' | 'ok
   return outcome.ok ? 'ok' : 'error';
 }
 
-export function iconForTool(name: string): IconName {
+/**
+ * Every `ToolIcon` the SDK defines, mapped to this surface's artwork.
+ *
+ * Typed as a total Record so adding a member to `TOOL_ICONS` fails to compile
+ * here rather than silently rendering a wrench. That is the point of the closed
+ * vocabulary: a new icon is a decision made across surfaces, not a fallback.
+ */
+const TOOL_ICON_ART: Record<ToolIcon, IconName> = {
+  file: 'file',
+  folder: 'folder',
+  search: 'search',
+  edit: 'edit',
+  diff: 'diff',
+  terminal: 'terminal',
+  globe: 'globe',
+  chat: 'chat',
+  workflow: 'workflow',
+  agent: 'agent',
+  settings: 'settings',
+  lock: 'lock',
+  plug: 'plug',
+  mic: 'mic',
+  speaker: 'speaker',
+  smartphone: 'smartphone',
+  workspace: 'workspace',
+  clipboard: 'copy',
+  spark: 'spark',
+  wrench: 'wrench',
+};
+
+/**
+ * A declared icon wins; the name heuristic is only a fallback.
+ *
+ * The heuristic alone could only ever recognise the handful of built-ins it was
+ * written against, so every plugin-contributed tool drew the same wrench with
+ * no way for its author to say otherwise.
+ */
+export function iconForTool(name: string, declared?: ToolIcon): IconName {
+  if (declared && declared in TOOL_ICON_ART) return TOOL_ICON_ART[declared];
   const normalized = name.toLowerCase();
   if (normalized === 'read') return 'file';
   if (normalized === 'grep' || normalized.includes('search')) return 'search';
@@ -122,6 +162,7 @@ export function SkillGroupView({ scope }: { readonly scope: SkillScope }): JSX.E
 
 export function ToolRow({ tool }: { readonly tool: ToolRowData }): JSX.Element {
   const [open, setOpen] = useState(false);
+  const declared = useToolIcon(tool.name);
   if (isFileDiffResult(tool.outcome)) {
     const display = (tool.outcome.output as { display: FileDiffDisplay }).display;
     if (isFileDiffDisplay(display)) {
@@ -139,7 +180,7 @@ export function ToolRow({ tool }: { readonly tool: ToolRowData }): JSX.Element {
   return (
     <li className="activity-list__item" data-status={status}>
       <button type="button" className="activity-detail-row" onClick={() => setOpen((value) => !value)} aria-expanded={open}>
-        <span className="activity-detail-row__icon" aria-hidden><Icon name={iconForTool(tool.name)} size={16} /></span>
+        <span className="activity-detail-row__icon" aria-hidden><Icon name={iconForTool(tool.name, declared)} size={16} /></span>
         <span className={`activity-detail-row__label${status === 'running' ? ' activity-shimmer' : ''}`}>{toolActivityLabel(tool)}</span>
         {status === 'error' ? <span className="activity-detail-row__error">failed</span> : null}
       </button>

--- a/apps/desktop/src/chat/ToolGroupView.tsx
+++ b/apps/desktop/src/chat/ToolGroupView.tsx
@@ -6,6 +6,7 @@ import {
 } from '@moxxy/chat-model';
 import { ActivityRow } from './ActivityRow';
 import { iconForTool, statusOf, ToolRow, useActivityDisclosure, type ToolRowData } from './SkillGroupView';
+import { useToolIcon } from './ToolIconContext';
 
 function errorCount(rows: ReadonlyArray<ToolRowData>): number {
   return rows.filter((row) => statusOf(row.outcome) === 'error').length;
@@ -51,10 +52,11 @@ export function LiveToolGroupView({ block }: { readonly block: LiveToolBlockData
   const [open, toggle] = useActivityDisclosure(running);
   const errors = errorCount(rows);
   const latest = block.calls.at(-1);
+  const latestIcon = useToolIcon(latest?.request.name ?? '');
   return (
     <div className="activity-block" data-testid="block-live-tools">
       <ActivityRow
-        icon={latest ? iconForTool(latest.request.name) : 'wrench'}
+        icon={latest ? iconForTool(latest.request.name, latestIcon) : 'wrench'}
         label={buildCompactSummary(block.calls, running)}
         meta={errors > 0 ? `${errors} failed` : undefined}
         active={running}

--- a/apps/desktop/src/chat/ToolIconContext.tsx
+++ b/apps/desktop/src/chat/ToolIconContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import type { ToolIcon } from '@moxxy/sdk';
+import { useActionCatalog } from '@moxxy/client-core';
+
+/**
+ * Name to declared icon, fetched once for the whole transcript.
+ *
+ * A context rather than a hook per row: the catalog comes from a `session.info`
+ * round trip, and a transcript can hold hundreds of tool rows, so calling the
+ * fetching hook in each leaf would mean hundreds of identical IPC calls to
+ * render one screen.
+ *
+ * Empty is a valid state, not an error: every consumer falls back to the name
+ * heuristic, which is what shipped before tools could declare anything.
+ */
+const ToolIconContext = createContext<ReadonlyMap<string, ToolIcon>>(new Map());
+
+export function ToolIconProvider({
+  workspaceId,
+  children,
+}: {
+  readonly workspaceId?: string;
+  readonly children: ReactNode;
+}): JSX.Element {
+  const catalog = useActionCatalog(workspaceId);
+  const map = useMemo(() => {
+    const out = new Map<string, ToolIcon>();
+    for (const tool of catalog.tools) {
+      if (tool.icon) out.set(tool.name, tool.icon);
+    }
+    return out;
+  }, [catalog.tools]);
+  return <ToolIconContext.Provider value={map}>{children}</ToolIconContext.Provider>;
+}
+
+/** The icon a tool declared, or undefined to let the name heuristic decide. */
+export function useToolIcon(name: string): ToolIcon | undefined {
+  return useContext(ToolIconContext).get(name);
+}

--- a/apps/desktop/src/chat/Transcript.tsx
+++ b/apps/desktop/src/chat/Transcript.tsx
@@ -9,6 +9,7 @@ import {
 } from '@moxxy/chat-model';
 import { buildRenderNodes, groupToolNodes, type Extension, type RenderNode } from '@moxxy/client-core';
 import { BlockView, StreamingAssistant } from './BlockView';
+import { ToolIconProvider } from './ToolIconContext';
 import { ToolGroupView } from './ToolGroupView';
 import { ExtensionCard } from './ExtensionCard';
 import { ThinkingIndicator } from './ThinkingIndicator';
@@ -221,8 +222,11 @@ export function Transcript({
   }, [nodes, workspaceId]);
 
   return (
-    // Relative wrapper so the jump-to-latest button can float over the
-    // scroller without joining the virtualised content.
+    // One catalog fetch for the whole transcript; every tool row reads the
+    // declared icon from context rather than asking for it per row.
+    <ToolIconProvider workspaceId={workspaceId}>
+    {/* Relative wrapper so the jump-to-latest button can float over the
+        scroller without joining the virtualised content. */}
     <div style={{ position: 'relative', flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
       <Virtuoso<RenderNode>
         ref={virtuosoRef}
@@ -267,5 +271,6 @@ export function Transcript({
       />
       <JumpToLatest visible={!atBottom} unread={newBelow} onJump={jumpToLatest} />
     </div>
+    </ToolIconProvider>
   );
 }

--- a/apps/desktop/src/chat/blocks/ToolBlock.tsx
+++ b/apps/desktop/src/chat/blocks/ToolBlock.tsx
@@ -3,6 +3,7 @@ import { isFileDiffResult, type ToolCallBlockData } from '@moxxy/chat-model';
 import { isFileDiffDisplay, type FileDiffDisplay } from '@moxxy/sdk/tool-display';
 import { ActivityRow } from '../ActivityRow';
 import { iconForTool, statusOf, toolActivityLabel } from '../SkillGroupView';
+import { useToolIcon } from '../ToolIconContext';
 import { preStyle, pretty } from './block-shared';
 import { FileDiffBlock } from './FileDiffBlock';
 
@@ -12,6 +13,7 @@ export function ToolBlock({ name, input, outcome }: {
   readonly outcome: ToolCallBlockData['outcome'];
 }): JSX.Element {
   const [open, setOpen] = useState(false);
+  const declared = useToolIcon(name);
   if (isFileDiffResult(outcome)) {
     const display = (outcome.output as { display: FileDiffDisplay }).display;
     if (isFileDiffDisplay(display)) return <FileDiffBlock display={display} />;
@@ -22,7 +24,7 @@ export function ToolBlock({ name, input, outcome }: {
   return (
     <div className="activity-block" data-testid="block-tool" data-status={status}>
       <ActivityRow
-        icon={iconForTool(name)}
+        icon={iconForTool(name, declared)}
         label={toolActivityLabel({ name, input, outcome })}
         meta={status === 'error' ? 'failed' : undefined}
         active={status === 'running'}

--- a/packages/cli/src/commands/run-tui.ts
+++ b/packages/cli/src/commands/run-tui.ts
@@ -214,6 +214,9 @@ async function applyTuiPreferences(argv: ParsedArgv): Promise<void> {
     if (tui.hints === false && process.env.MOXXY_TUI_HINTS === undefined) {
       process.env.MOXXY_TUI_HINTS = '0';
     }
+    if (tui.density && process.env.MOXXY_TUI_DENSITY === undefined) {
+      process.env.MOXXY_TUI_DENSITY = tui.density;
+    }
     if (tui.keys && process.env.MOXXY_TUI_KEYS === undefined) {
       process.env.MOXXY_TUI_KEYS = JSON.stringify(tui.keys);
     }

--- a/packages/client-core/src/useActionCatalog.test.tsx
+++ b/packages/client-core/src/useActionCatalog.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useActionCatalog } from './useActionCatalog.js';
+import { __setApiOverride } from './transport.js';
+
+/**
+ * The catalog is an ENHANCEMENT: callers use it to enrich what they render and
+ * every one of them has a defined fallback for "no catalog". So failing to
+ * reach the runner must degrade, never throw, or a component that merely wanted
+ * nicer output turns a configured transport into a hard requirement for
+ * rendering at all.
+ */
+describe('useActionCatalog', () => {
+  it('stays empty instead of throwing when no transport is configured', () => {
+    __setApiOverride(undefined);
+
+    const { result } = renderHook(() => useActionCatalog());
+
+    expect(result.current.loaded).toBe(false);
+    expect(result.current.tools).toEqual([]);
+  });
+
+  it('stays empty when the runner rejects the request', async () => {
+    __setApiOverride({ invoke: async () => Promise.reject(new Error('nope')) } as never);
+
+    const { result } = renderHook(() => useActionCatalog());
+
+    await waitFor(() => expect(result.current.loaded).toBe(false));
+    expect(result.current.tools).toEqual([]);
+  });
+
+  it('exposes the tools the runner reported, including their declared icons', async () => {
+    __setApiOverride({
+      invoke: async () => ({
+        skills: [],
+        tools: [
+          { name: 'Read', description: 'read a file', icon: 'file' },
+          { name: 'mystery', description: 'undeclared' },
+        ],
+      }),
+    } as never);
+
+    const { result } = renderHook(() => useActionCatalog());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.tools[0]?.icon).toBe('file');
+    expect(result.current.tools[1]?.icon).toBeUndefined();
+  });
+});

--- a/packages/client-core/src/useActionCatalog.ts
+++ b/packages/client-core/src/useActionCatalog.ts
@@ -32,13 +32,22 @@ export function useActionCatalog(workspaceId?: string): ActionCatalog {
   useEffect(() => {
     let cancelled = false;
     const fetchCatalog = (): void => {
-      void api()
-        .invoke('session.info', workspaceId ? { workspaceId } : undefined)
-        .then((info) => {
-          if (cancelled || !info) return;
-          setCatalog({ loaded: true, skills: info.skills, tools: info.tools });
-        })
-        .catch(() => {});
+      // `api()` THROWS synchronously when no transport is configured, which the
+      // promise `.catch` below cannot see. Left unguarded that escapes the
+      // effect and takes down whatever rendered the consumer, so a component
+      // that merely enriches its output would become a hard requirement for a
+      // transport. `loaded: false` already means "no catalog"; this is that.
+      try {
+        void api()
+          .invoke('session.info', workspaceId ? { workspaceId } : undefined)
+          .then((info) => {
+            if (cancelled || !info) return;
+            setCatalog({ loaded: true, skills: info.skills, tools: info.tools });
+          })
+          .catch(() => {});
+      } catch {
+        /* no transport: stay EMPTY */
+      }
     };
     fetchCatalog();
     const off = getPlatform().eventBus?.on(SESSION_INFO_REFRESH_EVENT, fetchCatalog);

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -323,6 +323,12 @@ export const moxxyConfigSchema = z.object({
       /** Hide the footer key-hint row when false. */
       hints: z.boolean().optional(),
       /**
+       * Vertical breathing room in the transcript. `compact` drops the blank
+       * line between entries, which is what a short split pane needs: on 24
+       * rows, half the screen is otherwise separator.
+       */
+      density: z.enum(['comfortable', 'compact']).optional(),
+      /**
        * Ctrl+<letter> overrides for the input-editor command hotkeys. Values
        * are single letters; unknown/conflicting letters are ignored at boot.
        */

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -596,6 +596,7 @@ export class Session implements ClientSession, SessionRuntime {
         name: t.name,
         description: t.description,
         ...(t.compact ? { compact: t.compact } : {}),
+        ...(t.icon ? { icon: t.icon } : {}),
       })),
       skills: this.skills.list().map((s) => ({ id: s.id, name: s.frontmatter.name })),
       commands: this.commands.list().map((c) => ({

--- a/packages/plugin-browser/src/web-fetch.ts
+++ b/packages/plugin-browser/src/web-fetch.ts
@@ -100,6 +100,7 @@ function createPinnedDispatcher(addresses: ReadonlyArray<string>): Agent {
 
 export const webFetchTool = defineTool({
   name: 'web_fetch',
+  icon: 'globe',
   description:
     'Fetch a URL over HTTP(S) and return the page content. HTML is post-processed to readable text (or markdown). Use for simple GETs; if the page needs JS execution, clicks, or form fills, use browser_session instead.',
   inputSchema: z.object({

--- a/packages/plugin-browser/src/web-search.ts
+++ b/packages/plugin-browser/src/web-search.ts
@@ -38,7 +38,8 @@ export function buildWebSearchTool(opts: BuildWebSearchToolOptions = {}) {
   const adapter = opts.adapter ?? duckDuckGoHtmlAdapter;
   return defineTool({
     name: 'web_search',
-    description:
+    icon: 'search',
+  description:
       'Search the public web for current information and return source URLs with snippets. On models with provider-hosted web search this fallback is replaced automatically by the provider; otherwise it uses the configured local search adapter.',
     inputSchema: z.object({
       query: z.string().trim().min(1).max(1_000).describe('Search query.'),

--- a/packages/plugin-cli/src/components/chat/AssistantBlock.tsx
+++ b/packages/plugin-cli/src/components/chat/AssistantBlock.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 import { Box, Text } from 'ink';
 import { Markdown } from '../Markdown.js';
 import { Glyphs } from '../../theme.js';
+import { blockGap } from './density.js';
 
 /**
  * Renders an assistant turn: a white `●` bullet on the first line and
@@ -15,7 +16,7 @@ export const AssistantBlock: React.FC<{ content: string }> = memo(function Assis
 }) {
   if (!content.trim()) return null;
   return (
-    <Box flexDirection="row" marginTop={1}>
+    <Box flexDirection="row" marginTop={blockGap()}>
       <Box flexDirection="column" marginRight={1}>
         <Text dimColor>{Glyphs.filled}</Text>
       </Box>

--- a/packages/plugin-cli/src/components/chat/BlockLine.tsx
+++ b/packages/plugin-cli/src/components/chat/BlockLine.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 import { Box, Text } from 'ink';
+import { blockGap } from './density.js';
 import { EventLine } from './EventLine.js';
 import { LiveToolBlock } from './LiveToolBlock.js';
 import { ToolCallBlock } from './ToolCallBlock.js';
@@ -88,7 +89,7 @@ const SkillScopeView: React.FC<{
   const runningTools = scope.children.some(hasRunningTool);
   const showChildren = !scope.closed || runningTools || expandToolOutputs;
   return (
-    <Box flexDirection="column" marginTop={1}>
+    <Box flexDirection="column" marginTop={blockGap()}>
       <Box>
         <Text dimColor>✦ </Text>
         <ShimmerText text={presentation.label} active={presentation.active} />

--- a/packages/plugin-cli/src/components/chat/CollabScopeView.tsx
+++ b/packages/plugin-cli/src/components/chat/CollabScopeView.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { Colors, Glyphs } from '../../theme.js';
+import { blockGap } from './density.js';
 import { formatElapsed, truncate, type CollaborationBlock } from '@moxxy/chat-model';
 import { MOTION_ENABLED } from '../motion.js';
 
@@ -32,7 +33,7 @@ export const CollabScopeView: React.FC<{ scope: CollaborationBlock }> = ({ scope
   const headColor = scope.conflicts.length > 0 ? Colors.danger : Colors.busy;
 
   return (
-    <Box flexDirection="column" marginTop={1}>
+    <Box flexDirection="column" marginTop={blockGap()}>
       <Box>
         <Text color={headColor}>{Glyphs.filled} </Text>
         <Text bold>collab </Text>

--- a/packages/plugin-cli/src/components/chat/EventLine.tsx
+++ b/packages/plugin-cli/src/components/chat/EventLine.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import type { MoxxyEvent, TriggerOrigin } from '@moxxy/sdk';
 import { Colors, Glyphs } from '../../theme.js';
+import { blockGap } from './density.js';
 import { truncate } from '@moxxy/chat-model';
 import { AssistantBlock } from './AssistantBlock.js';
 
@@ -13,7 +14,7 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
     case 'user_prompt':
       if (event.origin) {
         return (
-          <Box flexDirection="column" marginTop={1}>
+          <Box flexDirection="column" marginTop={blockGap()}>
             <Box>
               <Text dimColor>{`${Glyphs.filled} ${formatTriggerOrigin(event.origin)} · `}</Text>
               <Text>{event.origin.name}</Text>
@@ -32,7 +33,7 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
       // bar, so they don't dominate the transcript.
       if (event.source && event.source !== 'user') {
         return (
-          <Box marginTop={1}>
+          <Box marginTop={blockGap()}>
             <Text dimColor>{`${Glyphs.midDot} ${event.text}`}</Text>
           </Box>
         );
@@ -54,7 +55,7 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
       // and what the model receives are untouched — this only tightens
       // the echo render.
       return (
-        <Box flexDirection="column" marginTop={1}>
+        <Box flexDirection="column" marginTop={blockGap()}>
           <Box flexDirection="row">
             <Box flexDirection="column" marginRight={1} flexShrink={0}>
               <Text>{Glyphs.prompt}</Text>
@@ -73,7 +74,7 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
       // expanded — show a static withheld marker.
       if (event.redacted) {
         return (
-          <Box marginTop={1}>
+          <Box marginTop={blockGap()}>
             <Text dimColor>{`${Glyphs.pending} reasoning withheld`}</Text>
           </Box>
         );
@@ -84,7 +85,7 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
       // since Ink has no native collapse affordance.
       if (expandToolOutputs) {
         return (
-          <Box flexDirection="column" marginTop={1}>
+          <Box flexDirection="column" marginTop={blockGap()}>
             <Text dimColor>{`${Glyphs.pending} thinking`}</Text>
             <Box marginLeft={2}>
               <Text dimColor>{content}</Text>
@@ -94,7 +95,7 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
       }
       const firstLine = content.split('\n').find((l) => l.trim()) ?? '';
       return (
-        <Box marginTop={1}>
+        <Box marginTop={blockGap()}>
           <Text dimColor>{`${Glyphs.pending} thinking · ${truncate(firstLine, 100)}`}</Text>
         </Box>
       );
@@ -105,7 +106,7 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
       return null;
     case 'skill_created':
       return (
-        <Box marginTop={1}>
+        <Box marginTop={blockGap()}>
           <Text dimColor>{Glyphs.filled} </Text>
           <Text bold>skill created</Text>
           <Text dimColor>  {event.name}</Text>
@@ -119,14 +120,14 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
       );
     case 'compaction':
       return (
-        <Box marginTop={1}>
+        <Box marginTop={blockGap()}>
           <Text dimColor>⤺ </Text>
           <Text dimColor>{formatCompactionEvent(event)}</Text>
         </Box>
       );
     case 'error':
       return (
-        <Box marginTop={1}>
+        <Box marginTop={blockGap()}>
           <Text color={Colors.danger}>{Glyphs.filled} </Text>
           <Text color={Colors.danger}>error: </Text>
           <Text>{event.message}</Text>
@@ -134,7 +135,7 @@ export const EventLine: React.FC<{ event: MoxxyEvent; expandToolOutputs?: boolea
       );
     case 'abort':
       return (
-        <Box marginTop={1}>
+        <Box marginTop={blockGap()}>
           <Text color={Colors.busy}>⏹ aborted: {event.reason}</Text>
         </Box>
       );

--- a/packages/plugin-cli/src/components/chat/FileDiffView.tsx
+++ b/packages/plugin-cli/src/components/chat/FileDiffView.tsx
@@ -9,6 +9,7 @@ import {
   type FileDiffDisplay,
 } from '@moxxy/sdk';
 import { Colors, Glyphs } from '../../theme.js';
+import { blockGap } from './density.js';
 
 /** Lines shown before the diff is collapsed (Ctrl+O expands to the full set).
  *  Generous enough that a typical single-hunk edit shows in full. */
@@ -67,7 +68,7 @@ export const FileDiffView: React.FC<{
   );
   const dotColor = display.mode === 'create' ? Colors.active : 'cyan';
   return (
-    <Box flexDirection="column" marginTop={1}>
+    <Box flexDirection="column" marginTop={blockGap()}>
       <Box>
         <Text color={dotColor}>{Glyphs.filled} </Text>
         <Text bold>{fileDiffVerb(display)}</Text>

--- a/packages/plugin-cli/src/components/chat/StreamingPreview.tsx
+++ b/packages/plugin-cli/src/components/chat/StreamingPreview.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react';
 import { Box, Text } from 'ink';
 import { Glyphs } from '../../theme.js';
+import { blockGap } from './density.js';
 
 /**
  * In-flight streaming indicator: a SINGLE constant-height row showing the tail
@@ -37,7 +38,7 @@ export const StreamingPreview: React.FC<{ content: string; dim?: boolean }> = me
   const shown = lastNonEmptyLineShown(content, innerCols);
 
   return (
-    <Box flexDirection="row" marginTop={1}>
+    <Box flexDirection="row" marginTop={blockGap()}>
       <Box marginRight={1}>
         <Text dimColor>{Glyphs.filled}</Text>
       </Box>

--- a/packages/plugin-cli/src/components/chat/SubagentGroupView.tsx
+++ b/packages/plugin-cli/src/components/chat/SubagentGroupView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import { Colors, Glyphs } from '../../theme.js';
+import { blockGap } from './density.js';
 import {
   DotColors,
   formatTokensK,
@@ -50,7 +51,7 @@ export const SubagentGroupView: React.FC<{
 
   if (!expandToolOutputs) {
     return (
-      <Box marginTop={1}>
+      <Box marginTop={blockGap()}>
         <Text color={dotColor}>{Glyphs.filled} </Text>
         <Text>{header}</Text>
         <Text dimColor>{' (ctrl+o to expand)'}</Text>
@@ -59,7 +60,7 @@ export const SubagentGroupView: React.FC<{
   }
 
   return (
-    <Box flexDirection="column" marginTop={1}>
+    <Box flexDirection="column" marginTop={blockGap()}>
       <Box>
         <Text color={dotColor}>{Glyphs.filled} </Text>
         <Text>{header}</Text>

--- a/packages/plugin-cli/src/components/chat/SubagentScopeView.tsx
+++ b/packages/plugin-cli/src/components/chat/SubagentScopeView.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { Colors, Glyphs } from '../../theme.js';
+import { blockGap } from './density.js';
 import { DotColors, formatElapsed, truncate, type SubagentBlock } from '@moxxy/chat-model';
 import { MOTION_ENABLED } from '../motion.js';
 
@@ -22,7 +23,7 @@ export const SubagentScopeView: React.FC<{ scope: SubagentBlock }> = ({ scope })
       : DotColors.subagent;
   const state = scope.error ? 'failed' : running ? 'running' : 'done';
   return (
-    <Box flexDirection="column" marginTop={1}>
+    <Box flexDirection="column" marginTop={blockGap()}>
       <Box>
         <Text color={dotColor}>{Glyphs.filled} </Text>
         <Text bold>{`agent `}</Text>

--- a/packages/plugin-cli/src/components/chat/density-coverage.test.ts
+++ b/packages/plugin-cli/src/components/chat/density-coverage.test.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Every gap between transcript entries must go through `blockGap()`.
+ *
+ * A hardcoded `marginTop={1}` still renders fine, which is what makes this
+ * worth a test: `tui.density: compact` would tighten most entries and leave
+ * that one padded, so the setting looks half-broken rather than absent. The
+ * failure is invisible to a typechecker and easy to reintroduce by copying an
+ * existing component.
+ */
+const CHAT_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+describe('transcript density coverage', () => {
+  it('has no hardcoded vertical separator left in a chat component', async () => {
+    const files = (await fs.readdir(CHAT_DIR)).filter(
+      (f) => f.endsWith('.tsx') && !f.includes('.test.'),
+    );
+    expect(files.length).toBeGreaterThan(5);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = await fs.readFile(path.join(CHAT_DIR, file), 'utf8');
+      if (/marginTop=\{1\}/.test(source)) offenders.push(file);
+    }
+
+    expect(offenders, 'use marginTop={blockGap()} so `tui.density` reaches these').toEqual([]);
+  });
+});

--- a/packages/plugin-cli/src/components/chat/density.test.ts
+++ b/packages/plugin-cli/src/components/chat/density.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { blockGap, tuiDensity } from './density.js';
+
+const set = (value: string | undefined): void => {
+  if (value === undefined) delete process.env.MOXXY_TUI_DENSITY;
+  else process.env.MOXXY_TUI_DENSITY = value;
+};
+
+afterEach(() => set(undefined));
+
+describe('transcript density', () => {
+  it('leaves a blank line between entries by default', () => {
+    // Unset must behave exactly as before the setting existed: nobody opted in.
+    expect(tuiDensity()).toBe('comfortable');
+    expect(blockGap()).toBe(1);
+  });
+
+  it('drops the separator when compact is asked for', () => {
+    set('compact');
+
+    expect(tuiDensity()).toBe('compact');
+    expect(blockGap()).toBe(0);
+  });
+
+  it('treats an unrecognised value as the default rather than guessing', () => {
+    // A presentation preference must never be the reason a terminal renders
+    // strangely, so anything but the one opt-in word means "as before".
+    for (const junk of ['', 'COMPACT', 'tight', 'true', '1']) {
+      set(junk);
+      expect(blockGap(), `${junk} should not enable compact`).toBe(1);
+    }
+  });
+});

--- a/packages/plugin-cli/src/components/chat/density.ts
+++ b/packages/plugin-cli/src/components/chat/density.ts
@@ -1,0 +1,25 @@
+/**
+ * How much vertical room the transcript spends between entries.
+ *
+ * `comfortable` (the default) keeps one blank line between blocks, which reads
+ * well on a full-screen terminal. `compact` drops it, which is what a 24-row
+ * split pane or a tmux strip actually needs: on those, half the screen is
+ * separator.
+ *
+ * Read from the environment rather than config for the same reason the theme
+ * and hint preferences are: this package deliberately does not load config, so
+ * the CLI resolves the preference at boot and passes it down this channel.
+ *
+ * Evaluated per call rather than cached at import so a test can flip it, and
+ * because it is a property read on a component render, not a hot loop.
+ */
+export type TuiDensity = 'comfortable' | 'compact';
+
+export function tuiDensity(): TuiDensity {
+  return process.env.MOXXY_TUI_DENSITY === 'compact' ? 'compact' : 'comfortable';
+}
+
+/** Rows of separation between two transcript blocks. */
+export function blockGap(): 0 | 1 {
+  return tuiDensity() === 'compact' ? 0 : 1;
+}

--- a/packages/plugin-cli/src/session/settings-descriptors.ts
+++ b/packages/plugin-cli/src/session/settings-descriptors.ts
@@ -121,6 +121,15 @@ export const SETTINGS_KNOBS: ReadonlyArray<SettingsKnob> = [
     next: (c) => ((c.tui?.theme ?? 'default') === 'default' ? 'mono' : 'default'),
   },
   {
+    id: 'tui-density',
+    label: 'Transcript density',
+    description: 'compact drops the blank line between entries (for short panes)',
+    kind: 'enum',
+    dotPath: 'tui.density',
+    current: (c) => c.tui?.density ?? 'comfortable',
+    next: (c) => ((c.tui?.density ?? 'comfortable') === 'comfortable' ? 'compact' : 'comfortable'),
+  },
+  {
     id: 'tui-hints',
     label: 'Footer hints',
     description: 'the dim key-hint row under the input',

--- a/packages/plugin-computer-control/src/tools/clipboard.ts
+++ b/packages/plugin-computer-control/src/tools/clipboard.ts
@@ -3,6 +3,7 @@ import { ensureDarwin, procFailureCause, runProcess } from '../shell.js';
 
 export const clipboardTool = defineTool({
   name: 'computer_clipboard',
+  icon: 'clipboard',
   description:
     'Read from or write to the macOS clipboard. Use `read` to fetch what the ' +
     'user just copied; use `write` to stage text the user can then paste with ' +

--- a/packages/plugin-computer-control/src/tools/open.ts
+++ b/packages/plugin-computer-control/src/tools/open.ts
@@ -3,6 +3,7 @@ import { ensureDarwin, procFailureCause, runProcess } from '../shell.js';
 
 export const openTool = defineTool({
   name: 'computer_open',
+  icon: 'globe',
   description:
     'Open a URL, file path, or .app bundle via macOS `open`. Use this to ' +
     'launch / activate a specific app or jump to a web page. The model should ' +

--- a/packages/plugin-computer-control/src/tools/screenshot.ts
+++ b/packages/plugin-computer-control/src/tools/screenshot.ts
@@ -28,6 +28,7 @@ const MAX_BYTES = 1_500_000;
 
 export const screenshotTool = defineTool({
   name: 'computer_screenshot',
+  icon: 'workspace',
   description:
     'Take a screenshot of the macOS desktop. Returns base64-encoded image bytes ' +
     'the model can see directly. By default the image is downscaled to 1280px ' +

--- a/packages/plugin-terminal/src/terminal.ts
+++ b/packages/plugin-terminal/src/terminal.ts
@@ -197,6 +197,7 @@ const terminalInputSchema = z.object({
 export function buildTerminalTool() {
   return defineTool({
     name: 'terminal',
+    icon: 'terminal',
     description:
       'Run a shell command in the user-visible terminal and return its output. ' +
       'The terminal is SHARED with the user — they see what you run and can take over. ' +

--- a/packages/sdk/src/define.ts
+++ b/packages/sdk/src/define.ts
@@ -9,6 +9,7 @@ import type { PermissionRule } from './permission.js';
 import type { Plugin, PluginSpec } from './plugin.js';
 import type { ProviderDef } from './provider.js';
 import type { SkillDef, SkillFrontmatter } from './skill.js';
+import type { ToolIcon } from './tool-icon.js';
 import type { HostedTool, ToolCompactPresentation, ToolContext, ToolDef } from './tool.js';
 import type { ToolIsolationSpec } from './isolation.js';
 import type { TranscriberDef } from './transcriber.js';
@@ -46,6 +47,7 @@ export function defineTool<S extends z.ZodTypeAny, O = unknown>(spec: {
   permission?: PermissionRule;
   handler: (input: z.output<S>, ctx: ToolContext) => Promise<O> | O;
   compact?: ToolCompactPresentation;
+  icon?: ToolIcon;
   isolation?: ToolIsolationSpec;
 }): ToolDef {
   return Object.freeze({
@@ -58,6 +60,7 @@ export function defineTool<S extends z.ZodTypeAny, O = unknown>(spec: {
     permission: spec.permission,
     handler: spec.handler as (input: unknown, ctx: ToolContext) => Promise<unknown> | unknown,
     compact: spec.compact,
+    icon: spec.icon,
     isolation: spec.isolation,
   });
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -49,6 +49,8 @@ export { samePrincipal, formatPrincipal } from './principal.js';
 
 export { verifyEd25519 } from './signature.js';
 
+export { TOOL_ICONS, isToolIcon, type ToolIcon } from './tool-icon.js';
+
 export type {
   AuditExporterDef,
   AuditExportBatch,

--- a/packages/sdk/src/session-like.ts
+++ b/packages/sdk/src/session-like.ts
@@ -6,6 +6,7 @@ import type { ApprovalResolver, ModeBadge } from './mode.js';
 import type { PermissionResolver } from './permission.js';
 import type { ModelDescriptor, ProviderKeyValidation } from './provider.js';
 import type { PluginSetupSpec } from './schemas.js';
+import type { ToolIcon } from './tool-icon.js';
 import type { ToolCompactPresentation } from './tool.js';
 
 /**
@@ -80,6 +81,8 @@ export interface ToolInfo {
   readonly description: string;
   /** Compact presentation hint (plain data - crosses the wire intact). */
   readonly compact?: ToolCompactPresentation;
+  /** Declared icon, so a surface renders the tool's own choice, not a guess. */
+  readonly icon?: ToolIcon;
 }
 
 /** Serializable skill metadata. */

--- a/packages/sdk/src/tool-icon.test.ts
+++ b/packages/sdk/src/tool-icon.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { TOOL_ICONS, isToolIcon } from './tool-icon.js';
+import { defineTool } from './define.js';
+import { z } from 'zod';
+
+describe('tool icons', () => {
+  it('is a closed vocabulary, so a surface can map it exhaustively', () => {
+    expect(isToolIcon('terminal')).toBe(true);
+    // The whole reason the field is not a free string: a name no surface owns
+    // would render as nothing anywhere.
+    expect(isToolIcon('sparkles-v2')).toBe(false);
+    expect(isToolIcon('')).toBe(false);
+    expect(isToolIcon(undefined)).toBe(false);
+  });
+
+  it('has no duplicates, which would make a surface map ambiguous', () => {
+    expect(new Set(TOOL_ICONS).size).toBe(TOOL_ICONS.length);
+  });
+
+  it('always offers a neutral choice for a tool that fits nothing else', () => {
+    expect(TOOL_ICONS).toContain('wrench');
+  });
+
+  it('carries a declared icon through defineTool onto the def', () => {
+    const tool = defineTool({
+      name: 'thing',
+      description: 'does a thing',
+      icon: 'workflow',
+      inputSchema: z.object({}),
+      handler: () => undefined,
+    });
+
+    expect(tool.icon).toBe('workflow');
+  });
+
+  it('leaves icon undefined when a tool does not declare one', () => {
+    const tool = defineTool({
+      name: 'thing',
+      description: 'does a thing',
+      inputSchema: z.object({}),
+      handler: () => undefined,
+    });
+
+    expect(tool.icon).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/tool-icon.ts
+++ b/packages/sdk/src/tool-icon.ts
@@ -1,0 +1,46 @@
+/**
+ * What a tool looks like, as a semantic name rather than a glyph.
+ *
+ * A CLOSED vocabulary on purpose. Surfaces render wildly differently: the
+ * desktop draws SVG, the TUI prints a character, a future web surface might do
+ * something else again. If this were a free string, a plugin could name an icon
+ * no surface owns and every surface would have to guess, so in practice
+ * everything would fall back and the field would be decorative. A fixed set
+ * means each surface maps it exhaustively and a plugin's choice actually
+ * survives to the screen.
+ *
+ * The names describe WHAT THE TOOL TOUCHES, not what it looks like, so a
+ * surface is free to change its artwork without every plugin becoming wrong.
+ *
+ * Adding a member is a breaking change for surfaces (their maps stop being
+ * exhaustive and stop compiling), which is the intended cost: a new icon should
+ * be a deliberate decision across surfaces, not a silent fallback to a wrench.
+ */
+export const TOOL_ICONS = [
+  'file',
+  'folder',
+  'search',
+  'edit',
+  'diff',
+  'terminal',
+  'globe',
+  'chat',
+  'workflow',
+  'agent',
+  'settings',
+  'lock',
+  'plug',
+  'mic',
+  'speaker',
+  'smartphone',
+  'workspace',
+  'clipboard',
+  'spark',
+  'wrench',
+] as const;
+
+export type ToolIcon = (typeof TOOL_ICONS)[number];
+
+export function isToolIcon(value: unknown): value is ToolIcon {
+  return typeof value === 'string' && (TOOL_ICONS as ReadonlyArray<string>).includes(value);
+}

--- a/packages/sdk/src/tool.ts
+++ b/packages/sdk/src/tool.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 import type { EventLogReader } from './log.js';
+import type { ToolIcon } from './tool-icon.js';
 import type { PermissionRule } from './permission.js';
 import type { SessionId, ToolCallId, TurnId } from './ids.js';
 import type { SubagentSpawner } from './subagent.js';
@@ -191,6 +192,13 @@ export interface ToolDef {
   readonly handler: (input: unknown, ctx: ToolContext) => Promise<unknown> | unknown;
   /** Opt-in presentation hint. See `ToolCompactPresentation`. */
   readonly compact?: ToolCompactPresentation;
+  /**
+   * What this tool touches, so surfaces can show it. Without this a surface can
+   * only guess from the NAME, which works for the handful of built-ins it was
+   * written against and gives every plugin-contributed tool the same generic
+   * fallback. See {@link ToolIcon}.
+   */
+  readonly icon?: ToolIcon;
   /**
    * Optional capability declaration. Advisory unless the user enables
    * `@moxxy/plugin-security`, at which point the active `Isolator`

--- a/packages/tools-builtin/src/bash.ts
+++ b/packages/tools-builtin/src/bash.ts
@@ -114,6 +114,7 @@ function boundedSink(cap: number): {
 
 export const bashTool = defineTool({
   name: 'Bash',
+  icon: 'terminal',
   description: 'Run a shell command via /bin/sh. Respects the abort signal. Returns combined stdout/stderr with exit code.',
   inputSchema: z.object({
     command: z.string().min(1),

--- a/packages/tools-builtin/src/edit.ts
+++ b/packages/tools-builtin/src/edit.ts
@@ -6,6 +6,7 @@ import { MAX_FILE_BYTES, resolvePath } from './util.js';
 
 export const editTool = defineTool({
   name: 'Edit',
+  icon: 'edit',
   description: 'Replace exact string occurrences in a file. Use replace_all to substitute every occurrence; otherwise old_string must be unique.',
   inputSchema: z.object({
     file_path: z.string(),

--- a/packages/tools-builtin/src/glob.ts
+++ b/packages/tools-builtin/src/glob.ts
@@ -5,6 +5,7 @@ import { clampString, globToRegExp, IGNORED_DIR_NAMES, MAX_WALK_DEPTH, resolvePa
 
 export const globTool = defineTool({
   name: 'Glob',
+  icon: 'folder',
   description: 'Find files by glob pattern (e.g. "src/**/*.ts"). Returns absolute paths sorted by mtime descending.',
   inputSchema: z.object({
     pattern: z.string().min(1),

--- a/packages/tools-builtin/src/grep.ts
+++ b/packages/tools-builtin/src/grep.ts
@@ -120,6 +120,7 @@ function looksBinary(content: string): boolean {
 
 export const grepTool = defineTool({
   name: 'Grep',
+  icon: 'search',
   description: 'Recursively search files for a regex pattern. Returns lines as `path:line:text`.',
   inputSchema: z.object({
     pattern: z.string().min(1),

--- a/packages/tools-builtin/src/read.ts
+++ b/packages/tools-builtin/src/read.ts
@@ -3,6 +3,7 @@ import { readHandler } from './read-handler.js';
 
 export const readTool = defineTool({
   name: 'Read',
+  icon: 'file',
   description: 'Read a UTF-8 text file from disk. Returns lines as `cat -n` style numbered text.',
   inputSchema: z.object({
     file_path: z.string().describe('Absolute path or path relative to cwd.'),

--- a/packages/tools-builtin/src/recall.ts
+++ b/packages/tools-builtin/src/recall.ts
@@ -13,6 +13,7 @@ const SUMMARY_CHARS = 1_500;
  */
 export const recallTool = defineTool({
   name: 'recall',
+  icon: 'search',
   description:
     'Retrieve earlier content that was elided from context to save tokens. ' +
     'Pass the `callId` shown in an "[output elided — recall(...)]" stub to get a ' +

--- a/packages/tools-builtin/src/sleep.ts
+++ b/packages/tools-builtin/src/sleep.ts
@@ -17,6 +17,7 @@ export function resolveSleepMs(input: { seconds?: number; ms?: number }): number
 
 export const sleepTool = defineTool({
   name: 'Sleep',
+  icon: 'settings',
   description:
     'Pause for a set duration before continuing. Use it to wait for an external/async process ' +
     '(a build, a deploy, a server warming up) before re-checking, instead of busy-looping. ' +

--- a/packages/tools-builtin/src/write.ts
+++ b/packages/tools-builtin/src/write.ts
@@ -6,6 +6,7 @@ import { MAX_FILE_BYTES, resolvePath } from './util.js';
 
 export const writeTool = defineTool({
   name: 'Write',
+  icon: 'file',
   description: 'Write a UTF-8 file to disk, creating parent directories as needed. Overwrites if exists.',
   inputSchema: z.object({
     file_path: z.string(),


### PR DESCRIPTION
The two remaining items from the enterprise audit.

### `ToolDef.icon`

A surface could only guess from the tool's **name**, through a heuristic that recognised the handful of built-ins it was written against, so every plugin-contributed tool drew the same wrench and its author had no way to say otherwise. Tools declare `icon`, the session snapshot carries it, the desktop renders it, and the heuristic stays as the fallback for tools that declare nothing.

The vocabulary is **closed** (`ToolIcon`), not a free string. Surfaces render very differently (desktop draws SVG, TUI prints a character), so a name no surface owns would fall back everywhere and the field would be decorative. The desktop's map is typed as a total `Record<ToolIcon, IconName>`, so adding a member fails to compile rather than silently drawing a wrench. That fired while writing this: `copy` was rejected, and `clipboard` was added to the vocabulary deliberately.

14 built-in and plugin tools now declare one. The desktop reads the map from a single `session.info` fetch held in context, because a transcript can hold hundreds of tool rows and a fetching hook per row would mean hundreds of identical IPC calls to paint one screen.

### `tui.density`

`comfortable | compact`, beside `tui.theme` and `tui.hints`, togglable from `/settings`. `compact` drops the blank line between transcript entries: on a 24-row split pane, half the screen is otherwise separator. Default is unchanged, and any unrecognised value means "as before" so a presentation preference can never be why a terminal renders oddly.

All 18 separators across 8 chat components route through one helper. A test fails naming any component that hardcodes one again, because a single stray separator would make compact look half-broken rather than absent (typechecking cannot see this, and it is easy to reintroduce by copying a neighbour).

### A bug I introduced and fixed

Mounting the icon provider at the transcript root broke **8 desktop tests**: `api()` throws synchronously when no transport is configured, which the hook's promise `.catch` cannot see, so a component that merely wanted nicer icons made a configured transport a hard requirement for rendering the transcript at all. `useActionCatalog` now degrades to the `loaded: false` state it already models. Caught by the full suite, not by typechecking.

### Verified

Full workspace green (7473 tests, exit 0), lint clean. New guards were mutation-checked: removing the transport guard, and hardcoding a separator back into `FileDiffView` (the test names the offending file).

Not verified: I did not visually confirm the rendered TUI or desktop output. There is no Ink render harness in `plugin-cli` and I did not add a dependency for it, so density is covered by unit tests on the helper plus a static check that every separator routes through it.