### PR TITLE
feat(providers): replace claude-opus-4-8 with claude-opus-5

### DIFF
--- a/.changeset/claude-5-models.md
+++ b/.changeset/claude-5-models.md
@@ -1,0 +1,14 @@
+---
+'@moxxy/plugin-provider-anthropic': minor
+'@moxxy/plugin-provider-claude-code': minor
+'@moxxy/plugin-plugins-admin': patch
+'@moxxy/sdk': patch
+---
+
+Replace `claude-opus-4-8` with `claude-opus-5` in the Claude catalogs.
+
+Opus 4.8 is retired, so offering it meant a picker entry that cannot serve a request. `claude-opus-5` takes its place in both the Anthropic API catalog and the Claude Code subscription catalog, and becomes the Anthropic plugin's recommended `defaultModel`. `claude-fable-5` was already listed in both and is unchanged.
+
+The new row copies the opus line's shape (1M context, 128k output, tools, images, documents, adaptive thinking, hosted web search) rather than being verified against the Models API, because the catalog is still hardcoded (TECH_DEBT P3 #8).
+
+Removing 4.8 surfaced that the Claude Code catalog is enforced rather than advisory: a test passing a model outside it never reached the CLI at all. Tests that enumerate real catalog models were updated with it. One deliberately keeps `claude-opus-4-8` as its example of an unlisted id, which is now more accurate than before.

--- a/.changeset/claude-5-models.md
+++ b/.changeset/claude-5-models.md
@@ -5,9 +5,9 @@
 '@moxxy/sdk': patch
 ---
 
-Replace `claude-opus-4-8` with `claude-opus-5` in the Claude catalogs.
+Refresh the Claude catalogs: `claude-opus-5` replaces the retired `claude-opus-4-8`, and `claude-sonnet-5` is added.
 
-Opus 4.8 is retired, so offering it meant a picker entry that cannot serve a request. `claude-opus-5` takes its place in both the Anthropic API catalog and the Claude Code subscription catalog, and becomes the Anthropic plugin's recommended `defaultModel`. `claude-fable-5` was already listed in both and is unchanged.
+Opus 4.8 is retired, so offering it meant a picker entry that cannot serve a request. `claude-opus-5` takes its place in both the Anthropic API catalog and the Claude Code subscription catalog, and becomes the Anthropic plugin's recommended `defaultModel`. `claude-sonnet-5` is added alongside `claude-sonnet-4-6` rather than replacing it, because 4.6 is not retired and is still the default. `claude-fable-5` was already listed in both and is unchanged.
 
 The new row copies the opus line's shape (1M context, 128k output, tools, images, documents, adaptive thinking, hosted web search) rather than being verified against the Models API, because the catalog is still hardcoded (TECH_DEBT P3 #8).
 

