### PR TITLE
fix(desktop): resolve the renderer host without DNS, and drop the chat bubble

### DIFF
--- a/.changeset/desktop-dns-and-bubbles.md
+++ b/.changeset/desktop-dns-and-bubbles.md
@@ -1,0 +1,11 @@
+---
+'@moxxy/desktop': patch
+---
+
+Fix the blank desktop window, and drop the chat bubble for plain text.
+
+**Blank window.** The packaged app serves its renderer from a loopback HTTPS server at `https://desktop.moxxy.ai:<port>`, because a Clerk production key rejects any Origin that is not a `moxxy.ai` host. Resolving that name was left to a public DNS A-record pointing at 127.0.0.1, so every installed copy depended on one record staying alive. It stopped resolving, and every app opened to an empty window with only `ERR_NAME_NOT_RESOLVED` in a log nobody reads.
+
+Chromium now maps that one hostname to loopback itself, set in the bootstrap prologue (before the network stack initialises, and inside the immutable floor so a bad hot-update cannot remove the rule the app needs to load its own UI). The app no longer needs DNS to start, which also means it opens offline, on a filtered corporate resolver, and cannot be pointed elsewhere by whoever controls the zone. A test keeps the duplicated hostname literal in step with `DESKTOP_APP_HOST`.
+
+**Chat bubble.** A user prompt rendered as a gradient-filled rounded bubble with white ink, a text-shadow and a drop shadow, all to keep one short line readable against itself. Right alignment already says whose turn it is, so it is now just text.

