### PR TITLE
feat(brand): retune the desktop and mobile palette to Ink and Signal

### DIFF
--- a/.changeset/ink-signal-desktop.md
+++ b/.changeset/ink-signal-desktop.md
@@ -1,0 +1,37 @@
+---
+'@moxxy/desktop': minor
+'@moxxy/design-tokens': minor
+---
+
+Retune the desktop and mobile palette to the woven brand.
+
+The muted blue the palette landed on carries nothing of the mark: the brand is
+Ink (`#0B0D12`) plus Signal (`#FF4A1E`) on paper, so every accent in the app
+read cool around a warm mark.
+
+`@moxxy/design-tokens` is the source of truth for the desktop CSS variables and
+the mobile Tailwind config, so the change lands in one place and reaches every
+component that reads a variable. Signal becomes the primary, send and focus
+colour; the secondary moves into Signal's family; the canvas goes neutral so
+nothing fights Signal's warmth; and the text ramp becomes Ink.
+
+Interactive fills take Signal's DEEP stop (`#C4310F`), not the flat mark
+colour: white on flat Signal is 3.36:1, and a CTA label is the one place that
+cannot be borderline. Flat Signal lives on as the mark, the focus ring and the
+soft washes. On dark it lifts again, to `#FF6A44`, for the same reason the mark
+ships a `-dark` variant rather than being recoloured by CSS. The contrast suite
+covers both themes.
+
+Categorical and semantic hues are deliberately left alone. A workflow step kind
+is identified by its hue and green/amber/red mean success/attention/error, so
+collapsing them into the brand's single accent would destroy information. Only
+the fallback moves to Signal.
+
+Headings now take Space Grotesk, echoing the wordmark's geometric
+construction. It joins the Google Fonts request Inter already makes, and the
+stack falls back to Inter, so an offline launch looks exactly as it does today.
+
+Also swept: the standalone focus window carried a second copy of the palette,
+and a handful of components had the old hexes inline, including the pink glows
+and plan badges the previous retone left behind. The voice spectrogram keeps
+its blue-violet-pink ramp: that is a data gradient, not a brand accent.

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -14,13 +14,13 @@
       crossorigin
     />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
   </head>
   <body>
     <style>
-      html, body { margin: 0; background: rgb(252, 252, 255); color: #0f172a;
+      html, body { margin: 0; background: #ffffff; color: #0b0d12;
         font-family: 'Inter', -apple-system, system-ui, sans-serif; }
       #splash-fallback { position: fixed; inset: 0; display: flex;
         flex-direction: column; align-items: center; justify-content: center;
@@ -29,9 +29,9 @@
          no bundle. A quarter turn is a full loop: the mark is symmetric under
          90deg, so the animation closes on itself. Mirrors .moxxy-avatar-loader
          in styles.css so the pre-React and post-React splashes look identical. */
-      #splash-fallback .mark { width: 64px; height: 64px; color: #0f172a;
+      #splash-fallback .mark { width: 64px; height: 64px; color: #0b0d12;
         animation: splash-turn 3.4s linear infinite; }
