### PR TITLE
fix(test): remove the fs.watch race in the fileChanged concurrency test

### DIFF
--- a/.changeset/fix-filechanged-flake.md
+++ b/.changeset/fix-filechanged-flake.md
@@ -1,0 +1,11 @@
+---
+'@moxxy/cli': patch
+---
+
+Fix the workflows `fileChanged`-across-two-runners test, which was still failing after being declared fixed.
+
+The earlier attempt treated it as a timing budget and raised the timeout. It is not a timing problem: `fs.watch(dir, { recursive: true })` is FSEvents on macOS and is not delivering yet when the call returns, so the single write issued right after boot fell into that gap and was dropped outright. No amount of waiting rescues a dropped event, which is why the bigger budget changed nothing.
+
+The test now writes in a bounded retry loop and stops at the first observed run. Retrying cannot weaken the at-most-once assertion it exists for, because duplicates collapse twice over: the 600ms debounce coalesces events per watch key, and the `wf-file:` fire lock (3s TTL) coalesces fires per key across both runners.
+
+No production code changed.

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -24,6 +24,23 @@ or recorded-on-purpose decision.
 
 ## Resolved ledger
 
+- [med, tests/determinism, RESOLVED 2026-07-28] The workflows
+  `fileChanged`-across-two-runners test was still failing (1 in 6 idle, 2 in 3
+  under load) after being declared fixed on 2026-07-27. The earlier fix treated
+  it as a timing budget problem; it is not one. `fs.watch(dir, {recursive:true})`
+  is FSEvents on macOS and is not delivering when the call returns, so the single
+  write issued right after boot fell into that gap and was dropped outright. No
+  waiting rescues a dropped event, which is why a bigger timeout changed nothing.
+  The test now writes in a bounded retry loop and stops at the first observed
+  run. Retrying cannot weaken the at-most-once assertion because duplicates
+  collapse twice: the 600 ms debounce coalesces events per watch key, and the
+  `wf-file:` fire lock (3 s TTL) coalesces fires per key across both runners.
+  Verified 12/12 idle, 6/6 under a full `turbo run test --force`, and
+  mutation-checked both ways: disabling the fire lock still fails with "got 2",
+  and a watcher that never registers fails in 15 s with a named message rather
+  than hanging. `packages/cli/src/setup/workflows.test.ts`.
+
+
 - [med, tests/determinism, RESOLVED 2026-07-27] Three suites failed only under
   full-suite parallelism, which made a local `pnpm test` unable to distinguish a
   regression from load. Each was a test asserting wall-clock timing rather than
@@ -33,7 +50,8 @@ or recorded-on-purpose decision.
   all. The workflows `fileChanged`-across-two-runners test raised its `vi.waitFor`
   budget to 20 s while vitest's default TEST timeout stayed 10 s, so the generous
   budget was dead code and the test died first; it now declares its own 40 s
-  timeout. `isolator-subprocess`'s cooperative-abort test asserted that the
+  timeout. THAT DIAGNOSIS WAS INCOMPLETE and the test kept failing (see the
+  2026-07-28 entry below). `isolator-subprocess`'s cooperative-abort test asserted that the
   production 150 ms grace was enough for a child to be scheduled AND flush, which
   is a measurement of machine load; `abortGraceMs` is now injectable and the test
   passes a generous value, asserting the mechanism while the production default

