### PR TITLE
fix(provider-anthropic): trim the API catalog to the four current models

### DIFF
--- a/.changeset/anthropic-current-model-catalog.md
+++ b/.changeset/anthropic-current-model-catalog.md
@@ -1,0 +1,17 @@
+---
+"@moxxy/plugin-provider-anthropic": patch
+"@moxxy/config": patch
+"@moxxy/cli": patch
+---
+
+Trim the Anthropic API catalog to the four current Claude models
+
+The picker still offered `claude-opus-4-7`, `claude-opus-4-6` and `claude-sonnet-4-6`,
+listed Haiku under its dated id, and pinned the default at `claude-sonnet-4-6`. The
+catalog is now `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5` and
+`claude-haiku-4-5`, which matches the Claude Code catalog and the ids Anthropic
+documents today. `claude-sonnet-5` becomes the default (direct successor of the
+previous one) and gets its real 128k output ceiling instead of 64k; key validation
+and the `config_init` template move to current ids as well. Older generations are
+still served by the API and can still be pinned in config, they are just no longer
+offered in the picker.

--- a/apps/docs/src/content/docs/guides/http-channel.md
+++ b/apps/docs/src/content/docs/guides/http-channel.md
@@ -77,7 +77,7 @@ Optional tuning lives in the query string so the body stays raw:
 
 ```sh
 curl -X POST \
-  "http://localhost:3737/v1/turn/audio?model=claude-sonnet-4-6&language=en" \
+  "http://localhost:3737/v1/turn/audio?model=claude-sonnet-5&language=en" \
   -H "Authorization: Bearer $MOXXY_HTTP_TOKEN" \
   -H "Content-Type: audio/m4a" \
   --data-binary @voicenote.m4a

--- a/apps/docs/src/content/docs/packages/config.md
+++ b/apps/docs/src/content/docs/packages/config.md
@@ -23,7 +23,7 @@ import { defineConfig } from '@moxxy/config';
 export default defineConfig({
   provider: {
     name: 'anthropic',
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-5',
     config: { apiKey: '${vault:ANTHROPIC_API_KEY}' },
   },
   channels: {

--- a/apps/docs/src/content/docs/packages/plugin-provider-anthropic.md
+++ b/apps/docs/src/content/docs/packages/plugin-provider-anthropic.md
@@ -32,7 +32,7 @@ Or via vault placeholder in `moxxy.config.ts`:
 ```ts
 provider: {
   name: 'anthropic',
-  model: 'claude-sonnet-4-6',
+  model: 'claude-sonnet-5',
   config: { apiKey: '${vault:ANTHROPIC_API_KEY}' },
 }
 ```

--- a/apps/docs/src/content/docs/quickstart.md
+++ b/apps/docs/src/content/docs/quickstart.md
@@ -41,7 +41,7 @@ import { defineConfig } from '@moxxy/config';
 export default defineConfig({
   provider: {
     name: 'anthropic',
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-5',
     config: { apiKey: '${vault:ANTHROPIC_API_KEY}' },
   },
 });

--- a/apps/fixture-recorder/src/index.ts
+++ b/apps/fixture-recorder/src/index.ts
@@ -9,7 +9,7 @@
  *     --prompt "list files in cwd"  \
  *     --name list-files-demo        \
  *     --out packages/testing/__fixtures__ \
- *     --model claude-sonnet-4-6     \
+ *     --model claude-sonnet-5       \
  *     [--allow-tools Read,Glob]     \
  *     [--max-iterations 4]
  *

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ export default defineConfig({
       default: 'anthropic',
       items: {
         anthropic: {
-          model: 'claude-sonnet-4-6',
+          model: 'claude-sonnet-5',
           config: { apiKey: '${vault:ANTHROPIC_API_KEY}' },
         },
       },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -237,7 +237,7 @@ import { defineConfig } from '@moxxy/config';
 export default defineConfig({
   provider: {
     name: 'anthropic',
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-5',
     config: { apiKey: '${vault:ANTHROPIC_API_KEY}' },   // resolved from the vault
   },
   mode: 'default',

--- a/packages/config/src/define.ts
+++ b/packages/config/src/define.ts
@@ -6,7 +6,7 @@ import type { MoxxyConfig } from './schema.js';
  *   import { defineConfig } from '@moxxy/config';
  *
  *   export default defineConfig({
- *     provider: { name: 'anthropic', model: 'claude-sonnet-4-6' },
+ *     provider: { name: 'anthropic', model: 'claude-sonnet-5' },
  *     plugins: {
  *       '@moxxy/plugin-mcp': { enabled: true, options: { servers: [...] } },
  *       '@acme/moxxy-plugin-shell': { enabled: false },

--- a/packages/config/src/plugin.ts
+++ b/packages/config/src/plugin.ts
@@ -317,7 +317,7 @@ plugins:
     default: anthropic
     items:
       anthropic:
-        model: claude-sonnet-4-6
+        model: claude-sonnet-5
   mode:
     default: default
 `;

