### PR TITLE
fix(provider-claude-code): trim the catalog to the four current models

### DIFF
--- a/.changeset/tidy-pandas-marry.md
+++ b/.changeset/tidy-pandas-marry.md
@@ -1,0 +1,14 @@
+---
+"@moxxy/plugin-provider-claude-code": patch
+"@moxxy/plugin-plugins-admin": patch
+"@moxxy/cli": patch
+---
+
+Trim the Claude Code subscription catalog to the four current models
+
+The picker still offered `claude-sonnet-4-6`, `claude-opus-4-7` and `claude-opus-4-6`,
+and pinned the default at `claude-sonnet-4-6`. The catalog is now `claude-fable-5`,
+`claude-opus-5`, `claude-sonnet-5` and `claude-haiku-4-5`, with `claude-sonnet-5` as
+the default (direct successor of the previous one). Haiku moves from the dated
+`claude-haiku-4-5-20251001` id to the alias, and `claude-sonnet-5` gets its real
+128k output ceiling instead of 64k.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,7 +67,7 @@ For a custom installation that is not on `PATH`, set the executable explicitly:
 CLAUDE_CODE_EXECUTABLE=/absolute/path/to/claude moxxy doctor
 ```
 
-The default model is `claude-sonnet-4-6`. Select another model advertised by Moxxy with `--model` or the `plugins.provider.items.claude-code.model` setting.
+The default model is `claude-sonnet-5`. Select another model advertised by Moxxy with `--model` or the `plugins.provider.items.claude-code.model` setting.
 
 The provider uses a text transport and enables only Claude Code's native `WebSearch` by default. Set `config.webSearch: false` to disable it. Other native Claude tools are a separate opt-in setting, `config.mode: native-tools`, and should be paired with explicit `allowedTools` (include `WebSearch` there if desired) and, when needed, `permissionMode`. The Claude CLI owns and enforces native-tool permissions. Moxxy's `--allow-tools`, permission resolver, and isolators govern only Moxxy tools and do not override the Claude CLI.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -81,7 +81,7 @@ Requirements: Node.js 20.10 or later. Use an API key for Anthropic/OpenAI, sign 
 
 1. Install the official Claude CLI so `claude` is on `PATH` (or set `CLAUDE_CODE_EXECUTABLE=/absolute/path/to/claude`).
 2. Run `claude auth login` or `moxxy login claude-code`, then confirm with `claude auth status` and `moxxy doctor`.
-3. Select `claude-code` in `moxxy init`. It defaults to `claude-sonnet-4-6`; override per run with `--model`, or persist `plugins.provider.items.claude-code.model`.
+3. Select `claude-code` in `moxxy init`. It defaults to `claude-sonnet-5`; override per run with `--model`, or persist `plugins.provider.items.claude-code.model`.
 
 The default transport disables Claude's internal tools. To opt into an isolated coding task, configure the provider item explicitly:
 
@@ -91,7 +91,7 @@ plugins:
     default: claude-code
     items:
       claude-code:
-        model: claude-sonnet-4-6
+        model: claude-sonnet-5
         config:
           mode: native-tools
           permissionMode: acceptEdits
@@ -106,7 +106,7 @@ Contributors with an authenticated subscription can run the opt-in, no-API-key s
 
 ```sh
 node scripts/e2e-claude-cli-live.mjs