--- a/packages/cli/src/setup/workflows.test.ts
+++ b/packages/cli/src/setup/workflows.test.ts
@@ -562,15 +562,31 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
     const a = await boot('runner-A');
     const b = await boot('runner-B');
     try {
-      await fs.writeFile(path.join(watchedDir, 'note.txt'), 'hello');
-      // Wait until at least one runner has fired. Generous timeout: under
-      // full-suite load the fs watcher + debounce routinely exceeded 4s,
-      // making this the repo's flakiest test (TECH_DEBT 2026-07-03) — the
-      // assertion is about AT-MOST-ONCE semantics, not latency.
-      await vi.waitFor(() => expect(runs.length).toBeGreaterThanOrEqual(1), {
-        timeout: 20000,
-        interval: 50,
-      });
+      // Write, and write AGAIN if nothing fired, until a run is observed.
+      //
+      // `fs.watch(dir, { recursive: true })` is FSEvents on macOS, and the
+      // stream is not delivering yet when the call returns. A single write
+      // issued right after boot lands in that gap and is dropped outright, so
+      // no waiting rescues it: the event never comes. That is what made this
+      // the repo's flakiest test, and why raising the timeout did not help.
+      //
+      // Retrying is safe, and does not weaken the at-most-once assertion,
+      // because duplicates collapse twice over: the 600ms debounce coalesces
+      // events per watch key, and the `wf-file:` fire lock (3s TTL) coalesces
+      // fires per key across BOTH runners. So extra writes cannot manufacture
+      // the second run this test exists to rule out. We stop at the first
+      // observed run regardless, and a genuinely dead watcher still fails,
+      // because the attempts are bounded.
+      const attempts = 10;
+      for (let i = 0; i < attempts && runs.length === 0; i++) {
+        await fs.writeFile(path.join(watchedDir, 'note.txt'), `hello ${i}`);
+        // Past the 600ms debounce, plus slack for a loaded machine.
+        await vi.waitFor(() => expect(runs.length).toBeGreaterThanOrEqual(1), {
+          timeout: 1500,
+          interval: 25,
+        }).catch(() => undefined);
+      }
+      expect(runs.length, 'the fs watcher never delivered an event').toBeGreaterThanOrEqual(1);
       // ...then give the other runner ample time to (wrongly) also fire. It must
       // not: the cross-process lock lets exactly one claim the change.
       await new Promise((r) => setTimeout(r, 700));
@@ -579,10 +595,6 @@ describe('buildWorkflowsIntegration afterWorkflow wiring', () => {
       a.stop();
       b.stop();
     }
-    // Test timeout must exceed the waitFor budget above. It did not: the
-    // waitFor was raised to 20s to survive load, but vitest's default test
-    // timeout is 10s, so the test died first and the generous budget was dead
-    // code. That is the failure this test has been showing under load.
   }, 40_000);
 
   it('stop() cancels a pending fileChanged debounce so it does not fire after teardown', async () => {


### PR DESCRIPTION
This test was declared fixed on 2026-07-27 and kept failing: **1 in 6 idle, 2 in 3 under load**. I made that premature claim, so this corrects both the test and the ledger entry.

### The earlier diagnosis was wrong

It was treated as a timing budget: `vi.waitFor` had 20s while vitest's default test timeout was 10s, so the timeout was raised to 40s. That reasoning was sound but described a different bug, and the test kept failing.

It is not a timing problem. `fs.watch(dir, { recursive: true })` is FSEvents on macOS, and the stream is **not delivering when the call returns**. The single write issued right after boot fell into that gap and was dropped outright. No amount of waiting rescues an event that never arrives, which is exactly why a bigger budget did nothing.

### The fix

The write happens in a bounded retry loop that stops at the first observed run.

Retrying does not weaken the at-most-once assertion the test exists for, because duplicates collapse twice over:
- the 600ms debounce coalesces events per watch key, and
- the `wf-file:` fire lock (3s TTL) coalesces fires per key across **both** runners.

So extra writes cannot manufacture the second run this test is meant to rule out. No production code changed.

### Verified

- 12/12 idle, and 6/6 while a full `turbo run test --force` ran concurrently (the load that used to break it).
- Full workspace suite green (7473 tests, exit 0).
- Mutation-checked in both directions: disabling the fire lock still fails with `expected [...] to have a length of 1 but got 2`, so the guarantee is genuinely covered; and a watcher that never registers fails in 15s with `the fs watcher never delivered an event` rather than hanging to the timeout.

The TECH_DEBT "Resolved" entry from 2026-07-27 now says its diagnosis was incomplete instead of leaving a wrong claim on the record.