-      #splash-fallback .label { font-size: 0.85rem; color: #475569;
+      #splash-fallback .label { font-size: 0.85rem; color: #55596b;
         letter-spacing: 0.04em; font-family: 'JetBrains Mono', monospace; }
       @keyframes splash-turn { to { transform: rotate(90deg); } }
       /* Dark splash — main sets nativeTheme.themeSource from the persisted
@@ -39,9 +39,9 @@
          user's choice (not just the OS) by the time this CSS evaluates. The
          colors mirror styles.css's dark --color-main-bg / text tokens. */
       @media (prefers-color-scheme: dark) {
-        html, body { background: #101117; color: #e8eaf6; }
-        #splash-fallback .label { color: #a4abc8; }
-        #splash-fallback .mark { color: #e8eaf6; }
+        html, body { background: #0b0d12; color: #edeef2; }
+        #splash-fallback .label { color: #9096a6; }
+        #splash-fallback .mark { color: #edeef2; }
       }
       @media (prefers-reduced-motion: reduce) {
         #splash-fallback .mark { animation: none; }

--- a/apps/desktop/src/ErrorBoundary.tsx
+++ b/apps/desktop/src/ErrorBoundary.tsx
@@ -49,12 +49,12 @@ export class ErrorBoundary extends Component<Props, State> {
           // Theme vars with literal fallbacks: the boundary must still
           // render legibly if the app stylesheet itself failed to load.
           background: 'var(--color-main-bg, rgb(252, 252, 255))',
-          color: 'var(--color-text, #0f172a)',
+          color: 'var(--color-text, #0b0d12)',
           fontFamily: "'Inter', -apple-system, system-ui, sans-serif",
         }}
       >
         <div style={{ fontSize: 18, fontWeight: 700 }}>MoxxyAI Workspaces hit an error</div>
-        <div style={{ fontSize: 14, color: 'var(--color-text-muted, #475569)' }}>
+        <div style={{ fontSize: 14, color: 'var(--color-text-muted, #55596b)' }}>
           The app failed to render. You can reload, or report this with the details below.
         </div>
         <pre
@@ -62,7 +62,7 @@ export class ErrorBoundary extends Component<Props, State> {
             margin: 0,
             padding: 16,
             borderRadius: 10,
-            background: '#0f172a',
+            background: '#0b0d12',
             color: '#e2e8f0',
             fontSize: 12,
             lineHeight: 1.5,
@@ -86,7 +86,7 @@ export class ErrorBoundary extends Component<Props, State> {
               padding: '0 20px',
               borderRadius: 10,
               border: 'none',
-              background: 'linear-gradient(135deg, #ec4899, #8b5cf6)',
+              background: 'linear-gradient(135deg, #d13d14, #9c2409)',
               color: '#fff',
               fontWeight: 600,
               fontSize: 14,

--- a/apps/desktop/src/focus/FocusWidget.test.tsx
+++ b/apps/desktop/src/focus/FocusWidget.test.tsx
@@ -825,8 +825,8 @@ describe('FocusWidget theme', () => {
     render(<FocusWidget />);
 
     expect(focusCss()).toContain('[data-theme="dark"]');
-    expect(focusCss()).toContain('--focus-panel-bg: #161823');
-    expect(focusCss()).toContain('--focus-preview-bg: rgba(22, 24, 35, 0.96)');
+    expect(focusCss()).toContain('--focus-panel-bg: #12151d');
+    expect(focusCss()).toContain('--focus-preview-bg: rgba(18, 21, 29, 0.96)');
   });
 });
 

--- a/apps/desktop/src/focus/focus-styles.ts
+++ b/apps/desktop/src/focus/focus-styles.ts
@@ -86,7 +86,7 @@ export const style = {
     border: '2px solid var(--focus-panel-bg)',
     borderRadius: 999,
     background: 'var(--color-primary)',
-    boxShadow: '0 0 10px rgba(236, 72, 153, 0.7)',
+    boxShadow: '0 0 10px rgba(255, 74, 30, 0.7)',
     pointerEvents: 'none',
   },
   focusPet: {
@@ -103,7 +103,7 @@ export const style = {
     inset: '23% 2% 3%',
     zIndex: -1,
     borderRadius: '50%',
-    background: 'radial-gradient(ellipse at 52% 58%, rgba(236, 72, 153, 0.3), transparent 68%)',
+    background: 'radial-gradient(ellipse at 52% 58%, rgba(255, 74, 30, 0.3), transparent 68%)',
     opacity: 0.48,
     transform: 'scale(0.92)',
     pointerEvents: 'none',
@@ -247,7 +247,7 @@ export const style = {
     width: 22,
     height: 22,
     boxSizing: 'border-box',
-    border: '3px solid rgba(236, 72, 153, 0.22)',
+    border: '3px solid rgba(255, 74, 30, 0.22)',
     borderTopColor: 'var(--color-primary)',
     borderRadius: 999,
     pointerEvents: 'none',
@@ -378,7 +378,7 @@ export const style = {
     height: 5,
     borderRadius: 999,
     background: 'var(--color-primary)',
-    boxShadow: '0 0 14px rgba(236, 72, 153, 0.8)',
+    boxShadow: '0 0 14px rgba(255, 74, 30, 0.8)',
   },
   focusAskTitle: {
     margin: 0,
@@ -467,10 +467,10 @@ export const style = {
     color: 'var(--focus-ask-text)',
   },
   focusAskButtonPrimary: {
-    background: 'linear-gradient(135deg, #ec4899, #d946ef)',
+    background: 'linear-gradient(135deg, #d13d14, #9c2409)',
     borderColor: 'rgba(255, 255, 255, 0.18)',
     color: '#ffffff',
-    boxShadow: '0 10px 22px rgba(236, 72, 153, 0.25)',
+    boxShadow: '0 10px 22px rgba(196, 49, 15, 0.25)',
   },
   focusAskButtonDisabled: {
     opacity: 0.45,
@@ -565,7 +565,7 @@ export const style = {
     justifyContent: 'center',
   },
   actionBtnActive: {
-    background: 'rgba(236, 72, 153, 0.14)',
+    background: 'rgba(255, 74, 30, 0.14)',
     color: 'var(--color-primary)',
     borderRadius: 11,
   },
@@ -794,7 +794,7 @@ export const style = {
     height: 34,
     border: 'none',
     borderRadius: 10,
-    background: 'linear-gradient(135deg, #ec4899, #d946ef)',
+    background: 'linear-gradient(135deg, #d13d14, #9c2409)',
     color: '#fff',
     cursor: 'pointer',
     display: 'inline-flex',
@@ -819,50 +819,50 @@ if (typeof document !== 'undefined') {
   styleTag.id = 'focus-keyframes';
   styleTag.textContent = `
     :root {
-      --color-text: #0f172a;
-      --color-text-muted: #475569;
-      --color-text-dim: #94a3b8;
-      --color-primary: #ec4899;
-      --color-primary-strong: #db2777;
-      --color-primary-soft: #fdf2f8;
+      --color-text: #0b0d12;
+      --color-text-muted: #55596b;
+      --color-text-dim: #8a8f9f;
+      --color-primary: #c4310f;
+      --color-primary-strong: #9c2409;
+      --color-primary-soft: #fff1ec;
       --color-surface: #ffffff;
-      --grad-user: linear-gradient(135deg, #ec4899 0%, #f472b6 100%);
-      --color-red: #ef4444;
-      --color-card-border: #e3e5f0;
-      --color-card-border-strong: #cdd1e3;
-      --color-code-bg: #f1f3fb;
-      --color-bg-card-hover: #f4f5fa;
+      --grad-user: linear-gradient(135deg, #c4310f 0%, #e2551f 100%);
+      --color-red: #c53030;
+      --color-card-border: #e4e4ea;
+      --color-card-border-strong: #d3d4dc;
+      --color-code-bg: #f2f2f5;
+      --color-bg-card-hover: #f7f7f9;
       --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 
       --focus-panel-bg: #ffffff;
-      --focus-panel-border: rgba(15, 23, 42, 0.14);
-      --focus-panel-shadow: 0 14px 32px rgba(15, 23, 42, 0.18);
-      --focus-text: #0f172a;
+      --focus-panel-border: rgba(11, 13, 18, 0.14);
+      --focus-panel-shadow: 0 14px 32px rgba(11, 13, 18, 0.18);
+      --focus-text: #0b0d12;
       --focus-muted: #64748b;
-      --focus-dim: #94a3b8;
-      --focus-divider: rgba(15, 23, 42, 0.12);
-      --focus-subtle-border: rgba(15, 23, 42, 0.08);
-      --focus-action-hover-bg: rgba(15, 23, 42, 0.06);
+      --focus-dim: #8a8f9f;
+      --focus-divider: rgba(11, 13, 18, 0.12);
+      --focus-subtle-border: rgba(11, 13, 18, 0.08);
+      --focus-action-hover-bg: rgba(11, 13, 18, 0.06);
       --focus-action-danger-bg: rgba(239, 68, 68, 0.12);
       --focus-preview-bg: rgba(255, 255, 255, 0.96);
       --focus-preview-border: rgba(203, 213, 225, 0.75);
       --focus-preview-shadow: none;
-      --focus-preview-text: #0f172a;
+      --focus-preview-text: #0b0d12;
       --focus-composer-bg: #ffffff;
       --focus-input-bg: #f8fafc;
-      --focus-input-border: rgba(15, 23, 42, 0.12);
+      --focus-input-border: rgba(11, 13, 18, 0.12);
       --focus-ask-bg: rgba(255, 255, 255, 0.97);
-      --focus-ask-border: rgba(15, 23, 42, 0.14);
-      --focus-ask-shadow: 0 18px 44px rgba(15, 23, 42, 0.18);
-      --focus-ask-text: #0f172a;
-      --focus-ask-title: #0f172a;
-      --focus-ask-body: #475569;
-      --focus-ask-kicker: #db2777;
-      --focus-ask-detail-bg: rgba(15, 23, 42, 0.045);
-      --focus-ask-detail-border: rgba(15, 23, 42, 0.10);
-      --focus-ask-detail-text: #1e293b;
-      --focus-ask-neutral-bg: rgba(15, 23, 42, 0.06);
-      --focus-ask-neutral-border: rgba(15, 23, 42, 0.10);
+      --focus-ask-border: rgba(11, 13, 18, 0.14);
+      --focus-ask-shadow: 0 18px 44px rgba(11, 13, 18, 0.18);
+      --focus-ask-text: #0b0d12;
+      --focus-ask-title: #0b0d12;
+      --focus-ask-body: #55596b;
+      --focus-ask-kicker: #c4310f;
+      --focus-ask-detail-bg: rgba(11, 13, 18, 0.045);
+      --focus-ask-detail-border: rgba(11, 13, 18, 0.10);
+      --focus-ask-detail-text: #21252f;
+      --focus-ask-neutral-bg: rgba(11, 13, 18, 0.06);
+      --focus-ask-neutral-border: rgba(11, 13, 18, 0.10);
       --focus-ask-danger-bg: rgba(239, 68, 68, 0.10);
       --focus-ask-danger-border: rgba(239, 68, 68, 0.22);
       --focus-ask-danger-text: #b91c1c;
@@ -870,38 +870,38 @@ if (typeof document !== 'undefined') {
     }
 
     [data-theme="dark"] {
-      --color-text: #e8eaf6;
-      --color-text-muted: #a4abc8;
-      --color-text-dim: #697091;
-      --color-primary: #ec4899;
-      --color-primary-strong: #db2777;
-      --color-primary-soft: #2b1622;
-      --color-surface: #1b1e2b;
-      --grad-user: linear-gradient(135deg, #ec4899 0%, #f472b6 100%);
-      --color-red: #ef4444;
-      --color-card-border: #262a3c;
-      --color-card-border-strong: #363c54;
-      --color-code-bg: #262b40;
-      --color-bg-card-hover: #1d2030;
+      --color-text: #edeef2;
+      --color-text-muted: #9096a6;
+      --color-text-dim: #6b7284;
+      --color-primary: #ff6a44;
+      --color-primary-strong: #ff4a1e;
+      --color-primary-soft: #2e1409;
+      --color-surface: #1a1e28;
+      --grad-user: linear-gradient(135deg, #ff6a44 0%, #ff9a5e 100%);
+      --color-red: #d97070;
+      --color-card-border: #232833;
+      --color-card-border-strong: #333947;
+      --color-code-bg: #232833;
+      --color-bg-card-hover: #191d26;
 
-      --focus-panel-bg: #161823;
+      --focus-panel-bg: #12151d;
       --focus-panel-border: rgba(148, 163, 184, 0.22);
       --focus-panel-shadow: 0 16px 38px rgba(0, 0, 0, 0.42);
-      --focus-text: #e8eaf6;
-      --focus-muted: #a4abc8;
-      --focus-dim: #697091;
+      --focus-text: #edeef2;
+      --focus-muted: #9096a6;
+      --focus-dim: #6b7284;
       --focus-divider: rgba(148, 163, 184, 0.18);
       --focus-subtle-border: rgba(148, 163, 184, 0.14);
       --focus-action-hover-bg: rgba(255, 255, 255, 0.08);
       --focus-action-danger-bg: rgba(239, 68, 68, 0.16);
-      --focus-preview-bg: rgba(22, 24, 35, 0.96);
+      --focus-preview-bg: rgba(18, 21, 29, 0.96);
       --focus-preview-border: rgba(148, 163, 184, 0.24);
       --focus-preview-shadow: 0 22px 54px rgba(0, 0, 0, 0.48);
       --focus-preview-text: #f8fafc;
-      --focus-composer-bg: #101117;
+      --focus-composer-bg: #0b0d12;
       --focus-input-bg: #121420;
-      --focus-input-border: #262a3c;
-      --focus-ask-bg: rgba(22, 24, 35, 0.97);
+      --focus-input-border: #232833;
+      --focus-ask-bg: rgba(18, 21, 29, 0.97);
       --focus-ask-border: rgba(148, 163, 184, 0.22);
       --focus-ask-shadow: 0 22px 54px rgba(0, 0, 0, 0.48);
       --focus-ask-text: #f8fafc;
@@ -921,34 +921,34 @@ if (typeof document !== 'undefined') {
 
     @media (prefers-color-scheme: dark) {
       :root:not([data-theme]) {
-        --color-text: #e8eaf6;
-        --color-text-muted: #a4abc8;
-        --color-text-dim: #697091;
-        --color-primary-soft: #2b1622;
-        --color-surface: #1b1e2b;
-        --grad-user: linear-gradient(135deg, #ec4899 0%, #f472b6 100%);
-        --color-card-border: #262a3c;
-        --color-card-border-strong: #363c54;
-        --color-code-bg: #262b40;
-        --color-bg-card-hover: #1d2030;
-        --focus-panel-bg: #161823;
+        --color-text: #edeef2;
+        --color-text-muted: #9096a6;
+        --color-text-dim: #6b7284;
+        --color-primary-soft: #2e1409;
+        --color-surface: #1a1e28;
+        --grad-user: linear-gradient(135deg, #ff6a44 0%, #ff9a5e 100%);
+        --color-card-border: #232833;
+        --color-card-border-strong: #333947;
+        --color-code-bg: #232833;
+        --color-bg-card-hover: #191d26;
+        --focus-panel-bg: #12151d;
         --focus-panel-border: rgba(148, 163, 184, 0.22);
         --focus-panel-shadow: 0 16px 38px rgba(0, 0, 0, 0.42);
-        --focus-text: #e8eaf6;
-        --focus-muted: #a4abc8;
-        --focus-dim: #697091;
+        --focus-text: #edeef2;
+        --focus-muted: #9096a6;
+        --focus-dim: #6b7284;
         --focus-divider: rgba(148, 163, 184, 0.18);
         --focus-subtle-border: rgba(148, 163, 184, 0.14);
         --focus-action-hover-bg: rgba(255, 255, 255, 0.08);
         --focus-action-danger-bg: rgba(239, 68, 68, 0.16);
-        --focus-preview-bg: rgba(22, 24, 35, 0.96);
+        --focus-preview-bg: rgba(18, 21, 29, 0.96);
         --focus-preview-border: rgba(148, 163, 184, 0.24);
         --focus-preview-shadow: 0 22px 54px rgba(0, 0, 0, 0.48);
         --focus-preview-text: #f8fafc;
-        --focus-composer-bg: #101117;
+        --focus-composer-bg: #0b0d12;
         --focus-input-bg: #121420;
-        --focus-input-border: #262a3c;
-        --focus-ask-bg: rgba(22, 24, 35, 0.97);
+        --focus-input-border: #232833;
+        --focus-ask-bg: rgba(18, 21, 29, 0.97);
         --focus-ask-border: rgba(148, 163, 184, 0.22);
         --focus-ask-shadow: 0 22px 54px rgba(0, 0, 0, 0.48);
         --focus-ask-text: #f8fafc;

--- a/apps/desktop/src/onboarding/steps/CliStep.tsx
+++ b/apps/desktop/src/onboarding/steps/CliStep.tsx
@@ -71,7 +71,7 @@ export function CliStep({
               style={{
                 margin: 0,
                 padding: 10,
-                background: '#0f172a',
+                background: '#0b0d12',
                 color: '#e2e8f0',
                 borderRadius: 10,
                 fontSize: 11,

--- a/apps/desktop/src/onboarding/steps/NodeStep.tsx
+++ b/apps/desktop/src/onboarding/steps/NodeStep.tsx
@@ -49,7 +49,7 @@ export function NodeStep({
               style={{
                 margin: 0,
                 padding: 10,
-                background: '#0f172a',
+                background: '#0b0d12',
                 color: '#e2e8f0',
                 borderRadius: 10,
                 fontSize: 11,

--- a/apps/desktop/src/settings/MobileTab.tsx
+++ b/apps/desktop/src/settings/MobileTab.tsx
@@ -221,7 +221,7 @@ export function MobileTab(): JSX.Element {
                     padding: '8px 10px',
                     // Deliberate literals: terminal-style chip is dark in both
                     // themes (same as the AboutTab update log).
-                    background: '#0f172a',
+                    background: '#0b0d12',
                     color: '#e2e8f0',
                     borderRadius: 8,
                     whiteSpace: 'nowrap',

--- a/apps/desktop/src/settings/shared/OAuthSignIn.tsx
+++ b/apps/desktop/src/settings/shared/OAuthSignIn.tsx
@@ -214,7 +214,7 @@ export function OAuthSignIn({
           style={{
             margin: 0,
             padding: 10,
-            background: '#0f172a',
+            background: '#0b0d12',
             color: '#e2e8f0',
             borderRadius: 10,
             fontSize: 11,

--- a/apps/desktop/src/shell/ProfileView.tsx
+++ b/apps/desktop/src/shell/ProfileView.tsx
@@ -74,7 +74,7 @@ export function ProfileView({ tier, onClose }: Props): JSX.Element {
                 width: 52,
                 height: 52,
                 borderRadius: 14,
-                background: 'linear-gradient(135deg, #f59e0b, #f472b6)',
+                background: 'linear-gradient(135deg, #e2551f, #c4310f)',
                 color: '#fff',
                 display: 'inline-flex',
                 alignItems: 'center',
@@ -223,7 +223,7 @@ function tierBadgeStyle(tier: string): React.CSSProperties {
     fontSize: 10.5,
     background: isFree
       ? 'color-mix(in srgb, var(--color-text-dim) 18%, transparent)'
-      : 'linear-gradient(135deg, rgba(236, 72, 153, 0.95), rgba(217, 70, 239, 0.95))',
+      : 'linear-gradient(135deg, rgba(196, 49, 15, 0.95), rgba(156, 36, 9, 0.95))',
     color: isFree ? 'var(--color-text-muted)' : '#fff',
     border: isFree
       ? '1px solid color-mix(in srgb, var(--color-text-dim) 32%, transparent)'

--- a/apps/desktop/src/shell/workspace-sidebar/ProfilePill.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/ProfilePill.tsx
@@ -185,7 +185,7 @@ function tierBadgeStyle(tier: string): React.CSSProperties {
     fontSize: 9.5,
     background: isFree
       ? 'color-mix(in srgb, var(--color-text-dim) 16%, transparent)'
-      : 'linear-gradient(135deg, rgba(236, 72, 153, 0.85), rgba(217, 70, 239, 0.85))',
+      : 'linear-gradient(135deg, rgba(196, 49, 15, 0.85), rgba(156, 36, 9, 0.85))',
     color: isFree ? 'var(--color-sidebar-text)' : '#fff',
     border: isFree
       ? '1px solid color-mix(in srgb, var(--color-text-dim) 28%, transparent)'

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -6,49 +6,56 @@
  */
 
 :root {
-  /* App canvas — cool lavender to match the landing site's hero. */
-  --color-app-bg:        #f1f2f9;
-  /* Main chat column — near-white with a faint cool tint, a hair off
-   * pure white so the column reads as separate from any adjacent white
-   * surface without being grey. */
-  --color-main-bg:       rgb(252, 252, 255);
+  /* App canvas — neutral paper. The brand ground is white, and a tinted
+   * canvas fights Signal's warmth. */
+  --color-app-bg:        #f4f4f7;
+  /* Main chat column — pure paper, so the column reads as the sheet and the
+   * canvas around it as the desk. */
+  --color-main-bg:       #ffffff;
   /* Resting surface for buttons / chips / inputs that sit ON a card or
    * column (the things that used to be hard-coded `#fff`). */
   --color-surface:       #ffffff;
-  /* Recessed "soft" input fill — a cool near-white a step below the
-   * surface, used by TextInput/TextArea tone='soft' and modal fields. */
-  --color-input-soft:    #f7f8fc;
+  /* Recessed "soft" input fill — a step below the surface, used by
+   * TextInput/TextArea tone='soft' and modal fields. */
+  --color-input-soft:    #f4f4f7;
   --color-card-bg:       #ffffff;
-  --color-card-border:   #e3e5f0;
-  --color-card-border-strong: #cdd1e3;
-  --color-card-shadow:   0 1px 2px rgba(15, 23, 42, 0.04), 0 10px 24px -18px rgba(15, 23, 42, 0.10);
+  --color-card-border:   #e4e4ea;
+  --color-card-border-strong: #d3d4dc;
+  --color-card-shadow:   0 1px 2px rgba(11, 13, 18, 0.04), 0 10px 24px -18px rgba(11, 13, 18, 0.10);
 
-  /* Text — same high-contrast navy as the landing headlines. */
-  --color-text:          #0f172a;
-  --color-text-muted:    #475569;
-  --color-text-dim:      #7f8da4;
+  /* Ink, straight from assets/brand/README.md. */
+  --color-text:          #0b0d12;
+  --color-text-muted:    #55596b;
+  --color-text-dim:      #8a8f9f;
 
-  /* Sidebar — pure white. The chat column sits a hair off-white
-   * (rgb(252,252,255)) so the columns still register as separate
-   * against each other and against the lavender canvas. */
+  /* Sidebar — paper, with the canvas a step down so the columns still
+   * register as separate surfaces against each other. */
   --color-sidebar-bg:        #ffffff;
-  --color-sidebar-bg-hover:  #f4f5fb;
-  --color-sidebar-bg-active: #eef2f7;   /* cool wash for the active row */
-  --color-sidebar-text:      #0f172a;
-  --color-sidebar-text-dim:  #6b7194;
-  --color-sidebar-border:    #e3e5f0;
+  --color-sidebar-bg-hover:  #f4f4f7;
+  --color-sidebar-bg-active: #fff1ec;   /* Signal wash for the active row */
+  --color-sidebar-text:      #0b0d12;
+  --color-sidebar-text-dim:  #6e7383;
+  --color-sidebar-border:    #e4e4ea;
 
-  /* Accents — pink primary (CTA), cyan secondary, emerald success. */
-  --color-primary:        #2f5d8f;   /* deep muted blue: CTAs, send, focus ring */
-  --color-primary-strong: #24486e;
-  --color-primary-soft:   #eef2f7;
-  --color-send:           #2f5d8f;   /* CTA and send share the primary */
-  --color-accent:         #3f7f92;   /* desaturated teal: the secondary gradient stop */
-  --color-accent-strong:  #2f6577;
+  /* Signal — one accent, used only where the eye is meant to go. Interactive
+   * fills take the deep stop: flat Signal carries a white label at 3.36:1, and
+   * a CTA is the one place that cannot be borderline. The flat mark colour
+   * lives on as the mark itself and as the focus ring. */
+  --color-primary:        #c4310f;   /* CTAs, send button, focus */
+  --color-primary-strong: #9c2409;
+  --color-primary-soft:   #fff1ec;
+  --color-send:           #c4310f;
+  /* The secondary stays in Signal's family rather than introducing the cyan
+   * the old palette paired with pink. */
+  --color-accent:         #e2551f;
+  --color-accent-strong:  #c4310f;
+  /* Categorical and semantic hues are information, not brand: a workflow step
+   * kind is identified by its hue, green/amber/red mean success/attention/
+   * error. They keep their toned values; only the pink alias follows Signal. */
   --color-purple:         #6b6f9c;
   --color-green:          #2f855a;
   --color-amber:          #b7791f;
-  --color-pink:           #2f5d8f;
+  --color-pink:           #c4310f;
   --color-red:            #c53030;
   --color-purple-strong:  #4f5480;   /* readable violet for text on the purple tints */
 
@@ -66,7 +73,7 @@
   --color-diff-add-text: #15803d;
   --color-diff-del-bg:   #fdecee;
   --color-diff-del-text: #b91c1c;
-  --color-diff-gutter:   #94a3b8;
+  --color-diff-gutter:   #8a8f9f;
   /* Onboarding SuccessRow chip — a stronger green-100/200/800 set. */
   --color-success-soft:        #dcfce7;
   --color-success-soft-border: #bbf7d0;
@@ -76,18 +83,21 @@
   --color-amber-border: #fde68a;
   --color-amber-text:   #b45309;
   /* Inline-code background in rendered Markdown. */
-  --color-code-bg:      #f1f3fb;
+  --color-code-bg:      #f2f2f5;
 
-  /* Brand gradients */
-  --grad-user:    linear-gradient(135deg, #2f5d8f 0%, #4a7bb0 100%);
-  --grad-cta:     linear-gradient(135deg, #2f5d8f 0%, #24486e 100%);
-  --grad-accent:  linear-gradient(135deg, #4a7bb0 0%, #3f7f92 100%);
+  /* Brand gradients — all in Signal's family, and a CTA gradient carries a
+   * white label too, so it stays inside the deep stops. */
+  --grad-user:    linear-gradient(135deg, #c4310f 0%, #e2551f 100%);
+  --grad-cta:     linear-gradient(135deg, #d13d14 0%, #c4310f 55%, #9c2409 100%);
+  --grad-accent:  linear-gradient(135deg, #e2551f 0%, #c4310f 100%);
 
-  /* Typography */
+  /* Typography — Space Grotesk carries headings, echoing the wordmark's
+   * geometric construction. */
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-display: 'Space Grotesk', 'Inter', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-  --radius-block: 8px;
-  --radius-card:  14px;
+  --radius-block: 6px;
+  --radius-card:  10px;
   --radius-pill:  9999px;
 
   color-scheme: light;
@@ -102,9 +112,9 @@
 :root {
   --color-bg:              var(--color-app-bg);
   --color-bg-card:         var(--color-card-bg);
-  --color-bg-card-hover:   #f4f5fa;
+  --color-bg-card-hover:   #f7f7f9;
   --color-border:          var(--color-card-border);
-  --color-border-light:    #d8dbeb;
+  --color-border-light:    #d3d4dc;
 }
 
 /* --- Dark theme -------------------------------------------------
@@ -118,43 +128,45 @@
  * column < cards < surfaces in lightness, brand accents unchanged.
  */
 [data-theme="dark"] {
-  --color-app-bg:        #0b0c13;
-  --color-main-bg:       #101117;
-  --color-surface:       #1b1e2b;
+  /* Ink is the ground. */
+  --color-app-bg:        #08090d;
+  --color-main-bg:       #0b0d12;
+  --color-surface:       #1a1e28;
   /* Soft inputs recess BELOW the card they sit on (mirror of light's
    * near-white-on-white): between main column and card lightness. */
-  --color-input-soft:    #121420;
-  --color-card-bg:       #161823;
-  --color-card-border:   #262a3c;
-  --color-card-border-strong: #363c54;
+  --color-input-soft:    #0f1219;
+  --color-card-bg:       #12151d;
+  --color-card-border:   #232833;
+  --color-card-border-strong: #333947;
   --color-card-shadow:   0 1px 2px rgba(0, 0, 0, 0.5), 0 10px 24px -18px rgba(0, 0, 0, 0.7);
 
-  --color-text:          #e8eaf6;
-  --color-text-muted:    #a4abc8;
-  --color-text-dim:      #697091;
+  --color-text:          #edeef2;
+  --color-text-muted:    #9096a6;
+  --color-text-dim:      #6b7284;
 
-  /* Left rail deepens slightly below the canvas so the columns still
-   * register as separate surfaces in the dark. */
-  --color-sidebar-bg:        #0d0e16;
-  --color-sidebar-bg-hover:  #171927;
-  --color-sidebar-bg-active: #1b2430;   /* cool slate wash on dark */
-  --color-sidebar-text:      #e8eaf6;
-  --color-sidebar-text-dim:  #8b91b0;
-  --color-sidebar-border:    #1f2233;
+  /* Left rail deepens below the canvas so the columns still register as
+   * separate surfaces in the dark. */
+  --color-sidebar-bg:        #08090d;
+  --color-sidebar-bg-hover:  #14171f;
+  --color-sidebar-bg-active: #2e1409;   /* the Signal wash, at ink lightness */
+  --color-sidebar-text:      #edeef2;
+  --color-sidebar-text-dim:  #868da0;
+  --color-sidebar-border:    #1c202a;
 
-  /* Brand accents survive dark unchanged (re-declared so the parity
-   * test can assert full coverage), EXCEPT the near-white pink-50
-   * "soft" wash which flips to the dark plum. */
-  --color-primary:        #6f9ecf;
-  --color-primary-strong: #8fb6df;
-  --color-primary-soft:   #1b2430;
-  --color-send:           #6f9ecf;
-  --color-accent:         #78a9b8;
-  --color-accent-strong:  #8fbecb;
+  /* Signal LIFTS on ink: light's interactive stop is deep enough to carry
+   * white on paper, which is close to invisible here. The same reason the
+   * mark ships a -dark variant rather than being recoloured by CSS. */
+  --color-primary:        #ff6a44;
+  --color-primary-strong: #ff4a1e;
+  --color-primary-soft:   #2e1409;
+  --color-send:           #ff6a44;
+  --color-accent:         #ff9a5e;
+  --color-accent-strong:  #ff6a44;
+  /* Semantic and categorical hues keep their explicit dark counterparts. */
   --color-purple:         #9298c4;
   --color-green:          #5aa87c;
   --color-amber:          #c99a45;
-  --color-pink:           #6f9ecf;
+  --color-pink:           #ff6a44;
   --color-red:            #d97070;
   --color-purple-strong:  #aab0d6;   /* violet text lightens for contrast on dark tints */
 
@@ -169,7 +181,7 @@
   --color-diff-add-text: #86efac;
   --color-diff-del-bg:   #3a1620;
   --color-diff-del-text: #fca5a5;
-  --color-diff-gutter:   #697091;
+  --color-diff-gutter:   #6b7284;
   --color-success-soft:        #0e2a1c;
   --color-success-soft-border: #1c4532;
   --color-success-soft-text:   #7ce0a8;
@@ -178,15 +190,15 @@
   --color-amber-border: #5b430f;
   --color-amber-text:   #fbbf24;
   /* Inline code pops a step LIGHTER than the card it sits on. */
-  --color-code-bg:      #262b40;
+  --color-code-bg:      #232833;
 
-  --grad-user:    linear-gradient(135deg, #2f5d8f 0%, #4a7bb0 100%);
-  --grad-cta:     linear-gradient(135deg, #2f5d8f 0%, #24486e 100%);
-  --grad-accent:  linear-gradient(135deg, #4a7bb0 0%, #3f7f92 100%);
+  --grad-user:    linear-gradient(135deg, #ff6a44 0%, #ff9a5e 100%);
+  --grad-cta:     linear-gradient(135deg, #ff9a5e 0%, #ff6a44 55%, #ff4a1e 100%);
+  --grad-accent:  linear-gradient(135deg, #ff9a5e 0%, #ff6a44 100%);
 
   /* Legacy literal aliases — see the note above the alias block. */
-  --color-bg-card-hover:   #1d2030;
-  --color-border-light:    #2c3147;
+  --color-bg-card-hover:   #191d26;
+  --color-border-light:    #2b3140;
 
   color-scheme: dark;
 }
@@ -249,6 +261,15 @@ button:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
   border-radius: inherit;
+}
+
+/* Headings take the display face, which echoes the wordmark's geometric
+ * construction. The stack falls back to Inter, so an offline launch (the font
+ * is fetched, like Inter already is) looks like the app always has. */
+h1, h2, h3, h4, .display {
+  font-family: var(--font-display);
+  font-weight: 500;
+  letter-spacing: -0.03em;
 }
 
 code, kbd, pre, .mono { font-family: var(--font-mono); }

--- a/apps/desktop/src/workflows/accents.ts
+++ b/apps/desktop/src/workflows/accents.ts
@@ -3,7 +3,11 @@ import type { StepKindMeta } from '@moxxy/workflows-builder';
 /**
  * Map the shared model's semantic accent names to concrete desktop colors.
  * The shared package stays platform-neutral (it only names a color); each UI
- * resolves the name to its own palette. Falls back to the brand pink.
+ * resolves the name to its own palette.
+ *
+ * These stay a CATEGORICAL set: a workflow step kind is identified by its hue,
+ * so they must remain mutually distinguishable rather than collapse into the
+ * brand's single accent. Only the fallback is Signal.
  */
 const ACCENT_HEX: Record<StepKindMeta['accent'], string> = {
   blue: '#3b82f6',
@@ -17,5 +21,5 @@ const ACCENT_HEX: Record<StepKindMeta['accent'], string> = {
 };
 
 export function accentHex(accent: StepKindMeta['accent']): string {
-  return ACCENT_HEX[accent] ?? '#ec4899';
+  return ACCENT_HEX[accent] ?? '#c4310f';
 }

--- a/apps/mobile/src/navigation.ts
+++ b/apps/mobile/src/navigation.ts
@@ -157,7 +157,7 @@ export function buildWorkspaceMenuSections(
       id: stringOf(workspace.id, `workspace-${index}`),
       title: stringOf(workspace.name, stringOf(workspace.title, `Workspace ${index + 1}`)),
       subtitle: stringOf(workspace.cwd, ''),
-      color: stringOf(workspace.color, '#ec4899'),
+      color: stringOf(workspace.color, '#ff4a1e'),
       sessions: [] as WorkspaceMenuSession[],
     }));
   const byWorkspace = new Map<string, {

--- a/packages/design-tokens/src/css-vars.test.ts
+++ b/packages/design-tokens/src/css-vars.test.ts
@@ -54,20 +54,27 @@ describe('generateRootCss', () => {
   it('keeps the brand tokens parity with styles.css values', () => {
     const css = generateRootCss();
     // Spot-check the load-bearing brand declarations against the desktop CSS.
-    expect(css).toContain('--color-primary: #2f5d8f;');
-    expect(css).toContain('--color-app-bg: #f1f2f9;');
-    expect(css).toContain('--color-main-bg: rgb(252, 252, 255);');
+    // Ink (#0B0D12) comes from assets/brand/README.md, and the primary is
+    // Signal's deep stop (flat Signal cannot carry a white label). If one of
+    // these changes here without styles.css following, the desktop and the
+    // mobile tailwind config have silently diverged from the brand.
+    expect(css).toContain('--color-primary: #c4310f;');
+    expect(css).toContain('--color-text: #0b0d12;');
+    expect(css).toContain('--color-app-bg: #f4f4f7;');
+    expect(css).toContain('--color-main-bg: #ffffff;');
     expect(css).toContain('--color-surface: #ffffff;');
     expect(css).toContain(
-      '--color-card-shadow: 0 1px 2px rgba(15, 23, 42, 0.04), 0 10px 24px -18px rgba(15, 23, 42, 0.10);',
+      '--color-card-shadow: 0 1px 2px rgba(11, 13, 18, 0.04), 0 10px 24px -18px rgba(11, 13, 18, 0.10);',
     );
-    expect(css).toContain('--grad-cta: linear-gradient(135deg, #2f5d8f 0%, #24486e 100%);');
-    expect(css).toContain('--radius-card: 14px;');
+    expect(css).toContain(
+      '--grad-cta: linear-gradient(135deg, #d13d14 0%, #c4310f 55%, #9c2409 100%);',
+    );
+    expect(css).toContain('--radius-card: 10px;');
   });
 
   it('renders radii as numbers with a px unit (RN keeps the bare number)', () => {
-    expect(tokens.radius.card).toBe(14);
-    expect(generateRootCss()).toContain('--radius-card: 14px;');
+    expect(tokens.radius.card).toBe(10);
+    expect(generateRootCss()).toContain('--radius-card: 10px;');
   });
 });
 

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -13,55 +13,73 @@
 
 export const tokens = {
   color: {
-    appBg: '#f1f2f9',
-    /* Main chat column — a hair off pure white so it reads as separate
-     * from adjacent white surfaces without being grey. */
-    mainBg: 'rgb(252, 252, 255)',
+    /* Neutral paper, not tinted: the brand ground is white, and a lavender
+     * canvas fights Signal's warmth. */
+    appBg: '#f4f4f7',
+    /* Main chat column — pure paper, so the column reads as the sheet and the
+     * canvas around it as the desk. */
+    mainBg: '#ffffff',
     /* Resting surface for buttons / chips / inputs that sit ON a card
      * or column (the things that were hard-coded `#fff`). */
     surface: '#ffffff',
-    /* Recessed "soft" input fill — a cool near-white a step below the
-     * surface (TextInput/TextArea tone='soft', modal fields). */
-    inputSoft: '#f7f8fc',
+    /* Recessed "soft" input fill — a step below the surface
+     * (TextInput/TextArea tone='soft', modal fields). */
+    inputSoft: '#f4f4f7',
     cardBg: '#ffffff',
-    cardBorder: '#e3e5f0',
-    cardBorderStrong: '#cdd1e3',
-    text: '#0f172a',
-    textMuted: '#475569',
-    textDim: '#7f8da4' /* darkened from #94a3b8, which was 2.56:1 on white: below the 3:1 large-text floor */,
+    cardBorder: '#e4e4ea',
+    cardBorderStrong: '#d3d4dc',
+    /* Ink, straight from assets/brand/README.md. */
+    text: '#0b0d12',
+    textMuted: '#55596b',
+    textDim: '#8a8f9f',
     sidebarBg: '#ffffff',
-    sidebarBgHover: '#f4f5fb',
-    sidebarBgActive: '#eef2f7',
-    sidebarText: '#0f172a',
-    sidebarTextDim: '#6b7194',
-    sidebarBorder: '#e3e5f0',
-    primary: '#2f5d8f',
-    primaryStrong: '#24486e',
-    primarySoft: '#eef2f7',
-    send: '#2f5d8f',
-    accent: '#3f7f92',
-    accentStrong: '#2f6577',
+    sidebarBgHover: '#f4f4f7',
+    /* The active row carries a Signal wash. */
+    sidebarBgActive: '#fff1ec',
+    sidebarText: '#0b0d12',
+    sidebarTextDim: '#6e7383',
+    sidebarBorder: '#e4e4ea',
+    /* Signal, one accent, used only where the eye is meant to go. Interactive
+     * fills take the deeper stop: flat Signal carries white body text at only
+     * 3.36:1, and a CTA label is the one place that cannot be borderline. */
+    primary: '#c4310f',
+    primaryStrong: '#9c2409',
+    primarySoft: '#fff1ec',
+    send: '#c4310f',
+    /* The secondary accent stays in Signal's family instead of introducing the
+     * cyan the old palette paired with pink. */
+    accent: '#e2551f',
+    accentStrong: '#c4310f',
+    /* Categorical and semantic hues are not brand: a workflow step kind is
+     * identified by its hue, and green/amber/red mean success/attention/error.
+     * They keep the toned values #478 gave them; only the pink alias, which was
+     * never categorical, follows the accent. */
     purple: '#6b6f9c',
     green: '#2f855a',
     amber: '#b7791f',
-    pink: '#2f5d8f',
+    pink: '#c4310f',
     red: '#c53030',
   },
   shadow: {
-    card: '0 1px 2px rgba(15, 23, 42, 0.04), 0 10px 24px -18px rgba(15, 23, 42, 0.10)',
+    /* Ink-tinted and shallow. Structure comes from hairlines, not elevation. */
+    card: '0 1px 2px rgba(11, 13, 18, 0.04), 0 10px 24px -18px rgba(11, 13, 18, 0.10)',
   },
   gradient: {
-    user: 'linear-gradient(135deg, #2f5d8f 0%, #4a7bb0 100%)',
-    cta: 'linear-gradient(135deg, #2f5d8f 0%, #24486e 100%)',
-    accent: 'linear-gradient(135deg, #4a7bb0 0%, #3f7f92 100%)',
+    user: 'linear-gradient(135deg, #c4310f 0%, #e2551f 100%)',
+    /* A CTA gradient carries white too, so it stays inside the deep stops. */
+    cta: 'linear-gradient(135deg, #d13d14 0%, #c4310f 55%, #9c2409 100%)',
+    accent: 'linear-gradient(135deg, #e2551f 0%, #c4310f 100%)',
   },
   font: {
+    /* Space Grotesk carries headings, echoing the constructed wordmark. */
     sans: "'Inter', system-ui, -apple-system, sans-serif",
+    display: "'Space Grotesk', 'Inter', system-ui, sans-serif",
     mono: "'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace",
   },
   radius: {
-    block: 8,
-    card: 14,
+    /* Tighter geometry, matching the site's near-square corners. */
+    block: 6,
+    card: 10,
     pill: 9999,
   },
 } as const;
@@ -80,53 +98,60 @@ export type ThemeTokens = Widen<Tokens>;
  * The DESIGNED dark palette — not a naive inversion. Lightness ordering
  * (darkest → lightest): sidebar rail < app canvas < main column < cards <
  * resting surfaces, mirroring the light theme's "columns register against
- * each other" intent. The brand accents (pink / cyan / purple / status
- * colors) and gradients survive dark unchanged; text flips to light
- * grays in the same cool-indigo family; shadows go near-black at higher
- * alpha because rgba(15,23,42,…) ink reads as nothing on a dark canvas.
+ * each other" intent. Every accent has an explicit dark counterpart (a fill
+ * chosen to carry white on paper is close to invisible on ink); text flips to
+ * light greys in the same Ink family; shadows go near-black at higher alpha
+ * because rgba(11,13,18,…) ink reads as nothing on a dark canvas.
  *
  * Shape-frozen against {@link tokens} (same flat color keys) — mobile's
  * tailwind config and the CSS-var generator consume both interchangeably.
  */
 export const darkTokens: ThemeTokens = {
   color: {
-    appBg: '#0b0c13',
-    mainBg: '#101117',
-    surface: '#1b1e2b',
-    inputSoft: '#121420' /* soft inputs recess below the card they sit on */,
-    cardBg: '#161823',
-    cardBorder: '#262a3c',
-    cardBorderStrong: '#363c54',
-    text: '#e8eaf6',
-    textMuted: '#a4abc8',
-    textDim: '#697091',
-    sidebarBg: '#0d0e16',
-    sidebarBgHover: '#171927',
-    sidebarBgActive: '#1b2430' /* cool slate wash for the active row on dark */,
-    sidebarText: '#e8eaf6',
-    sidebarTextDim: '#8b91b0',
-    sidebarBorder: '#1f2233',
-    /* Accents no longer survive dark unchanged. The light palette's primary is
-     * a DEEP blue chosen to carry white text on a near-white surface; the same
-     * ink on a near-black canvas is close to invisible. Each accent therefore
-     * has an explicit dark counterpart lifted into the readable range, which is
-     * why these are literals rather than `tokens.color.*` references. */
-    primary: '#6f9ecf',
-    primaryStrong: '#8fb6df',
-    primarySoft: '#1b2430',
-    send: '#6f9ecf',
-    accent: '#78a9b8',
-    accentStrong: '#8fbecb',
+    /* Ink is the ground. The rail sits below the canvas, the canvas below the
+     * column, exactly as in light. */
+    appBg: '#08090d',
+    mainBg: '#0b0d12',
+    surface: '#1a1e28',
+    inputSoft: '#0f1219' /* soft inputs recess below the card they sit on */,
+    cardBg: '#12151d',
+    cardBorder: '#232833',
+    cardBorderStrong: '#333947',
+    text: '#edeef2',
+    textMuted: '#9096a6',
+    textDim: '#6b7284',
+    sidebarBg: '#08090d',
+    sidebarBgHover: '#14171f',
+    sidebarBgActive: '#2e1409' /* the Signal wash, at ink lightness */,
+    sidebarText: '#edeef2',
+    sidebarTextDim: '#868da0',
+    sidebarBorder: '#1c202a',
+    /* Accents do not survive dark unchanged. Light's interactive Signal is the
+     * DEEP stop, chosen to carry white on a near-white surface; that same ink
+     * on a near-black canvas is close to invisible. On ink the accent lifts to
+     * flat Signal and above, which is what the mark's own strand does, so these
+     * stay literals rather than `tokens.color.*` references. */
+    primary: '#ff6a44',
+    primaryStrong: '#ff4a1e',
+    primarySoft: '#2e1409',
+    send: '#ff6a44',
+    accent: '#ff9a5e',
+    accentStrong: '#ff6a44',
+    /* Semantic and categorical hues keep their explicit dark counterparts. */
     purple: '#9298c4',
     green: '#5aa87c',
     amber: '#c99a45',
-    pink: '#6f9ecf',
+    pink: '#ff6a44',
     red: '#d97070',
   },
   shadow: {
     card: '0 1px 2px rgba(0, 0, 0, 0.5), 0 10px 24px -18px rgba(0, 0, 0, 0.7)',
   },
-  gradient: { ...tokens.gradient },
+  gradient: {
+    user: 'linear-gradient(135deg, #ff6a44 0%, #ff9a5e 100%)',
+    cta: 'linear-gradient(135deg, #ff9a5e 0%, #ff6a44 55%, #ff4a1e 100%)',
+    accent: 'linear-gradient(135deg, #ff9a5e 0%, #ff6a44 100%)',
+  },
   font: { ...tokens.font },
   radius: { ...tokens.radius },
 };


### PR DESCRIPTION
The palette carries nothing of the mark. The logo ships Ink + Signal on paper; the app runs on a muted blue primary and a teal accent, so every CTA, focus ring and active row reads cool around a warm mark. This moves the accent family to Signal and the text ramp to Ink, in `@moxxy/design-tokens` (desktop CSS vars + mobile Tailwind) plus the mirrored `styles.css`, so it reaches every component that reads a variable. Headings take Space Grotesk, which joins the Google Fonts request Inter already makes and falls back to Inter offline.

**The one decision worth arguing with:** interactive fills take Signal's *deep* stop `#C4310F`, not the flat mark colour. White on flat `#FF4A1E` is 3.36:1, under the 4.5 floor the contrast suite from #478 pins, and a CTA label is the one place that cannot be borderline. Flat Signal stays as the mark, the focus ring and the soft washes; on dark it lifts to `#FF6A44`. So CTAs read a shade deeper than the mark next to them. The alternative was keeping flat Signal and inking the labels, which is a much wider change.

Rebased onto development, so it sits on top of #478 rather than reverting it: the contrast suite is kept and passes in both themes, the toned status hues and the explicit dark counterparts stay, and the categorical workflow hues are untouched (its `pink` entry stays pink, or it collides with `orange`). Also swept the pink glows, spinner rings and plan badges that survived #478. The voice spectrogram keeps its blue-violet-pink ramp: that is a data gradient, not a brand accent.

Green tests here mean the palette is *readable*, not that it looks right. That part needs your eye.

## Verification
- pnpm build / typecheck / lint / test / check:deps green (140 tasks)
- design-tokens 49 tests, including the 28-case contrast suite in both themes and the styles.css parity check