### PR TITLE
fix(desktop): make sidebar groups readable and Local Piper failures diagnosable

### DIFF
--- a/.changeset/local-piper-install-diagnosis.md
+++ b/.changeset/local-piper-install-diagnosis.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/desktop': patch
+---
+
+Report why a Local Piper install actually failed. The installer spawned the CLI with `stdio: 'ignore'` and then reported every non-zero exit as "The offline voice package could not be installed. Check your internet connection and try again." — a hardcoded guess. On a machine without Node the real output is `error: spawn npm ENOENT`, so a user with working internet was told to check their connection and had no way to discover the actual requirement. The CLI's stderr is now captured and classified into actionable causes (npm/Node missing, registry unreachable, permissions), unrecognised output is quoted rather than re-diagnosed, and the failing step is named.

--- a/.changeset/sidebar-group-row-hierarchy.md
+++ b/.changeset/sidebar-group-row-hierarchy.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/desktop': patch
+---
+
+Make workspace groups readable against the sessions inside them in the desktop sidebar. The group header was painted `--color-text-dim` while its session rows used `--color-sidebar-text-dim` — byte-identical colours in both themes — so a group and its children rendered the same, and a 4px indent was the only nesting cue. Headers now take the muted tier, carry the workspace's own colour as a square chip (`Desk.color`, already in the contract but never rendered), and their sessions hang off a guide rail with real spacing between groups.

--- a/apps/desktop/src/shell/workspace-sidebar/WorkspaceTree.test.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/WorkspaceTree.test.tsx
@@ -210,6 +210,47 @@ describe('WorkspaceTree', () => {
     expect(document.activeElement).toBe(trigger);
   });
 
+  /**
+   * Reported bug: "grupa zlewa się z czatami" — a group header and the session
+   * rows under it were indistinguishable.
+   *
+   * Root cause was a palette collision, not a layout mistake: the header was
+   * painted `--color-text-dim` and an inactive row `--color-sidebar-text-dim`,
+   * which are the SAME hex in both themes (#77868f dark / #66757e light). Two
+   * different token NAMES resolving to one colour is why this passed review —
+   * so these tests pin the three cues that actually separate the two row kinds,
+   * and the companion token test (design-tokens/contrast.test.ts) pins that the
+   * tiers stay different colours.
+   */
+  it('paints the group header in a different tier from the rows beneath it', () => {
+    renderTree();
+    // The header name carries the muted tier; the row keeps the dim one. The
+    // assertion is on the TOKEN because the bug was two names, one value —
+    // comparing rendered strings would have passed while the bug was live.
+    expect(screen.getByText('Alpha').style.color).toBe('var(--color-text-muted)');
+    expect(screen.getByTestId('session-row-a').style.color).toBe(
+      'var(--color-sidebar-text-dim)',
+    );
+  });
+
+  it('marks a folder row with its workspace colour, and a session row with an LED', () => {
+    renderTree();
+    // Shape AND colour differ: a square tinted chip heads a group, a round LED
+    // heads a conversation. `Desk.color` already exists in the contract and was
+    // simply never rendered here.
+    const chip = screen.getByTestId('desk-chip-a');
+    expect(chip.style.background).toBe('rgb(59, 130, 246)'); // desk.color #3b82f6
+    expect(screen.getByTestId('session-row-a').querySelector('.led')).toBeTruthy();
+  });
+
+  it('hangs a group’s sessions off a guide rail so they read as children', () => {
+    renderTree();
+    // The rail is the containment cue — without it the only nesting signal was
+    // a 4px indent, which is invisible next to a 12px row.
+    const group = screen.getByRole('group', { name: 'sessions in Alpha' });
+    expect(group.style.borderLeft).not.toBe('');
+  });
+
   // Regression: the ⋯ menu is anchored inside the row's subtree, and the
   // ActionsOverlay's `transform` traps the menu's z-index in a local
   // stacking context. Without lifting the owning row while its menu is

