### PR TITLE
fix(provider-codex): retry the gateway's untyped internal fault

### DIFF
--- a/.changeset/codex-untyped-gateway-fault-retry.md
+++ b/.changeset/codex-untyped-gateway-fault-retry.md
@@ -1,0 +1,13 @@
+---
+'@moxxy/plugin-provider-openai-codex': patch
+---
+
+Retry the Codex gateway's untyped internal fault instead of killing the turn.
+
+"An error occurred while processing your request ... Please include the request
+ID <uuid>" arrives in-band with `code: null` and no `type`, so the code/type
+allowlists added for the overload fix matched nothing and the turn ended fatal
+after a run's worth of tool calls (seen four times in local session logs). An
+unclassified failure is now judged by its message, which in this case literally
+says the request can be retried. Any failure that does carry a `code` or `type`
+keeps the old verdict, so quota and validation errors stay fatal.

--- a/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.test.ts
+++ b/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.test.ts
@@ -129,6 +129,44 @@ describe('handleSseEvent — in-band failures', () => {
     });
   });
 
+  it('retries the gateway internal fault, which arrives with no code and no type', () => {
+    const message =
+      'An error occurred while processing your request. You can retry your request, or contact us ' +
+      'through our help center at help.openai.com if the error persists. Please include the request ' +
+      'ID 1a3a7285-4738-42de-acb6-385fb334c4a5 in your message.';
+    const out = run(
+      {
+        type: 'response.failed',
+        response: { status: 'failed', error: { code: undefined, message } },
+      },
+      false,
+    );
+    expect(out.events?.[0]).toEqual({ type: 'error', message, retryable: true });
+  });
+
+  it('treats an explicit null code as unclassified, not as a code that failed to match', () => {
+    const out = run(
+      {
+        type: 'error',
+        // The wire shape: JSON `null`, which the declared `code?: string` hides.
+        error: { code: null, message: 'Please try again later.' } as unknown as {
+          code?: string;
+          message?: string;
+        },
+      },
+      false,
+    );
+    expect(out.events?.[0]).toMatchObject({ retryable: true });
+  });
+
+  it('keeps an unclassified failure fatal when its message claims nothing transient', () => {
+    const out = run(
+      { type: 'error', error: { message: 'Your prompt was rejected by content policy.' } },
+      false,
+    );
+    expect(out.events?.[0]).toMatchObject({ retryable: false });
+  });
+
   it('keeps quota exhaustion fatal — retrying cannot clear it', () => {
     const out = run(
       {

--- a/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.ts
+++ b/packages/plugin-provider-openai-codex/src/codex/sse-event-handler.ts
@@ -46,12 +46,30 @@ const RETRYABLE_FAILURE_TYPES = new Set([
   'rate_limit_error',
 ]);
 
-function isRetryableFailure(err: { type?: string; code?: string } | undefined): boolean {
+/**
+ * Transient-failure phrasing, consulted ONLY when the frame carries no `code`
+ * and no `type`. The Codex gateway reports its own internal faults with an
+ * error object that is just `{ code: null, message }`, so the allowlists above
+ * see nothing to match and the turn died on a fault whose own message says the
+ * request can be retried. Requiring the classification to be entirely absent
+ * keeps every typed failure (quota, validation) fatal however it is worded.
+ */
+const RETRYABLE_FAILURE_MESSAGE =
+  /an error occurred while processing your request|you can retry your request|please try again|temporarily unavailable|internal server error/i;
+
+function isRetryableFailure(
+  err: { type?: string; code?: string; message?: string } | undefined,
+): boolean {
   if (!err) return false;
-  return (
-    (err.code !== undefined && RETRYABLE_FAILURE_CODES.has(err.code)) ||
-    (err.type !== undefined && RETRYABLE_FAILURE_TYPES.has(err.type))
-  );
+  // `!= null` rather than `!== undefined`: the gateway sends an explicit JSON
+  // `null` for an unclassified fault, which must fall through to the message.
+  if (err.code != null || err.type != null) {
+    return (
+      (err.code != null && RETRYABLE_FAILURE_CODES.has(err.code)) ||
+      (err.type != null && RETRYABLE_FAILURE_TYPES.has(err.type))
+    );
+  }
+  return err.message !== undefined && RETRYABLE_FAILURE_MESSAGE.test(err.message);
 }
 
 const TOOL_STREAM_LIMIT_ERROR = (what: string): SseStepResult => ({


### PR DESCRIPTION
Codex turns were still dying, just on a different frame than the overload one. When the ChatGPT gateway hits its own internal fault it sends `{"code": null, "message": "An error occurred while processing your request ... Please include the request ID <uuid>"}` in-band: no `code`, no `type`, so the allowlists added in #495 matched nothing and the turn ended fatal. Four such runs sit in my local session logs, all `kind: fatal`, none retried, some after ten-plus tool calls.

An error frame with no classification at all is now judged by its message. Frames that do carry a `code` or `type` keep the old verdict, so quota and validation stay fatal, and the loop's bounded retry (6 attempts, backoff) still caps the downside if a fatal error ever slips through the regex.

Tests: two new cases fail on `development` and pass here; full gate green (build, typecheck, lint, test).

Note this only reaches Companion runs after a release, since those load the plugin from `~/.moxxy/plugins`.