-# optional: MOXXY_CLAUDE_E2E_MODEL=claude-opus-4-6 node scripts/e2e-claude-cli-live.mjs
+# optional: MOXXY_CLAUDE_E2E_MODEL=claude-opus-5 node scripts/e2e-claude-cli-live.mjs
 ```
 
 It skips clearly when `claude` is missing or signed out, streams a real text prompt, and performs its native-tool assertion only inside a generated temporary git repository.

--- a/packages/cli/src/provision/provision.test.ts
+++ b/packages/cli/src/provision/provision.test.ts
@@ -68,7 +68,7 @@ describe('provision', () => {
   });
 
   it('pins the exported Claude Code default and persists it in the provider item write', async () => {
-    expect(resolveProvider('claude-code')?.defaultModel).toBe('claude-sonnet-4-6');
+    expect(resolveProvider('claude-code')?.defaultModel).toBe('claude-sonnet-5');
     const eff = makeEffects({ loadedProviderNames: new Set(['claude-code']) });
     const res = await provision({ provider: 'claude-code', key: 'should-ignore' }, eff);
 
@@ -76,7 +76,7 @@ describe('provision', () => {
     expect(res.keyStored).toBe(false);
     expect(eff.writeConfig).toHaveBeenCalledWith(expect.objectContaining({
       providerSlug: 'claude-code',
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
     }));
   });
 

--- a/packages/plugin-plugins-admin/src/provider-catalog.generated.ts
+++ b/packages/plugin-plugins-admin/src/provider-catalog.generated.ts
@@ -33,7 +33,7 @@ export const PROVIDER_PLUGIN_CATALOG = [
     ],
     "provider": {
       "auth": "oauth",
-      "defaultModel": "claude-sonnet-4-6"
+      "defaultModel": "claude-sonnet-5"
     }
   },
   {

--- a/packages/plugin-provider-claude-code/package.json
+++ b/packages/plugin-provider-claude-code/package.json
@@ -60,7 +60,7 @@
       ],
       "provider": {
         "auth": "oauth",
-        "defaultModel": "claude-sonnet-4-6"
+        "defaultModel": "claude-sonnet-5"
       }
     }
   },

--- a/packages/plugin-provider-claude-code/src/process.test.ts
+++ b/packages/plugin-provider-claude-code/src/process.test.ts
@@ -37,7 +37,7 @@ class ControlledChild extends EventEmitter {
 
 const baseOptions: ClaudeProcessOptions = {
   executable: 'claude',
-  model: 'claude-sonnet-4-6',
+  model: 'claude-sonnet-5',
   prompt: 'hello',
   cwd: '/tmp',
   nativeTools: false,

--- a/packages/plugin-provider-claude-code/src/provider.test.ts
+++ b/packages/plugin-provider-claude-code/src/provider.test.ts
@@ -54,16 +54,13 @@ describe('claude-code provider definition', () => {
   it('registers the exact Claude Code catalog and its native web-search capability', () => {
     expect(claudeCodeProviderDef.name).toBe('claude-code');
     expect(claudeCodeProviderDef.auth?.kind).toBe('oauth');
-    expect(CLAUDE_CODE_DEFAULT_MODEL).toBe('claude-sonnet-4-6');
+    expect(CLAUDE_CODE_DEFAULT_MODEL).toBe('claude-sonnet-5');
     expect(claudeCodeProviderDef.models).toBe(claudeCodeModels);
     expect(claudeCodeProviderDef.models.map((model) => model.id)).toEqual([
-      'claude-sonnet-4-6',
       'claude-fable-5',
       'claude-opus-5',
       'claude-sonnet-5',
-      'claude-opus-4-7',
-      'claude-opus-4-6',
-      'claude-haiku-4-5-20251001',
+      'claude-haiku-4-5',
     ]);
     for (const model of claudeCodeProviderDef.models) {
       expect(model).toMatchObject({
@@ -95,7 +92,7 @@ describe('claude-code provider definition', () => {
     const events = await collect(client.stream(textRequest()));
 
     expect(events).toEqual([
-      { type: 'message_start', model: 'claude-sonnet-4-6' },
+      { type: 'message_start', model: 'claude-sonnet-5' },
       { type: 'text_delta', delta: 'Hello ' },
       { type: 'text_delta', delta: 'world' },
       { type: 'message_end', stopReason: 'end_turn', usage: { inputTokens: 8, outputTokens: 2 } },
@@ -143,7 +140,7 @@ describe('claude-code provider definition', () => {
     const events = await collect(createClaudeCodeClient({ executable: join(dir, 'claude') }).stream(textRequest()));
 
     expect(events).toEqual([
-      { type: 'message_start', model: 'claude-sonnet-4-6' },
+      { type: 'message_start', model: 'claude-sonnet-5' },
       { type: 'text_delta', delta: 'Visible answer' },
       { type: 'message_end', stopReason: 'end_turn', usage: { inputTokens: 3, outputTokens: 2 } },
     ]);
@@ -162,7 +159,7 @@ describe('claude-code provider definition', () => {
     const events = await collect(createClaudeCodeClient({ executable: join(dir, 'claude') }).stream(textRequest()));
 
     expect(events).toEqual([
-      { type: 'message_start', model: 'claude-sonnet-4-6' },
+      { type: 'message_start', model: 'claude-sonnet-5' },
       { type: 'message_end', stopReason: 'end_turn', usage: { inputTokens: 3, outputTokens: 2 } },
     ]);
     expect(JSON.stringify(events)).not.toContain('private chain of thought');
@@ -501,7 +498,7 @@ describe('claude-code provider definition', () => {
 
 function textRequest(): ProviderRequest {
   return {
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-5',
     system: 'system instructions',
     messages: [
       { role: 'user', content: [{ type: 'text', text: 'prior user' }] },

--- a/packages/plugin-provider-claude-code/src/provider.ts
+++ b/packages/plugin-provider-claude-code/src/provider.ts
@@ -4,7 +4,7 @@ import { CLAUDE_CODE_PROVIDER_ID } from './constants.js';
 import { ClaudeProcessError, runClaudeProcess, type ClaudeSpawn } from './process.js';
 import { createProtocolState, parseClaudeRecord, serializeClaudePrompt } from './protocol.js';
 
-export const CLAUDE_CODE_DEFAULT_MODEL = 'claude-sonnet-4-6';
+export const CLAUDE_CODE_DEFAULT_MODEL = 'claude-sonnet-5';
 const NON_TEXT_BLOCK_TOKENS = 256;
 
 /**
@@ -26,13 +26,10 @@ const textOnlyCapabilities = {
 } as const;
 
 export const claudeCodeModels: ReadonlyArray<ModelDescriptor> = [
-  { id: CLAUDE_CODE_DEFAULT_MODEL, contextWindow: 1_000_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },
   { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
   { id: 'claude-opus-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
-  { id: 'claude-sonnet-5', contextWindow: 1_000_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },
-  { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
-  { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
-  { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },
+  { id: CLAUDE_CODE_DEFAULT_MODEL, contextWindow: 1_000_000, maxOutputTokens: 128_000, ...textOnlyCapabilities },
+  { id: 'claude-haiku-4-5', contextWindow: 200_000, maxOutputTokens: 64_000, ...textOnlyCapabilities },
 ];
 
 export interface ClaudeCodeProviderConfig {

--- a/scripts/e2e-claude-cli-live.mjs
+++ b/scripts/e2e-claude-cli-live.mjs
@@ -22,7 +22,7 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const cliBin = join(repoRoot, 'packages', 'cli', 'dist', 'bin.js');
 const executable = process.env.CLAUDE_CODE_EXECUTABLE?.trim() || 'claude';
-const model = process.env.MOXXY_CLAUDE_E2E_MODEL?.trim() || 'claude-sonnet-4-6';
+const model = process.env.MOXXY_CLAUDE_E2E_MODEL?.trim() || 'claude-sonnet-5';
 const root = mkdtempSync(join(tmpdir(), 'moxxy-claude-live-'));
 const moxxyHome = join(root, 'moxxy-home');
 mkdirSync(moxxyHome);


### PR DESCRIPTION
The Claude Code picker still offered `claude-sonnet-4-6`, `claude-opus-4-7` and `claude-opus-4-6`, and defaulted to `claude-sonnet-4-6`. The catalog is now the four current models: `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5` (new default) and `claude-haiku-4-5`.

Two things worth a look beyond the deletions:

- Haiku moves from the dated `claude-haiku-4-5-20251001` to the alias, so all four ids are undated.
- `claude-sonnet-5` was listed at 64k max output; the real ceiling is 128k. That value feeds `resolveModelContext` and the compaction budget, so it was under-reporting.

`provider-catalog.generated.ts` is regenerated from the package manifest, not hand-edited. Scope is the claude-code provider only — `@moxxy/plugin-provider-anthropic` still lists the older models and still defaults to `claude-sonnet-4-6` while its catalog entry recommends `claude-opus-5`; that inconsistency is left for a follow-up.

Build, lint, typecheck clean; claude-code (45) and cli (392) suites pass. The 6 failures in `apps/desktop/src/shell/AppRail.test.tsx` (missing ClerkProvider around `ProfilePill`) reproduce on a clean `development` checkout and are unrelated.