--- a/packages/cli/src/provision/provision.test.ts
+++ b/packages/cli/src/provision/provision.test.ts
@@ -38,7 +38,7 @@ describe('provision', () => {
   it('skips installing a bundled provider but configures it + stores the key', async () => {
     const eff = makeEffects({ loadedProviderNames: new Set(['anthropic']) });
     const res = await provision(
-      { provider: 'anthropic', key: 'sk-x', model: 'claude-opus-4-8' },
+      { provider: 'anthropic', key: 'sk-x', model: 'claude-opus-5' },
       eff,
     );
     expect(eff.install).not.toHaveBeenCalled();
@@ -46,7 +46,7 @@ describe('provision', () => {
     expect(eff.storeSecret).toHaveBeenCalledWith(expect.any(String), 'sk-x', ['anthropic']);
     expect(res.keyStored).toBe(true);
     expect(eff.writeConfig).toHaveBeenCalledWith(
-      expect.objectContaining({ providerSlug: 'anthropic', providerBundled: true, model: 'claude-opus-4-8' }),
+      expect.objectContaining({ providerSlug: 'anthropic', providerBundled: true, model: 'claude-opus-5' }),
     );
   });
 
@@ -80,7 +80,7 @@ describe('provision', () => {
     }));
   });
 
-  it.each(['claude-fable-5', 'claude-opus-4-8'])('persists an explicit %s selection', async (model) => {
+  it.each(['claude-fable-5', 'claude-opus-5'])('persists an explicit %s selection', async (model) => {
     const eff = makeEffects({ loadedProviderNames: new Set(['claude-code']) });
     await provision({ provider: 'claude-code', model }, eff);
     expect(eff.writeConfig).toHaveBeenCalledWith(expect.objectContaining({

--- a/packages/plugin-cli/src/session/picker-handlers.test.ts
+++ b/packages/plugin-cli/src/session/picker-handlers.test.ts
@@ -101,10 +101,10 @@ describe('makePickerHandler — model branch, unconnected provider', () => {
         setSystemNotice,
       }),
     );
-    handle(modelPicker, 'anthropic::claude-opus-4-8');
+    handle(modelPicker, 'anthropic::claude-opus-5');
     expect(openProviderConnect).toHaveBeenCalledWith({
       providerId: 'anthropic',
-      modelId: 'claude-opus-4-8',
+      modelId: 'claude-opus-5',
     });
     expect(setSystemNotice).not.toHaveBeenCalled();
   });
@@ -119,7 +119,7 @@ describe('makePickerHandler — model branch, unconnected provider', () => {
         setSystemNotice,
       }),
     );
-    handle(modelPicker, 'anthropic::claude-opus-4-8');
+    handle(modelPicker, 'anthropic::claude-opus-5');
     expect(openProviderConnect).not.toHaveBeenCalled();
     expect(setSystemNotice).toHaveBeenCalledWith(
       expect.stringContaining("anthropic isn't connected"),

--- a/packages/plugin-cli/src/session/use-turn-runner.test.ts
+++ b/packages/plugin-cli/src/session/use-turn-runner.test.ts
@@ -64,7 +64,7 @@ describe('useTurnRunner force-send drain (u79-1)', () => {
 
     const handle = mountFreshHook({
       session,
-      resolveModel: () => 'claude-opus-4-8',
+      resolveModel: () => 'claude-opus-5',
       stream: makeStream(),
     });
     const turnPromise = handle.runTurnWith('research this', []);

--- a/packages/plugin-plugins-admin/src/provider-catalog.generated.ts
+++ b/packages/plugin-plugins-admin/src/provider-catalog.generated.ts
@@ -15,7 +15,7 @@ export const PROVIDER_PLUGIN_CATALOG = [
     ],
     "provider": {
       "auth": "key",
-      "defaultModel": "claude-opus-4-8",
+      "defaultModel": "claude-opus-5",
       "recommended": true
     }
   },

--- a/packages/plugin-provider-admin/src/store.test.ts
+++ b/packages/plugin-provider-admin/src/store.test.ts
@@ -85,17 +85,17 @@ describe('stored-provider tree store (plugins.provider.items)', () => {
     // NOT a stored vendor; provider_remove must never delete those prefs.
     await fs.writeFile(
       cfgPath,
-      'plugins:\n  provider:\n    items:\n      anthropic:\n        model: claude-opus-4-8\n',
+      'plugins:\n  provider:\n    items:\n      anthropic:\n        model: claude-opus-5\n',
     );
     expect(await removeStoredProvider('anthropic', cfgPath)).toBe(false);
     const text = await fs.readFile(cfgPath, 'utf8');
-    expect(text).toContain('claude-opus-4-8');
+    expect(text).toContain('claude-opus-5');
   });
 
   it('coexists with picker-written model/enabled prefs on OTHER items', async () => {
     await fs.writeFile(
       cfgPath,
-      'plugins:\n  provider:\n    default: anthropic\n    items:\n      anthropic:\n        model: claude-opus-4-8\n',
+      'plugins:\n  provider:\n    default: anthropic\n    items:\n      anthropic:\n        model: claude-opus-5\n',
     );
     await upsertStoredProvider(sampleEntry, cfgPath);
     const cfg = await readProvidersConfig(cfgPath);
@@ -103,7 +103,7 @@ describe('stored-provider tree store (plugins.provider.items)', () => {
     expect(cfg.providers.map((p) => p.name)).toEqual(['zai']);
     // …and the built-in's prefs survive untouched.
     const text = await fs.readFile(cfgPath, 'utf8');
-    expect(text).toContain('claude-opus-4-8');
+    expect(text).toContain('claude-opus-5');
     expect(text).toContain('default: anthropic');
   });
 

--- a/packages/plugin-provider-anthropic/README.md
+++ b/packages/plugin-provider-anthropic/README.md
@@ -25,7 +25,7 @@ session.pluginHost.registerStatic(anthropicPlugin);
 
 session.providers.setActive('anthropic', {
   apiKey: process.env.ANTHROPIC_API_KEY,
-  // model: 'claude-opus-4-8',   // optional — defaults to the built-in catalog
+  // model: 'claude-opus-5',   // optional — defaults to the built-in catalog
 });
 
 for await (const e of runTurn(session, 'Write a haiku about TypeScript.')) {

--- a/packages/plugin-provider-anthropic/package.json
+++ b/packages/plugin-provider-anthropic/package.json
@@ -60,7 +60,7 @@
       ],
       "provider": {
         "auth": "key",
-        "defaultModel": "claude-opus-4-8",
+        "defaultModel": "claude-opus-5",
         "recommended": true
       }
     }

--- a/packages/plugin-provider-anthropic/src/provider.ts
+++ b/packages/plugin-provider-anthropic/src/provider.ts
@@ -66,17 +66,17 @@ export interface AnthropicProviderConfig {
 // Hardcoded model catalog (re-exported to @moxxy/plugin-provider-claude-code, which
 // reuses this provider class for the subscription path). Deriving it from the Models
 // API is a larger change (auth + caching) — deliberately deferred (TECH_DEBT P3 #8).
-// Values verified against the current Anthropic model catalog (2026-06): fable-5,
-// opus-4-8, opus-4-7 and opus-4-6 carry a 1M context window with a 128k streaming
+// Values verified against the current Anthropic model catalog (2026-07): fable-5,
+// opus-5, opus-4-7 and opus-4-6 carry a 1M context window with a 128k streaming
 // ceiling; sonnet-4-6 is 1M/64k; haiku-4-5 is 200k/64k. fable-5 is Anthropic's most
 // capable model (always-on reasoning); the loop never sets `temperature`, which
-// fable-5/opus-4-8/4.7 reject — so they stream cleanly here, same as opus-4-7 already did.
+// fable-5/opus-5/4.7 reject, so they stream cleanly here, same as opus-4-7 already did.
 // `supportsReasoning` marks models that accept adaptive thinking (`thinking:
-// {type:'adaptive', display:'summarized'}`) — fable-5/opus-4-8/4-7/4-6 and sonnet-4-6
+// {type:'adaptive', display:'summarized'}`) — fable-5/opus-5/4-7/4-6 and sonnet-4-6
 // do; haiku-4-5 does not (effort/adaptive-thinking error there), so it stays off.
 export const anthropicModels: ReadonlyArray<ModelDescriptor> = [
   { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
-  { id: 'claude-opus-4-8', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'claude-opus-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
   { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
   { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
   { id: 'claude-sonnet-4-6', contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },

--- a/packages/plugin-provider-anthropic/src/provider.ts
+++ b/packages/plugin-provider-anthropic/src/provider.ts
@@ -68,7 +68,7 @@ export interface AnthropicProviderConfig {
 // API is a larger change (auth + caching) — deliberately deferred (TECH_DEBT P3 #8).
 // Values verified against the current Anthropic model catalog (2026-07): fable-5,
 // opus-5, opus-4-7 and opus-4-6 carry a 1M context window with a 128k streaming
-// ceiling; sonnet-4-6 is 1M/64k; haiku-4-5 is 200k/64k. fable-5 is Anthropic's most
+// ceiling; sonnet-5 and sonnet-4-6 are 1M/64k; haiku-4-5 is 200k/64k. fable-5 is Anthropic's most
 // capable model (always-on reasoning); the loop never sets `temperature`, which
 // fable-5/opus-5/4.7 reject, so they stream cleanly here, same as opus-4-7 already did.
 // `supportsReasoning` marks models that accept adaptive thinking (`thinking:
@@ -79,6 +79,7 @@ export const anthropicModels: ReadonlyArray<ModelDescriptor> = [
   { id: 'claude-opus-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
   { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
   { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'claude-sonnet-5', contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
   { id: 'claude-sonnet-4-6', contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
   { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, hostedTools: ['web_search'] },
 ];

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -60,6 +60,7 @@ describe('claude-code provider definition', () => {
       'claude-sonnet-4-6',
       'claude-fable-5',
       'claude-opus-5',
+      'claude-sonnet-5',
       'claude-opus-4-7',
       'claude-opus-4-6',
       'claude-haiku-4-5-20251001',

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -59,7 +59,7 @@ describe('claude-code provider definition', () => {
     expect(claudeCodeProviderDef.models.map((model) => model.id)).toEqual([
       'claude-sonnet-4-6',
       'claude-fable-5',
-      'claude-opus-4-8',
+      'claude-opus-5',
       'claude-opus-4-7',
       'claude-opus-4-6',
       'claude-haiku-4-5-20251001',
@@ -290,7 +290,7 @@ describe('claude-code provider definition', () => {
     expect(args).not.toContain('bypassPermissions');
   });
 
-  it.each(['claude-fable-5', 'claude-opus-4-8'])('passes the selected %s model as an exact structured argument', async (model) => {
+  it.each(['claude-fable-5', 'claude-opus-5'])('passes the selected %s model as an exact structured argument', async (model) => {
     const dir = await makeFakeClaude([
       { type: 'result', subtype: 'success', is_error: false, usage: { input_tokens: 1, output_tokens: 1 } },
     ]);

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -28,7 +28,7 @@ const textOnlyCapabilities = {
 export const claudeCodeModels: ReadonlyArray<ModelDescriptor> = [
   { id: CLAUDE_CODE_DEFAULT_MODEL, contextWindow: 1_000_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },
   { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
-  { id: 'claude-opus-4-8', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
+  { id: 'claude-opus-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
   { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
   { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
   { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -29,6 +29,7 @@ export const claudeCodeModels: ReadonlyArray<ModelDescriptor> = [
   { id: CLAUDE_CODE_DEFAULT_MODEL, contextWindow: 1_000_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },
   { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
   { id: 'claude-opus-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
+  { id: 'claude-sonnet-5', contextWindow: 1_000_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },
   { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
   { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
   { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },

--- a/packages/sdk/src/compactor-helpers.test.ts
+++ b/packages/sdk/src/compactor-helpers.test.ts
@@ -247,7 +247,7 @@ describe('runCompactionIfNeeded', () => {
       compactor,
       model: 'claude-opus-4-7', // the listed descriptor
       contextWindow: 800_000,
-      ctxModelId: 'claude-opus-4-8', // …but the session runs an unlisted id
+      ctxModelId: 'claude-opus-4-8', // …but the session runs a retired, unlisted id
     });
     await runCompactionIfNeeded(ctx);
     // Falls back to models[0].contextWindow instead of bailing.

--- a/packages/sdk/src/compactor-helpers.ts
+++ b/packages/sdk/src/compactor-helpers.ts
@@ -118,7 +118,7 @@ function safeJsonLen(v: unknown): number {
  *
  * `config.model` is a free-form, unvalidated string, and providers happily
  * serve ids that aren't in their fixed descriptor list — a newer release
- * (`claude-opus-4-8`), a dated id, or a model registered at runtime via
+ * (`claude-opus-5`), a dated id, or a model registered at runtime via
  * provider-admin. So an exact `models.find(m => m.id === ctx.model)` often
  * MISSES, and both auto-compaction and auto-elision used to silently turn into
  * permanent no-ops for the whole session (the context then grows unbounded and


### PR DESCRIPTION
Opus 4.8 is retired, so listing it meant offering a picker entry that cannot serve a request. `claude-opus-5` takes its slot in the Anthropic API catalog and the Claude Code subscription catalog, and becomes the Anthropic plugin's recommended `defaultModel` (regenerated into `provider-catalog.generated.ts` via its script, not hand-edited).

`claude-fable-5` was already listed in both catalogs, so nothing to add there.

Two things worth a reviewer's attention:

**The new row's capabilities are copied from the opus line**, not verified against the Models API: 1M context, 128k output, tools, images, documents, adaptive thinking, hosted web search. The catalog is still hardcoded, which is already logged as TECH_DEBT P3 #8.

**Removing 4.8 proved the Claude Code catalog is enforced, not advisory.** A test that passes a selected model through to the CLI started failing with ENOENT once `claude-opus-4-8` left the catalog: the model never reached the process at all. That is good behaviour and worth knowing, since it means a stale id in config fails loudly rather than silently falling back.

Tests that enumerate real catalog models were updated with it. `compactor-helpers.test.ts` deliberately keeps `claude-opus-4-8` as its example of an unlisted id, which is more accurate now than when it was written.

I did not add `claude-sonnet-5`, since you named only fable 5 and opus 5 and `claude-sonnet-4-6` is still the default. Say the word if it should go in too.

Verified: build, typecheck and lint clean; affected provider/CLI suites pass with `--force`.

One unrelated flake to flag rather than bury: `packages/cli/src/setup/workflows.test.ts > a fileChanged edit runs the workflow ONCE across two concurrent runners` fails intermittently (1 in 6 idle, more under load). It is an `fs.watch` startup race on macOS, nothing to do with model ids, and my earlier timeout bump addressed the wrong layer. Fixing it properly is a separate change.