--- a/apps/desktop/src/shell/workspace-sidebar/WorkspaceTree.tsx
+++ b/apps/desktop/src/shell/workspace-sidebar/WorkspaceTree.tsx
@@ -10,10 +10,18 @@ import { useMenuKeyboard } from '../useMenuKeyboard';
  * active-desk-only pair (WorkspaceSwitcher card + flat SessionList).
  *
  *   WORKSPACES                                 [+]  ← new workspace
- *   ▾ ▣ blocky                              [+] ⋯   ← toggle / new session / menu
- *       Fix the sign-in bug                          ← session (first-prompt title)
- *       Redesign the sidebar          ●              ← unread dot
- *   ▸ ▣ website                       ●     [+] ⋯   ← collapsed: dot rolls up
+ *   ▾ ▣ BLOCKY                            2 [+] ⋯   ← toggle / count / new / menu
+ *     │ ● Fix the sign-in bug                        ← session (first-prompt title)
+ *     │ ● Redesign the sidebar                       ← rail shows what nests where
+ *   ▸ ▣ WEBSITE                       ●   1 [+] ⋯   ← collapsed: dot rolls up
+ *
+ * Telling the two row kinds apart is the layout's whole job, and it is carried
+ * by four cues at once rather than by any single one: a SQUARE workspace-colour
+ * chip vs a ROUND session LED, the muted header tier vs the dim row tier,
+ * uppercase+letterspaced vs sentence case, and the guide rail + group gap that
+ * make containment visible. They previously shared one colour
+ * (`--color-text-dim` === `--color-sidebar-text-dim`) and a 4px indent, and the
+ * tree read as one flat list.
  *
  * Interaction contract:
  *  - clicking a folder row (or its chevron) toggles collapse — switching