--- a/apps/desktop/electron/main/bootstrap.ts
+++ b/apps/desktop/electron/main/bootstrap.ts
@@ -37,6 +37,7 @@ import {
 import { BUNDLED_UPDATE_PUBLIC_KEY } from './update-key.js';
 import { FLOOR_RUNNER_PROTOCOL } from './floor-runner-protocol.js';
 import { registerAppAssetSchemePrivileged } from './app-scheme.js';
+import { pinRendererHostToLoopback } from './renderer-host.js';
 
 // MUST run before any `app.getPath('userData')` below. `userData` resolves to
 // `…/Application Support/<app.getName()>`, and in a packaged build Electron
@@ -60,6 +61,12 @@ app.setName('MoxxyAI Workspaces');
 // downgrade). The privileges live in `./app-scheme` so this and `index.ts`
 // can't disagree.
 registerAppAssetSchemePrivileged();
+
+// Same prologue, same reason: Chromium reads the resolver switch when the
+// network stack initialises, which is before `whenReady`. Without it the
+// packaged renderer's hostname has to be resolved by public DNS, so one missing
+// A-record blanks every installed app.
+pinRendererHostToLoopback(app);
 
 /** Dir holding this bootstrap + the baked floor `index.js` (…/dist-electron/main). */
 const floorMainDir = import.meta.dirname;

--- a/apps/desktop/electron/main/renderer-host.test.ts
+++ b/apps/desktop/electron/main/renderer-host.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { App } from 'electron';
+import { DESKTOP_APP_HOST } from '@moxxy/desktop-host';
+import { RENDERER_HOST, pinRendererHostToLoopback } from './renderer-host.js';
+
+const fakeApp = (existing = ''): { app: App; switches: Array<[string, string]> } => {
+  const switches: Array<[string, string]> = [];
+  return {
+    switches,
+    app: {
+      commandLine: {
+        getSwitchValue: () => existing,
+        appendSwitch: (k: string, v: string) => switches.push([k, v]),
+      },
+    } as unknown as App,
+  };
+};
+
+describe('renderer host pinning', () => {
+  it('matches the host the loopback server actually serves', () => {
+    // The literal is duplicated into the floor to keep a heavy import out of
+    // the bootstrap prologue. Drift would mean the app maps one name and
+    // requests another, which is precisely the blank window this prevents.
+    expect(RENDERER_HOST).toBe(DESKTOP_APP_HOST);
+  });
+
+  it('maps the renderer host to loopback so no DNS lookup is needed', () => {
+    const { app, switches } = fakeApp();
+
+    pinRendererHostToLoopback(app);
+
+    expect(switches).toEqual([['host-resolver-rules', 'MAP desktop.moxxy.ai 127.0.0.1']]);
+  });
+
+  it('keeps an operator-supplied rule instead of overwriting it', () => {
+    const { app, switches } = fakeApp('MAP api.internal 10.0.0.5');
+
+    pinRendererHostToLoopback(app);
+
+    expect(switches[0]?.[1]).toBe('MAP api.internal 10.0.0.5,MAP desktop.moxxy.ai 127.0.0.1');
+  });
+
+  it('maps only the renderer host, never a wildcard', () => {
+    const { app, switches } = fakeApp();
+
+    pinRendererHostToLoopback(app);
+
+    // A blanket MAP * would silently reroute every request the app makes.
+    expect(switches[0]?.[1]).not.toContain('*');
+  });
+});

--- a/apps/desktop/electron/main/renderer-host.ts
+++ b/apps/desktop/electron/main/renderer-host.ts
@@ -1,0 +1,43 @@
+import type { App } from 'electron';
+
+/**
+ * The hostname the packaged renderer is served on.
+ *
+ * Duplicated from `DESKTOP_APP_HOST` in `@moxxy/desktop-host` rather than
+ * imported: this runs in the bootstrap's synchronous prologue, which is the
+ * immutable floor, and importing the host barrel there drags the whole main
+ * process in before `app` is ready. That has crashed boot before. A test keeps
+ * the two literals in agreement, which a comment would not.
+ */
+export const RENDERER_HOST = 'desktop.moxxy.ai';
+
+/**
+ * Resolve the renderer's hostname to loopback inside Chromium, without DNS.
+ *
+ * The renderer is served from a loopback HTTPS server but must carry a
+ * `moxxy.ai` Origin, because a Clerk production key rejects anything else.
+ * That was achieved with a public A-record pointing `desktop.moxxy.ai` at
+ * 127.0.0.1, which made every installed copy depend on one DNS record staying
+ * alive: when it stopped resolving, every app opened to a blank window with
+ * only `ERR_NAME_NOT_RESOLVED` in a log nobody reads. It also meant the app
+ * could not open on a plane, on a filtered corporate resolver, or anywhere DNS
+ * was slow.
+ *
+ * Mapping it here removes the dependency entirely. It is also strictly safer:
+ * the name can no longer be pointed anywhere by whoever controls the zone.
+ *
+ * MUST be called before `app` is ready; Chromium reads this switch at network
+ * stack init. Kept in the floor so a bad hot-update cannot remove the one rule
+ * the app needs to load its own UI.
+ */
+export function pinRendererHostToLoopback(electronApp: App): void {
+  const existing = electronApp.commandLine.getSwitchValue('host-resolver-rules');
+  const rule = `MAP ${RENDERER_HOST} 127.0.0.1`;
+  // Append rather than overwrite: an operator debugging with their own
+  // --host-resolver-rules should not silently lose it, and Chromium applies
+  // the first matching rule, so theirs still wins for other hosts.
+  electronApp.commandLine.appendSwitch(
+    'host-resolver-rules',
+    existing ? `${existing},${rule}` : rule,
+  );
+}

--- a/apps/desktop/src/chat/blocks/UserBlock.tsx
+++ b/apps/desktop/src/chat/blocks/UserBlock.tsx
@@ -145,20 +145,18 @@ export function UserBlock({
       {(text.length > 0 || !hasAttachments) && (
         <div
           style={{
-            padding: '12px 16px',
-            // Solid contrast-safe base UNDER the gradient: if the lightest
-            // gradient stop resolves too pale in a given theme, the dark base
-            // (and the text-shadow below) keep the white prompt text legible.
-            backgroundColor: 'var(--color-primary-strong)',
-            backgroundImage: 'var(--grad-user)',
-            color: '#fff',
-            // Guarantees the white text stays readable over the lightest stop.
-            textShadow: '0 1px 2px rgba(15, 23, 42, 0.45)',
-            borderRadius: '16px 16px 4px 16px',
+            // Just the text. The gradient bubble it replaces carried a solid
+            // base, a gradient, white ink, a text-shadow and a drop shadow, all
+            // to keep one short line readable against itself. Right alignment
+            // already says whose turn this is, so none of that chrome was
+            // paying for the noise it added.
+            padding: '2px 0',
+            color: 'var(--color-text)',
+            fontWeight: 500,
+            textAlign: 'right',
             whiteSpace: 'pre-wrap',
             lineHeight: 1.55,
             fontSize: 14.5,
-            boxShadow: '0 6px 18px -10px color-mix(in srgb, var(--color-primary) 55%, transparent)',
           }}
         >
           {text}


### PR DESCRIPTION
### The blank window

The packaged app serves its renderer from a loopback HTTPS server at `https://desktop.moxxy.ai:<port>`, because a Clerk production key rejects any Origin that is not a `moxxy.ai` host. Resolving that name was left to a public DNS A-record pointing at 127.0.0.1 (the code says so: *"a public DNS A-record → 127.0.0.1 (owner-provisioned)"*).

That record no longer resolves, so **every installed copy opens to an empty window**:

```
electron: Failed to load URL: https://desktop.moxxy.ai:51789/index.html
  with error: ERR_NAME_NOT_RESOLVED
```

Confirmed on the shipped 0.32.0 build: `desktop.moxxy.ai` does not resolve, there is no hosts entry, and `moxxy.ai` itself resolves fine, so it is that record specifically. Launching the same binary with `--host-resolver-rules="MAP desktop.moxxy.ai 127.0.0.1"` renders normally, which proves both the cause and the fix.

Chromium now applies that mapping itself, from the bootstrap prologue. Two reasons for that placement: the switch must be read before the network stack initialises, and the prologue is the immutable floor, so a bad hot-update cannot remove the one rule the app needs to load its own UI.

Beyond fixing today's outage this removes a single point of failure for every installed app, lets it open offline or behind a filtered corporate resolver, and means the hostname can no longer be pointed anywhere by whoever controls the zone.

The hostname literal is duplicated into the floor rather than imported, because importing the host barrel into the prologue has crashed boot before; a test asserts it equals `DESKTOP_APP_HOST` and fails on drift.

**You can unblock everyone right now without waiting for this release** by restoring the `desktop.moxxy.ai` A-record to 127.0.0.1. This change is what stops it mattering next time.

### The chat bubble

A user prompt rendered as a gradient-filled rounded bubble with white ink, a text-shadow *and* a drop shadow, all to keep one short line legible against itself. Right alignment already says whose turn it is, so it is now just text.

I left `--grad-user` defined. It has no consumer now, but removing it means removing `gradient.user` from the shared design system (the parity test correctly caught the half-measure), which is a bigger call than a visual tweak. Say the word and I will retire the token properly.

### Verified

Full workspace green (7477 tests, exit 0), desktop suite 538/538, lint clean. The mapping was proven against the real packaged app, and the drift guard was mutation-checked. I did not rebuild the packaged app to re-verify end to end, since the fix was validated by running the shipped binary with the same switch.