--- a/packages/plugin-provider-anthropic/src/provider.test.ts
+++ b/packages/plugin-provider-anthropic/src/provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { assertDefined, defineTool, z } from '@moxxy/sdk';
-import { AnthropicProvider } from './provider.js';
+import { AnthropicProvider, anthropicModels } from './provider.js';
 
 // A minimal fake Anthropic SDK client to drive the translator without HTTP.
 function fakeAnthropic(stream: ReadonlyArray<unknown>): { messages: { stream: () => AsyncIterable<unknown>; countTokens: () => Promise<{ input_tokens: number }> } } {
@@ -46,7 +46,7 @@ describe('AnthropicProvider.stream', () => {
 
     const events = [];
     for await (const event of provider.stream({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       messages: [],
       tools: [fallback],
     })) events.push(event);
@@ -76,7 +76,7 @@ describe('AnthropicProvider.stream', () => {
     ]);
     const provider = new AnthropicProvider({ client: fake as never });
     const events = [];
-    for await (const event of provider.stream({ model: 'claude-sonnet-4-6', messages: [] })) {
+    for await (const event of provider.stream({ model: 'claude-sonnet-5', messages: [] })) {
       events.push(event);
     }
     const text = events
@@ -303,16 +303,48 @@ describe('AnthropicProvider.stream', () => {
     };
     const p = new AnthropicProvider({ client: client as never });
     // haiku ceiling is 64_000 — an absurd request must be clamped, not forwarded.
-    for await (const _ of p.stream({ model: 'claude-haiku-4-5-20251001', maxTokens: 5_000_000, messages: [] })) {
+    for await (const _ of p.stream({ model: 'claude-haiku-4-5', maxTokens: 5_000_000, messages: [] })) {
       void _;
     }
     const call0 = calls[0];
     assertDefined(call0, 'first call recorded');
     expect(call0.max_tokens).toBe(64_000);
     // No maxTokens → defaults to the descriptor ceiling.
-    for await (const _ of p.stream({ model: 'claude-haiku-4-5-20251001', messages: [] })) void _;
+    for await (const _ of p.stream({ model: 'claude-haiku-4-5', messages: [] })) void _;
     const call1 = calls[1];
     assertDefined(call1, 'second call recorded');
     expect(call1.max_tokens).toBe(64_000);
+  });
+});
+
+describe('anthropicModels', () => {
+  it('offers the current Claude catalog and defaults to a model inside it', async () => {
+    expect(anthropicModels.map((model) => model.id)).toEqual([
+      'claude-fable-5',
+      'claude-opus-5',
+      'claude-sonnet-5',
+      'claude-haiku-4-5',
+    ]);
+
+    const calls: Array<{ model?: string }> = [];
+    const client = {
+      messages: {
+        stream: (args: { model?: string }) => {
+          calls.push(args);
+          return (async function* () {
+            yield { type: 'message_stop' };
+          })();
+        },
+        countTokens: async () => ({ input_tokens: 0 }),
+      },
+    };
+    const p = new AnthropicProvider({ client: client as never });
+    // An unset model falls back to the provider default, which must be a listed
+    // model — an unlisted default silently loses its output ceiling (4096) and
+    // its hosted tools.
+    for await (const _ of p.stream({ model: '', messages: [] })) void _;
+    const call0 = calls[0];
+    assertDefined(call0, 'request recorded');
+    expect(anthropicModels.some((model) => model.id === call0.model)).toBe(true);
   });
 });

--- a/packages/plugin-provider-anthropic/src/provider.ts
+++ b/packages/plugin-provider-anthropic/src/provider.ts
@@ -63,25 +63,24 @@ export interface AnthropicProviderConfig {
   readonly oauthRefresh?: () => Promise<{ readonly token: string; readonly expiresAt?: number }>;
 }
 
-// Hardcoded model catalog (re-exported to @moxxy/plugin-provider-claude-code, which
-// reuses this provider class for the subscription path). Deriving it from the Models
-// API is a larger change (auth + caching) — deliberately deferred (TECH_DEBT P3 #8).
+// Hardcoded model catalog. Deriving it from the Models API is a larger change
+// (auth + caching) — deliberately deferred (TECH_DEBT P3 #8).
 // Values verified against the current Anthropic model catalog (2026-07): fable-5,
-// opus-5, opus-4-7 and opus-4-6 carry a 1M context window with a 128k streaming
-// ceiling; sonnet-5 and sonnet-4-6 are 1M/64k; haiku-4-5 is 200k/64k. fable-5 is Anthropic's most
-// capable model (always-on reasoning); the loop never sets `temperature`, which
-// fable-5/opus-5/4.7 reject, so they stream cleanly here, same as opus-4-7 already did.
+// opus-5 and sonnet-5 carry a 1M context window with a 128k streaming ceiling;
+// haiku-4-5 is 200k/64k and is listed under its alias, matching the Claude Code
+// catalog. The previous generation (opus-4-7/4-6, sonnet-4-6) is still served by
+// the API but no longer offered here, so the picker matches what Anthropic
+// currently recommends; a config can still pin any id the API accepts.
+// fable-5 is Anthropic's most capable model (always-on reasoning); the loop never
+// sets `temperature`, which fable-5/opus-5/sonnet-5 reject, so they stream cleanly.
 // `supportsReasoning` marks models that accept adaptive thinking (`thinking:
-// {type:'adaptive', display:'summarized'}`) — fable-5/opus-5/4-7/4-6 and sonnet-4-6
-// do; haiku-4-5 does not (effort/adaptive-thinking error there), so it stays off.
+// {type:'adaptive', display:'summarized'}`) — fable-5, opus-5 and sonnet-5 do;
+// haiku-4-5 does not (effort/adaptive-thinking error there), so it stays off.
 export const anthropicModels: ReadonlyArray<ModelDescriptor> = [
   { id: 'claude-fable-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
   { id: 'claude-opus-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
-  { id: 'claude-opus-4-7', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
-  { id: 'claude-opus-4-6', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
-  { id: 'claude-sonnet-5', contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
-  { id: 'claude-sonnet-4-6', contextWindow: 1_000_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
-  { id: 'claude-haiku-4-5-20251001', contextWindow: 200_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, hostedTools: ['web_search'] },
+  { id: 'claude-sonnet-5', contextWindow: 1_000_000, maxOutputTokens: 128_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, supportsReasoning: true, hostedTools: ['web_search'] },
+  { id: 'claude-haiku-4-5', contextWindow: 200_000, maxOutputTokens: 64_000, supportsTools: true, supportsStreaming: true, supportsImages: true, supportsDocuments: true, hostedTools: ['web_search'] },
 ];
 
 export class AnthropicProvider implements LLMProvider {
@@ -109,7 +108,7 @@ export class AnthropicProvider implements LLMProvider {
   constructor(config: AnthropicProviderConfig = {}) {
     this.name = config.name ?? 'anthropic';
     this.models = config.models ?? anthropicModels;
-    this.defaultModel = config.defaultModel ?? 'claude-sonnet-4-6';
+    this.defaultModel = config.defaultModel ?? 'claude-sonnet-5';
     if (config.baseURL) this.baseURL = config.baseURL;
 
     if (config.oauthToken) {

--- a/packages/plugin-provider-anthropic/src/validate.test.ts
+++ b/packages/plugin-provider-anthropic/src/validate.test.ts
@@ -36,9 +36,9 @@ describe('anthropic validateKey', () => {
   it('respects model override', async () => {
     const create = vi.fn().mockResolvedValue({});
     const make = () => ({ messages: { create } });
-    await validateKey('sk-ant-key-of-reasonable-length', { client: make, model: 'claude-opus-4-7' });
+    await validateKey('sk-ant-key-of-reasonable-length', { client: make, model: 'claude-opus-5' });
     const args = create.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(args.model).toBe('claude-opus-4-7');
+    expect(args.model).toBe('claude-opus-5');
   });
 
   it('maps a 401 to a fixed friendly message (no raw SDK text echoed)', async () => {

--- a/packages/plugin-provider-anthropic/src/validate.ts
+++ b/packages/plugin-provider-anthropic/src/validate.ts
@@ -22,7 +22,7 @@ export async function validateKey(key: string, deps: ValidateKeyDeps = {}): Prom
   try {
     const client = make(key);
     await client.messages.create({
-      model: deps.model ?? 'claude-haiku-4-5-20251001',
+      model: deps.model ?? 'claude-haiku-4-5',
       max_tokens: 1,
       messages: [{ role: 'user', content: 'ping' }],
     });


### PR DESCRIPTION
The Anthropic API picker still listed `claude-opus-4-7`, `claude-opus-4-6` and `claude-sonnet-4-6`, showed Haiku under its dated id, and defaulted to `claude-sonnet-4-6`. It now offers `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5` and `claude-haiku-4-5`, the same four the Claude Code provider was trimmed to in #497 and the ids Anthropic documents today (verified against the models overview page). `claude-sonnet-5` becomes the default and gets its real 128k output ceiling instead of 64k, which also feeds the compaction budget.

Key validation and the `config_init` template moved to current ids too, plus the doc/README snippets that told people to configure `claude-sonnet-4-6`. Older generations are still served by the API and can still be pinned in config, they are just no longer offered in the picker.

The claude-code catalog needed no change, #497 already fixed it.

New test pins the catalog and that the default model is inside it (an unlisted default silently loses its output ceiling and hosted web search). Full gate green: build, typecheck, lint, test, check:deps.