@@ -73,7 +81,11 @@ export function WorkspaceTree({
           padding: 0,
           display: 'flex',
           flexDirection: 'column',
-          gap: 1,
+          // Gap BETWEEN groups, where the old `1` packed folders and sessions at
+          // one density and left the tree reading as a single flat list. Rows
+          // inside a group keep the tight `1` — the rhythm itself now says which
+          // rows belong together.
+          gap: 'var(--space-6)',
         }}
       >
         {desks.map((desk) => {
@@ -99,8 +111,14 @@ export function WorkspaceTree({
                   aria-label={`sessions in ${desk.name}`}
                   style={{
                     listStyle: 'none',
-                    margin: 0,
-                    padding: 0,
+                    // The guide rail. Nesting used to be carried by a 4px indent
+                    // alone, which is invisible beside a 12.5px row — the rail
+                    // is what actually shows a session hanging off its group,
+                    // and it makes the group's extent readable at a glance
+                    // (where it starts, where it ends).
+                    margin: '2px 0 0 var(--space-12)',
+                    padding: '0 0 0 var(--space-8)',
+                    borderLeft: '1px solid var(--color-sidebar-border)',
                     display: 'flex',
                     flexDirection: 'column',
                     gap: 1,
@@ -231,6 +249,26 @@ function FolderRow({
           <Icon name="chevron-right" size={13} />
         </span>
       </button>
+      {/* The workspace's own colour, as a SQUARE chip. A session row is headed by
+          a round LED, so the two row kinds now differ in shape as well as hue —
+          the distinction survives both a colourblind reader and a glance too
+          quick to read any text. `Desk.color` has been in the contract all along
+          and was simply never rendered. */}
+      <span
+        aria-hidden
+        data-testid={`desk-chip-${desk.id}`}
+        style={{
+          width: 8,
+          height: 8,
+          flexShrink: 0,
+          borderRadius: 'var(--radius-tag)',
+          background: desk.color,
+          // Dim the chip while the group is collapsed and idle, so an expanded
+          // (or active) workspace is the one that draws the eye.
+          opacity: active || !collapsed ? 1 : 0.55,
+          transition: 'opacity 120ms ease',
+        }}
+      />
       <span
         style={{
           flex: 1,
@@ -238,8 +276,13 @@ function FolderRow({
           fontSize: 'var(--type-label)',
           letterSpacing: '0.1em',
           textTransform: 'uppercase',
-          color: 'var(--color-text-dim)',
-          fontWeight: active ? 600 : 500,
+          // The muted tier, NOT the dim one. `--color-text-dim` is byte-identical
+          // to the `--color-sidebar-text-dim` the rows below use, so a header
+          // painted with it was literally the same colour as its own children.
+          // Hierarchy is now three real tiers: active row (bright) > group header
+          // (muted) > idle row (dim).
+          color: 'var(--color-text-muted)',
+          fontWeight: 600,
           whiteSpace: 'nowrap',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
@@ -358,7 +401,10 @@ function SessionRow({
           alignItems: 'center',
           gap: 8,
           minHeight: 'var(--frame-row)',
-          padding: '2px var(--space-6) 2px var(--space-8)',
+          // The group now carries the indent (margin + rail + padding), so the
+          // row itself only needs breathing room — keeping the old space-8 here
+          // would push every title a further 8px right for no added meaning.
+          padding: '2px var(--space-6) 2px var(--space-4)',
           borderRadius: 'var(--radius-block)',
           cursor: 'pointer',
           background: active ? 'var(--color-card-bg)' : 'transparent',

--- a/packages/design-tokens/src/contrast.test.ts
+++ b/packages/design-tokens/src/contrast.test.ts
@@ -79,6 +79,25 @@ describe.each([
   it('dim text clears the large-text floor', () => {
     expect(contrast(theme.color.textDim, theme.color.cardBg)).toBeGreaterThanOrEqual(3);
   });
+
+  /**
+   * The sidebar tree paints a GROUP HEADER in `textMuted` and the session rows
+   * under it in `sidebarTextDim`. Those two must stay visibly different colours,
+   * or the tree collapses into one flat list — which is exactly what shipped:
+   * the header used `textDim`, and `textDim === sidebarTextDim` to the byte, so
+   * two token names resolved to one colour and nothing failed.
+   *
+   * Contrast between two TEXT tiers has no WCAG rule (the standard is about text
+   * against its background), so the floor here is a deliberate house rule: a
+   * ratio of 1.25 is roughly where a tier separation stops being a rounding
+   * error and starts being legible as hierarchy.
+   */
+  it('separates the sidebar’s group-header tier from its row tier', () => {
+    expect(theme.color.textMuted).not.toBe(theme.color.sidebarTextDim);
+    expect(contrast(theme.color.textMuted, theme.color.sidebarTextDim)).toBeGreaterThanOrEqual(
+      1.25,
+    );
+  });
 });
 
 /**

--- a/packages/desktop-host/src/local-piper.test.ts
+++ b/packages/desktop-host/src/local-piper.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createLocalPiperInstaller,
+  describeLocalPiperFailure,
   isLocalPiperInstalled,
   LOCAL_PIPER_PACKAGE,
 } from './local-piper';
@@ -66,6 +67,117 @@ describe('Local Piper package probe', () => {
   });
 });
 
+/**
+ * Reported bug: the install failed with "The offline voice package could not be
+ * installed. Check your internet connection and try again." — on a machine
+ * whose internet was fine.
+ *
+ * The message was a hardcoded guess. `runLocalPiperCliCommand` spawned the CLI
+ * with `stdio: 'ignore'`, so the one thing that said WHY was discarded, and
+ * every non-zero exit was blamed on the network. The reproduced failure on a
+ * host without Node is `error: spawn npm ENOENT` on stderr with exit 1 — a user
+ * following that advice would check their WiFi forever.
+ *
+ * These cases are the CLI's real observed output, not invented strings.
+ */
+describe('Local Piper failure diagnosis', () => {
+  const install = ['plugins', 'install', LOCAL_PIPER_PACKAGE];
+
+  it('names npm/Node as missing rather than blaming the network', () => {
+    const message = describeLocalPiperFailure(
+      install,
+      'pinned install @moxxy/plugin-tts-local@0.35.4 failed (spawn npm ENOENT); ' +
+        'retrying latest @moxxy/plugin-tts-local\nerror: spawn npm ENOENT\n',
+    );
+    expect(message).toMatch(/node\.js|npm/i);
+    expect(message).not.toMatch(/internet connection/i);
+  });
+
+  it('recognises the Windows spelling of a missing npm', () => {
+    const message = describeLocalPiperFailure(
+      install,
+      "'npm' is not recognized as an internal or external command",
+    );
+    expect(message).toMatch(/node\.js|npm/i);
+    expect(message).not.toMatch(/internet connection/i);
+  });
+
+  it('blames the network only when the output actually says so', () => {
+    for (const output of [
+      'npm error code ENOTFOUND\nnpm error syscall getaddrinfo',
+      'npm error code EAI_AGAIN',
+      'request to https://registry.npmjs.org/... failed, reason: connect ECONNREFUSED',
+      'npm error network request to https://registry.npmjs.org failed, reason: ETIMEDOUT',
+    ]) {
+      expect(describeLocalPiperFailure(install, output)).toMatch(/internet|network|offline/i);
+    }
+  });
+
+  it('calls out a permissions failure so the user stops retrying', () => {
+    const message = describeLocalPiperFailure(
+      install,
+      'npm error code EACCES\nnpm error syscall mkdir\nnpm error path /Users/x/.moxxy/plugins',
+    );
+    expect(message).toMatch(/permission/i);
+    expect(message).not.toMatch(/internet connection/i);
+  });
+
+  it('surfaces an unrecognised reason verbatim instead of inventing one', () => {
+    const message = describeLocalPiperFailure(install, 'npm error code ETARGET no matching version');
+    // A wrong-but-confident diagnosis is worse than an honest quote: the user
+    // can paste this into an issue, and we can read it off a screenshot.
+    expect(message).toContain('ETARGET');
+  });
+
+  it('stays honest when the CLI said nothing at all', () => {
+    const message = describeLocalPiperFailure(install, '   \n  ');
+    expect(message).toMatch(/download|install/i);
+    expect(message).not.toMatch(/undefined|null/);
+  });
+
+  it('bounds a runaway CLI transcript so it cannot flood the UI', () => {
+    const message = describeLocalPiperFailure(install, `${'x'.repeat(20_000)}\nnpm error code EBADPLATFORM`);
+    expect(message.length).toBeLessThan(1_200);
+  });
+});
+
+/**
+ * The pure classifier above cannot catch the actual shipped defect: the CLI was
+ * spawned with `stdio: 'ignore'`, so there was never any output to classify.
+ * This drives the REAL spawn path — real child process, real pipe, real exit
+ * code — with `MOXXY_CLI_ENTRY` pointed at a stub CLI, so only the CLI itself
+ * is substituted. Reintroducing `stdio: 'ignore'` fails this test.
+ */
+describe('Local Piper installer (real spawn)', () => {
+  const previousEntry = process.env.MOXXY_CLI_ENTRY;
+
+  afterEach(() => {
+    if (previousEntry === undefined) delete process.env.MOXXY_CLI_ENTRY;
+    else process.env.MOXXY_CLI_ENTRY = previousEntry;
+  });
+
+  async function stubCli(body: string): Promise<string> {
+    const directory = await temporaryMoxxyHome();
+    const entry = path.join(directory, 'stub-cli.js');
+    await writeFile(entry, body);
+    return entry;
+  }
+
+  it('captures the CLI’s stderr and reports the real reason', async () => {
+    process.env.MOXXY_CLI_ENTRY = await stubCli(
+      "process.stderr.write('error: spawn npm ENOENT\\n'); process.exit(1);",
+    );
+
+    await expect(createLocalPiperInstaller()()).rejects.toThrow(/Node\.js/i);
+    await expect(createLocalPiperInstaller()()).rejects.not.toThrow(/internet connection/i);
+  });
+
+  it('succeeds silently when every step exits cleanly', async () => {
+    process.env.MOXXY_CLI_ENTRY = await stubCli('process.exit(0);');
+    await expect(createLocalPiperInstaller()()).resolves.toBeUndefined();
+  });
+});
+
 describe('Local Piper installer', () => {
   it('installs, enables and selects only the fixed Local Piper contribution', async () => {
     const run = vi.fn(async () => undefined);
@@ -78,6 +190,18 @@ describe('Local Piper installer', () => {
       [['plugins', 'enable', LOCAL_PIPER_PACKAGE]],
       [['plugins', 'set-default', 'synthesizer', 'local-piper']],
     ]);
+  });
+
+  it('reports which step failed, not just that something did', async () => {
+    const run = vi.fn(async (args: ReadonlyArray<string>) => {
+      if (args[1] === 'set-default') throw new Error('boom');
+    });
+    const install = createLocalPiperInstaller(run);
+
+    // Naming the step is half the diagnosis: "install" failing is a download
+    // problem, "set-default" failing is a discovery problem, and the old
+    // message could not tell a user (or us, from a screenshot) which it was.
+    await expect(install()).rejects.toThrow(/set-default|voice as the default/i);
   });
 
   it('shares one in-flight installation across concurrent renderer requests', async () => {

--- a/packages/desktop-host/src/local-piper.ts
+++ b/packages/desktop-host/src/local-piper.ts
@@ -73,25 +73,111 @@ export function createLocalPiperInstaller(
 }
 
 async function installLocalPiper(runCommand: LocalPiperCliRunner): Promise<void> {
-  await runCommand(['plugins', 'install', LOCAL_PIPER_PACKAGE]);
-  await runCommand(['plugins', 'enable', LOCAL_PIPER_PACKAGE]);
-  await runCommand([
-    'plugins',
-    'set-default',
-    'synthesizer',
-    LOCAL_PIPER_SYNTHESIZER,
-  ]);
+  for (const args of [
+    ['plugins', 'install', LOCAL_PIPER_PACKAGE],
+    ['plugins', 'enable', LOCAL_PIPER_PACKAGE],
+    ['plugins', 'set-default', 'synthesizer', LOCAL_PIPER_SYNTHESIZER],
+  ]) {
+    try {
+      await runCommand(args);
+    } catch (error) {
+      const message = toMessage(error);
+      // Name the step even when the runner threw something we never shaped (a
+      // spawn ENOENT, an injected test double): WHICH step failed is half the
+      // diagnosis, and it is the half a screenshot can carry. Already-described
+      // failures carry their own step, so don't stamp a second one on.
+      throw message.includes('(while ')
+        ? error
+        : new Error(`${message} (while ${stepLabel(args)})`);
+    }
+  }
+}
+
+/** Bytes of CLI output retained for diagnosis — enough for npm's error block. */
+const MAX_CAPTURED_OUTPUT = 8 * 1024;
+/** Bytes of that output quoted back to the user when we can't classify it. */
+const MAX_QUOTED_OUTPUT = 400;
+
+/**
+ * What the user was waiting for when a given step ran, as a gerund phrase.
+ *
+ * Lower-case and suffix-shaped on purpose: the renderer already prefixes
+ * "Local Piper installation failed: ", so a message that opened with its own
+ * "<Step> failed" read as "…failed: …failed:". The step rides at the end
+ * instead, where it reads as the qualifier it is.
+ */
+function stepLabel(args: ReadonlyArray<string>): string {
+  switch (args[1]) {
+    case 'install':
+      return 'downloading the voice package';
+    case 'enable':
+      return 'enabling the voice package';
+    case 'set-default':
+      return 'selecting the offline voice as the default';
+    default:
+      return 'setting up the offline voice';
+  }
+}
+
+/**
+ * Turn a failed CLI step into something the user can act on.
+ *
+ * This exists because the previous message was a hardcoded guess — every
+ * non-zero exit was reported as "Check your internet connection", including the
+ * common case of a host with no Node/npm at all, where the real output is
+ * `error: spawn npm ENOENT` and no amount of checking the WiFi helps.
+ *
+ * Pure and exported so the mapping is testable against the CLI's REAL output
+ * rather than through a spawned process. The order matters: npm-missing is
+ * checked before the network patterns, because an ENOENT line can sit in the
+ * same transcript as a retry notice that mentions the registry.
+ */
+export function describeLocalPiperFailure(
+  args: ReadonlyArray<string>,
+  output: string,
+): string {
+  const text = output.trim();
+  const say = (reason: string): string => `${reason} (while ${stepLabel(args)})`;
+
+  if (/spawn npm|npm.{0,3}: (not found|command not found)|'npm' is not recognized|ENOENT.*npm/i.test(text)) {
+    return say(
+      'Node.js and npm are required to install it, and npm was not found on this computer. ' +
+        'Install Node.js (nodejs.org), then try again.',
+    );
+  }
+  if (/EACCES|EPERM|EROFS|permission denied/i.test(text)) {
+    return say(
+      'the plugins folder could not be written (permission denied). ' +
+        'Check permissions on ~/.moxxy/plugins, then try again.',
+    );
+  }
+  if (/ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ERR_SOCKET_TIMEOUT|network request to|offline/i.test(text)) {
+    return say('the package registry could not be reached. Check your internet connection and try again.');
+  }
+  if (!text) {
+    return say('the download reported no reason. Try again, and if it repeats please report it.');
+  }
+  // Unrecognised: quote the CLI's own words rather than inventing a cause. The
+  // TAIL is the informative end — npm prints its error block last.
+  return say(tail(text, MAX_QUOTED_OUTPUT));
 }
 
 async function runLocalPiperCliCommand(args: ReadonlyArray<string>): Promise<void> {
   const cli = resolveMoxxyCli({ extraPaths: augmentedPaths() });
-  if (!cli) throw new Error('The bundled Moxxy CLI is unavailable.');
-  const child = spawnCli(cli, args, { stdio: 'ignore' });
+  if (!cli) throw new Error('the bundled Moxxy CLI is unavailable.');
+  // stderr is CAPTURED, not ignored: it carries the only description of what
+  // actually went wrong, and discarding it is what made this failure
+  // undiagnosable from a user's screenshot. stdout stays ignored — nothing
+  // reads it, and a verbose npm run would buffer for no purpose.
+  const child = spawnCli(cli, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+  let captured = '';
+  child.stderr?.on('data', (chunk: Buffer) => {
+    captured += chunk.toString('utf8');
+    if (captured.length > MAX_CAPTURED_OUTPUT) captured = captured.slice(-MAX_CAPTURED_OUTPUT);
+  });
   const code = await waitForCommand(child);
   if (code === 0) return;
-  throw new Error(
-    'The offline voice package could not be installed. Check your internet connection and try again.',
-  );
+  throw new Error(describeLocalPiperFailure(args, captured));
 }
 
 function waitForCommand(child: ChildProcess): Promise<number | null> {
@@ -108,4 +194,12 @@ function waitForCommand(child: ChildProcess): Promise<number | null> {
       resolve(code);
     });
   });
+}
+
+function toMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function tail(text: string, max: number): string {
+  return text.length <= max ? text : `…${text.slice(-max)}`;
 }


### PR DESCRIPTION
Two independent desktop defects, both reported from the same session.

## What

**1. Sidebar groups were indistinguishable from the sessions inside them.**

A workspace header and its own child rows rendered in the same colour, so the tree read as one flat list and you could not tell a folder from a conversation.

The cause was a palette collision rather than a layout mistake: the header used `--color-text-dim` and an idle row used `--color-sidebar-text-dim`, and those two tokens resolve to the *same hex* in both themes (`#77868f` dark, `#66757e` light). Two names, one colour — which is why it passed review. With the colour carrying nothing, the only nesting cue left was a 4px indent, invisible next to a 30px row, and `gap: 1` packed headers and rows at one density.

Now separated by four independent cues:

| | group header | session row |
|---|---|---|
| marker | square workspace-colour chip | round LED |
| text tier | `--color-text-muted` | `--color-sidebar-text-dim` |
| case | uppercase, letterspaced | sentence case |
| containment | — | guide rail + inter-group gap |

Three real tiers now: active row (bright) > group header (muted) > idle row (dim). The chip renders `Desk.color`, which has been in the IPC contract all along and was simply never drawn — the component's own docstring already described a "tinted workspace glyph" that did not exist. No new tokens, no contract change.

**2. A failed Local Piper install always blamed the network.**

The installer spawned the CLI with `stdio: 'ignore'` and reported every non-zero exit as *"The offline voice package could not be installed. Check your internet connection and try again."* — a hardcoded guess, with the only description of the real cause discarded before anyone could read it.

Reproduced on a host without Node: the CLI writes `error: spawn npm ENOENT` to stderr and exits 1, because the install shells out to `npm`. A user whose internet was fine was told to check their connection, with no path to discovering that Node was the actual requirement.

stderr is now captured (bounded to 8 KB) and classified into causes that can be acted on — npm/Node missing, registry unreachable, plugins folder not writable. Unrecognised output is quoted verbatim instead of re-diagnosed, because a confident wrong answer is worse than the CLI's own words. Every message names which of the three steps (`install` / `enable` / `set-default`) failed.

> Scope note for reviewers: this changes the **diagnosis, not the installation**. A run that failed before still fails — it now says what to do about it. Which underlying cause hit the reporting user is still unknown, precisely because the old code destroyed the evidence.

## Why

Both are cases where the code was confidently wrong rather than merely imperfect: one asserted a hierarchy it did not draw, the other asserted a cause it had not observed. In each case the fix is to make the thing say something true.

## Verification

- `pnpm build` — 85/85 green
- `packages/desktop-host` — 559/559 tests green; `apps/desktop/src/shell/workspace-sidebar` — 24/24
- typecheck clean; eslint clean on all changed files
- Changesets present for both fixes (`@moxxy/desktop` patch)

Written test-first; every new test was observed failing for the right reason before the implementation landed:

- The sidebar regression test asserts on the *token*, not the rendered string — comparing rendered values would have passed while the bug was live, since both names resolved to one colour. A companion test in `design-tokens/contrast.test.ts` pins that the header tier and row tier stay distinguishable, so the palette cannot re-collapse them.
- The Piper classifier is a pure function tested against the CLI's **real** observed output, not invented strings.
- A spawn-level test drives a real child process, real pipe and real exit code (only the CLI binary is stubbed). This is the one that matters: a pure classifier can never catch the shipped defect, because with `stdio: 'ignore'` there was no output to classify. Confirmed the guard bites — reintroducing `stdio: 'ignore'` fails exactly that test and nothing else.

Sidebar verified visually by rendering the real component before and after (the "before" from the stashed original, not a reconstruction), in both themes.

## Not included, deliberately

- **Auto-installing Node** when npm is missing. `installManagedNode()` already exists in `desktop-host` and would likely fix the most common cause, but wiring it to this button changes its behaviour — a click would silently pull ~50 MB of runtime. That is a product decision, not a bug fix.
- **6 pre-existing failures in `AppRail.test.tsx`** (`useUser` outside `<ClerkProvider>`). Verified pre-existing on this branch by stashing; untouched here as unrelated.
- `@moxxy/sdk` did not build before this work: `undici` is declared in its manifest but was absent from the install. Resolved with `pnpm install --frozen-lockfile` (lockfile unchanged) — no source change was needed, but worth knowing if others hit it.