### PR TITLE
feat: bound long sessions with sub-session records, and drive the desktop from the keyboard

### DIFF
--- a/.changeset/sub-session-context-and-hotkeys.md
+++ b/.changeset/sub-session-context-and-hotkeys.md
@@ -1,0 +1,15 @@
+---
+'@moxxy/cli': minor
+'@moxxy/sdk': minor
+'@moxxy/desktop': minor
+---
+
+Bound a session's context by policy instead of by how long it has been running, and give the desktop a real keymap.
+
+A new default compactor (`segments`) records every finished turn as one dense sub-session record (Asked / Did / Outcome / Facts / Open) that replaces the turn's raw events in context. Once the index of records passes its cap the oldest fold into a chapter, so the index is bounded too. Nothing is lost: the event log keeps every original event, the new `session_recall` tool searches the records, and `recall({ turnId })` restores one sub-session verbatim. `summarize-old-turns` stays registered as the protected floor and is selectable via `plugins.compactor.default`.
+
+SDK: compaction ranges now supersede any earlier range they fully contain (`activeCompactionRanges`), which is what lets a compactor re-compact its own summaries; projection and the token estimate share that one decision. `summarizeWithProvider` is extracted so compactors don't each re-implement the summarize-or-degrade-but-never-on-abort contract.
+
+Desktop: one registry-backed keymap with a single window dispatcher: ⌘K palette, ⌘L composer, ⌘F search, ⌘. interrupt, ⌘N session, ⌘⌥↑/↓ session switching, ⌘B sidebar, ⌘J workbench, ⌘1-5 destinations, ⌘, settings, ⌘/ for the shortcut sheet, which renders from the live registry so it cannot drift from what is bound.
+
+Also fixes a pre-existing name drift: the CLI's compactor floor and built-in default referred to `summarize`, but the def is named `summarize-old-turns`, so neither ever matched.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ If you're a Claude Code agent or any other autonomous agent: read this file firs
 @moxxy/mode-default               "default" mode — Claude Code-style ReAct loop (registered by the CLI; first registered mode auto-activates)
 @moxxy/mode-goal                  "goal" mode — autonomous auto-approve loop; works across turns until goal_complete
 @moxxy/mode-deep-research         "research" mode — multi-query fan-out + synthesis
-@moxxy/compactor-summarize        default summarize-old-turns compactor
+@moxxy/compactor-segments         DEFAULT compactor: sub-session records (one per finished turn) folded into chapters; adds `session_recall`
+@moxxy/compactor-summarize        summarize-old-turns compactor; the protected floor, selectable via `plugins.compactor.default`
 @moxxy/cache-strategy-stable-prefix  default prompt-cache strategy (stable-prefix breakpoints; `none` = opt-out)
 @moxxy/skills-builtin             MD skills shipped with the framework
 
@@ -77,6 +78,8 @@ apps/desktop                 Electron desktop app — attaches to @moxxy/runner,
 **Plugin model.** Plugins are TS code distributed as `@moxxy/*` npm packages, auto-discovered via `package.json#moxxy.plugin.entry`. The CLI also auto-loads any package under `~/.moxxy/plugins/*/` that carries that manifest. Plugins contribute `tools`, `providers`, `loopStrategies`, `compactors`, `cacheStrategies`, `channels`, and `hooks` via `definePlugin({...})`.
 
 **Caching model.** A `CacheStrategy` decides *where* prompt-cache breakpoints go and returns provider-neutral `CacheHint`s (`{ target: 'tools' | 'system' | { messageIndex } }`); the provider expresses them (Anthropic → `cache_control`). One is active per session — registered via plugins exactly like compactors/modes; first registered auto-activates. `@moxxy/cache-strategy-stable-prefix` is the default (static prefix + rolling tail); `none` opts out. `plan()` MUST be deterministic given identical inputs — a non-deterministic breakpoint shifts the cached prefix between calls and silently defeats the cache (paying 1.25x writes for 0 reads).
+
+**Context model.** Three layers keep one long-running session inside the window, all expressed as EVENTS the projection folds, never as mutations of history. (1) **Elision** stubs bulky old tool results (`recall(callId)` expands them). (2) **Compaction** replaces a seq range with a summary; the default `segments` compactor records each finished turn as one dense sub-session record and folds old records into chapters once the index passes its cap, so context is bounded by policy rather than by session length. `session_recall` searches those records, `recall({ turnId })` restores one verbatim. (3) **Memory** (`@moxxy/plugin-memory`) persists across sessions. A compaction range fully contained in a LATER range is superseded (see `activeCompactionRanges`), which is what lets a compactor re-compact its own summaries.
 
 **Channels.** A `Channel` is a bidirectional surface that drives a Session — TUI, Telegram, HTTP, etc. Channels expose `subcommands` for one-shot maintenance ops (`moxxy channels telegram pair|unpair|status`); the CLI's `bin.ts` knows nothing about specific channels.
 

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -24,7 +24,37 @@ or recorded-on-purpose decision.
 
 ## Open
 
-No open items.
+- [med, context/intra-turn-overflow, LOGGED 2026-08-03] The `segments` compactor
+  bounds context ACROSS turns; it cannot bound a single runaway turn. Compaction
+  and elision both advance only on completed-turn boundaries, so one turn that
+  makes hundreds of tool calls can still approach the window on its own. Under
+  pressure `segments` drops the verbatim tail to one turn and the loop's
+  reactive `force` compaction still fires, but neither touches the live turn.
+  A real fix needs intra-turn compaction that preserves tool_use/tool_result
+  pairing. `packages/compactor-segments/src/segments.ts`,
+  `packages/sdk/src/elision-helpers.ts`.
+
+- [low, context/chapter-fidelity, LOGGED 2026-08-03] Each chapter fold caps its
+  output at half the records it replaces, so detail degrades geometrically the
+  longer a session runs. That is the intended trade (a bounded index beats a
+  faithful one that overflows), and `recall({ turnId })` still reaches the
+  originals, but there is no signal to the model that an old chapter is
+  lossier than a recent record. Consider stamping a fold depth on the header.
+  `packages/compactor-segments/src/index.ts`.
+
+- [low, desktop/hotkeys-menu, LOGGED 2026-08-03] The keymap is renderer-only, so
+  the Electron application menu still lists just Focus Mode. Nothing surfaces
+  the shortcuts outside the ⌘/ sheet and the composer hint, and shortcuts do not
+  work when a non-renderer window holds focus. Wiring menu accelerators needs a
+  main→renderer IPC command and a rule that a chord is bound in exactly one
+  place (menu OR renderer) so it can't fire twice.
+  `apps/desktop/electron/main/menus.ts`, `apps/desktop/src/hotkeys/`.
+
+- [low, desktop/editable-target-dupe, LOGGED 2026-08-03] `isEditableTarget` now
+  exists in both `apps/desktop/src/hotkeys/chord.ts` and the workflow canvas's
+  helpers. The App.tsx copy was retired with the hand-rolled ⌘B handler; the
+  canvas one should move onto the hotkeys registry rather than keep its own
+  window listener. `apps/desktop/src/workflows/WorkflowCanvas.tsx`.
 
 ## Resolved ledger
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,7 +15,8 @@ import {
 import { AskSheet } from './chat/AskSheet';
 import { useAskSurfaceClaimed } from '@/lib/askSurface';
 import { useTheme } from '@/lib/useTheme';
-import { toggleSidebarCollapsed } from '@/lib/useSidebarCollapsed';
+import { useHotkeyDispatcher, ShortcutsSheet } from './hotkeys';
+import { useAppHotkeys } from './hotkeys/useAppHotkeys';
 import { ConnectionScreen, type UpdateCliResult } from './connection/ConnectionScreen';
 import { Onboarding } from './onboarding/Onboarding';
 import { ChatSurface } from './chat/ChatSurface';
@@ -90,6 +91,7 @@ export function App(): JSX.Element {
   const [channelId, setChannelId] = useChannelSelection();
   const [settingsTab, setSettingsTab] = useSettingsTab();
   const [lastConnected, setLastConnected] = useState<LastConnectedSession | null>(null);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   // Local flag that flips the moment the user clicks "Open my
   // workspaces" in the FirstRunWizard, so we don't re-render the
   // wizard while waiting for prefs.read to round-trip.
@@ -148,21 +150,6 @@ export function App(): JSX.Element {
   // tab so its work is shown to the user (once per session per tab).
   useAgentSurfaceReveal(activeWorkspaceId, setBenchTab);
 
-  // Cmd/Ctrl+B toggles the workspace sidebar (same window-level keydown
-  // pattern as WorkflowCanvas's Delete handling). Skipped while typing —
-  // Cmd+B means "bold" inside inputs/textareas/contentEditable.
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent): void => {
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
-      if (e.key.toLowerCase() !== 'b') return;
-      if (isEditableTarget(e.target)) return;
-      e.preventDefault();
-      toggleSidebarCollapsed();
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
-
   // Boot-probe heartbeat: the React tree mounted, so a hot-updated bundle is
   // healthy — tell main to confirm it (no-op on the bundled floor). A SINGLE
   // swallowed invoke here was the prime suspect for "updates but reverts to the
@@ -217,6 +204,18 @@ export function App(): JSX.Element {
       setView('chat');
     }
   }, [runnerTabsLocked, view]);
+
+  // One window-level dispatcher for the whole keymap; the bindings themselves
+  // live in `useAppHotkeys`, which is also what the help sheet renders from.
+  // Registered through `onView` so a shortcut can't jump to a runner-locked
+  // destination the rail itself refuses.
+  useHotkeyDispatcher();
+  useAppHotkeys({
+    setView: onView,
+    benchTab,
+    setBenchTab,
+    onShowShortcuts: () => setShortcutsOpen(true),
+  });
 
   if (prefsLoading) {
     return (
@@ -386,6 +385,7 @@ export function App(): JSX.Element {
           <MobilePanel />
         </main>
       )}
+      {shortcutsOpen && <ShortcutsSheet onClose={() => setShortcutsOpen(false)} />}
       {!connected && <ReconnectBanner label={describePhase(shellPhase)} />}
       {/* The runner BLOCKS on permission/approval asks. ChatSurface renders
           them in the chat view and AgentTaskModal claims the surface while a
@@ -394,15 +394,6 @@ export function App(): JSX.Element {
       {view !== 'chat' && <GlobalAskFallback workspaceId={activeWorkspaceId} />}
     </div>
   );
-}
-
-/** True when the key event originated in a text-entry surface (so global
- *  shortcuts must not fire). Mirrors WorkflowCanvas's guard. */
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  if (target.isContentEditable) return true;
-  const tag = target.tagName;
-  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
 }
 
 function isRunnerLockedView(view: View): boolean {

--- a/apps/desktop/src/chat/ChatSurface.tsx
+++ b/apps/desktop/src/chat/ChatSurface.tsx
@@ -17,6 +17,7 @@ import { ImagePreviewModal } from './image-preview/ImagePreviewModal';
 import { useImagePreview } from './image-preview/useImagePreview';
 import { VoiceCallSurface } from '../voice-call/VoiceCallSurface';
 import { useVoiceCallRequest } from '@/lib/voiceCallRequest';
+import { abortTurnPulse, transcriptSearchPulse } from '@/lib/chatPulses';
 import { deriveVoiceTranscriptLines } from '../voice-call/voice-transcript';
 import { useDesktopVoiceCall } from '../voice-call/useDesktopVoiceCall';
 import { useFocusModeToggle } from './chat-surface/useFocusModeToggle';
@@ -98,6 +99,11 @@ export function ChatSurface({
   const enterFocusMode = useFocusModeToggle();
   const [searchQuery, setSearchQuery] = useState<string | null>(null);
   const [renameOpen, setRenameOpen] = useState(false);
+  // Keyboard shortcuts owned by the shell, executed here where the state lives.
+  transcriptSearchPulse.use(() => setSearchQuery((q) => q ?? ''));
+  abortTurnPulse.use(() => {
+    if (chat.activeTurnId !== null || chat.sending) void chat.abort();
+  });
   const imagePreview = useImagePreview();
   // workspaceId is a SESSION id (the runner-pool routing key) — resolve the
   // desk that owns it (first sessions share their desk's id, so old ids work).

--- a/apps/desktop/src/chat/Composer.tsx
+++ b/apps/desktop/src/chat/Composer.tsx
@@ -14,6 +14,7 @@ import { useVoiceRecorder } from '@moxxy/client-core';
 import { useActiveModeBadge } from '@moxxy/client-core';
 import { chatStore } from '@moxxy/client-core';
 import { composerDraftStore, usePendingComposerDraft } from '@moxxy/client-core';
+import { commandPalettePulse, focusComposerPulse } from '@/lib/chatPulses';
 import type { AgentSession } from './agent-picker/useAgentSession';
 import { ModeBanner } from './composer/ModeBanner';
 import { CommandPalette } from './CommandPalette';
@@ -109,6 +110,15 @@ export function Composer({
 
   /** Stable callback for the attachment hooks to refocus the textarea. */
   const focusInput = useCallback(() => taRef.current?.focus(), []);
+
+  // Shell-owned shortcuts (⌘K / ⌘L) landing on the state that owns them.
+  commandPalettePulse.use(() => setActionsOpen(true));
+  focusComposerPulse.use(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.focus();
+    ta.selectionStart = ta.selectionEnd = ta.value.length;
+  });
 
   // Attachment handling (rail file-insert, native picker, image paste) lives
   // in its own hook so the attach path is independently testable.
@@ -505,7 +515,7 @@ export function Composer({
       )}
       <p className="cmdbar__keys">
         {inFlight ? 'Enter queues behind the running turn' : 'Enter sends'} · Shift+Enter
-        newline · Esc clears
+        newline · Esc clears · ⌘/ shortcuts
       </p>
       {actionsOpen && (
         <CommandPalette

--- a/apps/desktop/src/chat/chat-surface/Header.tsx
+++ b/apps/desktop/src/chat/chat-surface/Header.tsx
@@ -46,6 +46,9 @@ export function Header({
   readonly onRename: () => void;
 }): JSX.Element {
   const [searchOpen, setSearchOpen] = useState(searchQuery !== null);
+  // A live query forces the field open, so the ⌘F shortcut (which sets the
+  // query from outside this component) reveals and focuses it.
+  const open = searchOpen || searchQuery !== null;
   const toggleFocusMode = useFocusModeToggle();
   const crumbs = [deskName, sessionName].filter((c): c is string => Boolean(c));
   return (
@@ -62,7 +65,7 @@ export function Header({
           onPick={agent.onPickProviderModel}
         />
       )}
-      {searchOpen ? (
+      {open ? (
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-6)' }}>
           <input
             autoFocus

--- a/apps/desktop/src/hotkeys/ShortcutsSheet.tsx
+++ b/apps/desktop/src/hotkeys/ShortcutsSheet.tsx
@@ -1,0 +1,66 @@
+import { Modal } from '@moxxy/desktop-ui';
+import { formatChord, parseChord } from './chord';
+import { useHotkeyList$ } from './useHotkeys';
+
+/**
+ * The keyboard reference, rendered FROM the live registry rather than from a
+ * hand-kept list, so it can never drift from what is actually bound.
+ */
+export function ShortcutsSheet({ onClose }: { readonly onClose: () => void }): JSX.Element {
+  const bindings = useHotkeyList$().filter((b) => !b.hidden);
+  const isMac = navigator.platform.toLowerCase().includes('mac');
+  const groups = new Map<string, typeof bindings>();
+  for (const binding of bindings) {
+    const list = groups.get(binding.group) ?? [];
+    groups.set(binding.group, [...list, binding]);
+  }
+
+  return (
+    <Modal title="Keyboard shortcuts" onClose={onClose} width={520}>
+      <div style={{ display: 'grid', gap: 20 }}>
+        {[...groups.entries()].map(([group, items]) => (
+          <section key={group} style={{ display: 'grid', gap: 6 }}>
+            <h3
+              style={{
+                margin: 0,
+                fontSize: 'var(--type-ui-sm)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                color: 'var(--color-text-muted)',
+              }}
+            >
+              {group}
+            </h3>
+            {items.map((binding) => (
+              <div
+                key={binding.id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  justifyContent: 'space-between',
+                  gap: 16,
+                  opacity: binding.disabled ? 0.45 : 1,
+                }}
+              >
+                <span style={{ fontSize: 'var(--type-ui)' }}>{binding.label}</span>
+                <kbd
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 'var(--type-ui-sm)',
+                    padding: '2px 7px',
+                    borderRadius: 'var(--radius-sm)',
+                    border: '1px solid var(--color-card-border)',
+                    background: 'var(--color-card-bg)',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {formatChord(parseChord(binding.chord), isMac)}
+                </kbd>
+              </div>
+            ))}
+          </section>
+        ))}
+      </div>
+    </Modal>
+  );
+}

--- a/apps/desktop/src/hotkeys/chord.ts
+++ b/apps/desktop/src/hotkeys/chord.ts
@@ -1,0 +1,104 @@
+/**
+ * Chord parsing / matching / rendering. Pure and DOM-free so the keymap can be
+ * tested without a window, and so the same spec string drives both the listener
+ * and the shortcut help sheet (one source of truth: a shortcut that is listed
+ * but not bound, or bound but not listed, is the classic keymap bug).
+ *
+ * `mod` is ⌘ on macOS and Ctrl elsewhere. Matching accepts either, exactly as
+ * the app's original hand-rolled Cmd/Ctrl+B handler did, so a bound chord works
+ * on whichever key the user's platform trained them to reach for.
+ */
+
+export interface Chord {
+  /** Normalized `KeyboardEvent.key`, lowercased. */
+  readonly key: string;
+  readonly mod: boolean;
+  readonly alt: boolean;
+  readonly shift: boolean;
+}
+
+export interface KeyLike {
+  readonly key: string;
+  readonly metaKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly altKey: boolean;
+  readonly shiftKey: boolean;
+}
+
+const MODIFIERS = new Set(['mod', 'alt', 'shift']);
+
+export function parseChord(spec: string): Chord {
+  const parts = spec.split('+').map((p) => p.trim().toLowerCase());
+  // Every malformed spec throws. A hotkey that parses but can never match is
+  // the worst failure mode here: it looks bound, it lists in the help sheet,
+  // and it silently does nothing.
+  if (parts.some((p) => p.length === 0)) {
+    throw new Error(`hotkey spec has an empty segment: "${spec}"`);
+  }
+  const key = parts[parts.length - 1]!;
+  if (MODIFIERS.has(key)) {
+    throw new Error(`hotkey spec "${spec}" ends in a modifier, so it has no key`);
+  }
+  const mods = new Set(parts.slice(0, -1));
+  for (const m of mods) {
+    if (!MODIFIERS.has(m)) {
+      throw new Error(`unknown hotkey modifier "${m}" in "${spec}" (use mod/alt/shift)`);
+    }
+  }
+  return { key, mod: mods.has('mod'), alt: mods.has('alt'), shift: mods.has('shift') };
+}
+
+export function matchesChord(event: KeyLike, chord: Chord): boolean {
+  if (event.key.toLowerCase() !== chord.key) return false;
+  // Exact modifier match in both directions: without this, ⌘⇧N would also fire
+  // the ⌘N binding and create a session every time the user meant a workspace.
+  if (chord.mod !== (event.metaKey || event.ctrlKey)) return false;
+  if (chord.alt !== event.altKey) return false;
+  if (chord.shift !== event.shiftKey) return false;
+  return true;
+}
+
+/** A chord with no modifier (Escape, ?) is unsafe to fire while the user is
+ *  typing; a modified one is the whole point of a global shortcut. */
+export function defaultAllowInEditable(chord: Chord): boolean {
+  return chord.mod || chord.alt;
+}
+
+const MAC_SYMBOLS: Readonly<Record<string, string>> = {
+  mod: '⌘',
+  alt: '⌥',
+  shift: '⇧',
+};
+
+const KEY_LABELS: Readonly<Record<string, string>> = {
+  escape: 'Esc',
+  enter: '↵',
+  arrowup: '↑',
+  arrowdown: '↓',
+  arrowleft: '←',
+  arrowright: '→',
+  ' ': 'Space',
+};
+
+/** Human-readable chord for the help sheet and tooltips. */
+export function formatChord(chord: Chord, isMac: boolean): string {
+  const parts: string[] = [];
+  if (chord.mod) parts.push(isMac ? MAC_SYMBOLS.mod! : 'Ctrl');
+  if (chord.alt) parts.push(isMac ? MAC_SYMBOLS.alt! : 'Alt');
+  if (chord.shift) parts.push(isMac ? MAC_SYMBOLS.shift! : 'Shift');
+  const key = KEY_LABELS[chord.key] ?? (chord.key.length === 1 ? chord.key.toUpperCase() : capitalize(chord.key));
+  parts.push(key);
+  return isMac ? parts.join('') : parts.join('+');
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/** True when the key event came from a text-entry surface. */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}

--- a/apps/desktop/src/hotkeys/hotkeys.test.ts
+++ b/apps/desktop/src/hotkeys/hotkeys.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import { formatChord, matchesChord, parseChord } from './chord';
+import { HotkeyRegistry, type HotkeyBinding } from './registry';
+
+function key(k: string, mods: Partial<Record<'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey', boolean>> = {}) {
+  return {
+    key: k,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...mods,
+  };
+}
+
+function binding(over: Partial<HotkeyBinding> & { id: string; chord: string }): HotkeyBinding {
+  return { label: 'x', group: 'g', run: () => {}, ...over };
+}
+
+describe('parseChord', () => {
+  it('parses modifiers and the key', () => {
+    expect(parseChord('mod+shift+n')).toEqual({ key: 'n', mod: true, alt: false, shift: true });
+    expect(parseChord('escape')).toEqual({ key: 'escape', mod: false, alt: false, shift: false });
+  });
+
+  it('rejects a typo instead of silently never firing', () => {
+    expect(() => parseChord('cmd+k')).toThrow(/unknown hotkey modifier/);
+    expect(() => parseChord('mod+')).toThrow(/empty segment/);
+    expect(() => parseChord('mod+shift')).toThrow(/no key/);
+  });
+});
+
+describe('matchesChord', () => {
+  it('accepts either platform modifier for `mod`', () => {
+    const chord = parseChord('mod+k');
+    expect(matchesChord(key('k', { metaKey: true }), chord)).toBe(true);
+    expect(matchesChord(key('k', { ctrlKey: true }), chord)).toBe(true);
+    expect(matchesChord(key('k'), chord)).toBe(false);
+  });
+
+  it('requires an EXACT modifier match, so ⌘⇧N never fires ⌘N', () => {
+    const modN = parseChord('mod+n');
+    expect(matchesChord(key('n', { metaKey: true, shiftKey: true }), modN)).toBe(false);
+    expect(matchesChord(key('n', { metaKey: true, altKey: true }), modN)).toBe(false);
+    expect(matchesChord(key('n', { metaKey: true }), modN)).toBe(true);
+  });
+
+  it('is case-insensitive about the key the browser reports', () => {
+    expect(matchesChord(key('K', { metaKey: true }), parseChord('mod+k'))).toBe(true);
+  });
+});
+
+describe('formatChord', () => {
+  it('renders platform-appropriate labels', () => {
+    expect(formatChord(parseChord('mod+shift+k'), true)).toBe('⌘⇧K');
+    expect(formatChord(parseChord('mod+shift+k'), false)).toBe('Ctrl+Shift+K');
+    expect(formatChord(parseChord('mod+alt+arrowdown'), true)).toBe('⌘⌥↓');
+    expect(formatChord(parseChord('escape'), false)).toBe('Esc');
+  });
+});
+
+describe('HotkeyRegistry', () => {
+  it('resolves a registered chord and drops it on unregister', () => {
+    const registry = new HotkeyRegistry();
+    const dispose = registry.register(binding({ id: 'a', chord: 'mod+k' }));
+    expect(registry.resolve(key('k', { metaKey: true }), null)?.id).toBe('a');
+    dispose();
+    expect(registry.resolve(key('k', { metaKey: true }), null)).toBeNull();
+  });
+
+  it('skips disabled bindings', () => {
+    const registry = new HotkeyRegistry();
+    registry.register(binding({ id: 'a', chord: 'mod+k', disabled: true }));
+    expect(registry.resolve(key('k', { metaKey: true }), null)).toBeNull();
+  });
+
+  it('lets a higher-priority binding shadow a global one', () => {
+    const registry = new HotkeyRegistry();
+    registry.register(binding({ id: 'global', chord: 'mod+k' }));
+    registry.register(binding({ id: 'overlay', chord: 'mod+k', priority: 100 }));
+    expect(registry.resolve(key('k', { metaKey: true }), null)?.id).toBe('overlay');
+  });
+
+  it('does not fire an unmodified chord while the user is typing', () => {
+    const registry = new HotkeyRegistry();
+    registry.register(binding({ id: 'esc', chord: 'escape' }));
+    const input = document.createElement('input');
+    expect(registry.resolve(key('escape'), input)).toBeNull();
+    expect(registry.resolve(key('escape'), document.createElement('div'))).not.toBeNull();
+  });
+
+  it('fires a modified chord while typing, unless opted out', () => {
+    const registry = new HotkeyRegistry();
+    registry.register(binding({ id: 'palette', chord: 'mod+k' }));
+    registry.register(binding({ id: 'bold', chord: 'mod+b', allowInEditable: false }));
+    const textarea = document.createElement('textarea');
+    expect(registry.resolve(key('k', { metaKey: true }), textarea)?.id).toBe('palette');
+    expect(registry.resolve(key('b', { metaKey: true }), textarea)).toBeNull();
+  });
+
+  it('replaces a binding re-registered under the same id', () => {
+    const registry = new HotkeyRegistry();
+    const first = vi.fn();
+    const second = vi.fn();
+    registry.register(binding({ id: 'a', chord: 'mod+k', run: first }));
+    registry.register(binding({ id: 'a', chord: 'mod+k', run: second }));
+    registry.resolve(key('k', { metaKey: true }), null)?.run();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+    expect(registry.list()).toHaveLength(1);
+  });
+
+  it('hands out a stable snapshot until something changes', () => {
+    const registry = new HotkeyRegistry();
+    registry.register(binding({ id: 'a', chord: 'mod+k' }));
+    const first = registry.list();
+    expect(registry.list()).toBe(first);
+    registry.register(binding({ id: 'b', chord: 'mod+j' }));
+    expect(registry.list()).not.toBe(first);
+  });
+});

--- a/apps/desktop/src/hotkeys/index.ts
+++ b/apps/desktop/src/hotkeys/index.ts
@@ -1,0 +1,12 @@
+export {
+  parseChord,
+  matchesChord,
+  formatChord,
+  defaultAllowInEditable,
+  isEditableTarget,
+  type Chord,
+  type KeyLike,
+} from './chord';
+export { HotkeyRegistry, hotkeys, type HotkeyBinding } from './registry';
+export { useHotkey, useHotkeyList, useHotkeyDispatcher, useHotkeyList$ } from './useHotkeys';
+export { ShortcutsSheet } from './ShortcutsSheet';

--- a/apps/desktop/src/hotkeys/registry.ts
+++ b/apps/desktop/src/hotkeys/registry.ts
@@ -1,0 +1,119 @@
+import {
+  defaultAllowInEditable,
+  isEditableTarget,
+  matchesChord,
+  parseChord,
+  type Chord,
+  type KeyLike,
+} from './chord';
+
+/**
+ * The single keymap. Components register what they can do; one window listener
+ * dispatches. Keeping the bindings in a registry rather than in a dozen local
+ * `keydown` effects is what makes the help sheet truthful and what lets an
+ * overlay shadow a global chord without the two racing.
+ */
+
+export interface HotkeyBinding {
+  /** Stable id, also the React key in the help sheet. */
+  readonly id: string;
+  /** e.g. `mod+k`, `mod+shift+n`. */
+  readonly chord: string;
+  /** Imperative, sentence-case: "Open the command palette". */
+  readonly label: string;
+  /** Help-sheet grouping. */
+  readonly group: string;
+  readonly run: () => void;
+  /** Registered but inert (e.g. no session yet), still listed, shown dimmed. */
+  readonly disabled?: boolean;
+  /** Override the modifier-based default (see `defaultAllowInEditable`). */
+  readonly allowInEditable?: boolean;
+  /** Higher wins when two bindings share a chord. Overlays use 100. */
+  readonly priority?: number;
+  /** Hide from the help sheet (for internal/duplicate aliases). */
+  readonly hidden?: boolean;
+}
+
+interface Entry {
+  readonly binding: HotkeyBinding;
+  readonly parsed: Chord;
+  readonly order: number;
+}
+
+export class HotkeyRegistry {
+  private readonly entries = new Map<string, Entry>();
+  private readonly listeners = new Set<() => void>();
+  private counter = 0;
+  private snapshot: ReadonlyArray<HotkeyBinding> | null = null;
+
+  register(binding: HotkeyBinding): () => void {
+    const parsed = parseChord(binding.chord);
+    // Re-registering the same id replaces it (a component re-rendering with a
+    // new closure must not leave the previous handler live).
+    this.entries.set(binding.id, { binding, parsed, order: this.counter++ });
+    this.emit();
+    return () => {
+      const current = this.entries.get(binding.id);
+      if (current?.binding === binding) {
+        this.entries.delete(binding.id);
+        this.emit();
+      }
+    };
+  }
+
+  /**
+   * Every binding, ordered for display: by group, then registration order.
+   *
+   * The result is memoized until the next change because `useSyncExternalStore`
+   * treats a fresh array as new state, so recomputing per call would re-render the
+   * help sheet forever.
+   */
+  list(): ReadonlyArray<HotkeyBinding> {
+    if (!this.snapshot) {
+      this.snapshot = [...this.entries.values()]
+        .sort((a, b) => a.binding.group.localeCompare(b.binding.group) || a.order - b.order)
+        .map((e) => e.binding);
+    }
+    return this.snapshot;
+  }
+
+  /**
+   * Resolve a key event to its binding. Returns null when nothing matches, the
+   * match is disabled, or the event came from a text field the binding is not
+   * cleared for. Pure: the caller decides about `preventDefault`.
+   */
+  resolve(event: KeyLike, target: EventTarget | null): HotkeyBinding | null {
+    const editable = isEditableTarget(target);
+    let best: Entry | null = null;
+    for (const entry of this.entries.values()) {
+      if (entry.binding.disabled) continue;
+      if (!matchesChord(event, entry.parsed)) continue;
+      if (editable && !(entry.binding.allowInEditable ?? defaultAllowInEditable(entry.parsed))) {
+        continue;
+      }
+      const bestPriority = best?.binding.priority ?? 0;
+      const priority = entry.binding.priority ?? 0;
+      // Later registration wins ties, so a freshly-opened overlay claims the
+      // chord from an equal-priority binding that was already mounted.
+      if (!best || priority > bestPriority || (priority === bestPriority && entry.order > best.order)) {
+        best = entry;
+      }
+    }
+    return best?.binding ?? null;
+  }
+
+  subscribe(fn: () => void): () => void {
+    this.listeners.add(fn);
+    return () => {
+      this.listeners.delete(fn);
+    };
+  }
+
+  private emit(): void {
+    this.snapshot = null;
+    for (const fn of this.listeners) fn();
+  }
+}
+
+/** The app-wide registry. One per renderer. */
+export const hotkeys = new HotkeyRegistry();

--- a/apps/desktop/src/hotkeys/useAppHotkeys.ts
+++ b/apps/desktop/src/hotkeys/useAppHotkeys.ts
@@ -1,0 +1,163 @@
+import { useActiveWorkspaceId, useDesks } from '@moxxy/client-core';
+import { toggleSidebarCollapsed } from '@/lib/useSidebarCollapsed';
+import {
+  abortTurnPulse,
+  commandPalettePulse,
+  focusComposerPulse,
+  transcriptSearchPulse,
+} from '@/lib/chatPulses';
+import type { View } from '../shell/views';
+import type { WorkbenchTab } from '../shell/Workbench';
+import { useHotkeyList } from './useHotkeys';
+import type { HotkeyBinding } from './registry';
+
+export interface AppHotkeysOptions {
+  readonly setView: (view: View) => void;
+  readonly benchTab: WorkbenchTab | null;
+  readonly setBenchTab: (tab: WorkbenchTab | null) => void;
+  readonly onShowShortcuts: () => void;
+}
+
+/** Rail destinations in rail order, so ⌘1…⌘5 match what the eye sees. */
+const NUMBERED_VIEWS: ReadonlyArray<{ view: View; label: string }> = [
+  { view: 'chat', label: 'Runs' },
+  { view: 'collaborate', label: 'Collaborate' },
+  { view: 'automations', label: 'Automations' },
+  { view: 'apps', label: 'Apps' },
+  { view: 'channels', label: 'Channels' },
+];
+
+/**
+ * The app's keymap, in one place.
+ *
+ * Actions that live inside the chat surface (palette, search, abort, composer
+ * focus) are reached through pulses rather than by lifting their state up. See
+ * `lib/pulse`.
+ */
+export function useAppHotkeys(opts: AppHotkeysOptions): void {
+  const { setView, benchTab, setBenchTab, onShowShortcuts } = opts;
+  const desks = useDesks();
+  const activeSessionId = useActiveWorkspaceId();
+
+  // Every session across every workspace, in the order the sidebar tree shows
+  // them, so "next session" moves the way the list looks.
+  const ordered = desks.desks.flatMap((desk) => desk.sessions.map((s) => s.id));
+  const currentIndex = activeSessionId ? ordered.indexOf(activeSessionId) : -1;
+
+  const step = (delta: number): void => {
+    if (ordered.length < 2 || currentIndex < 0) return;
+    const next = ordered[(currentIndex + delta + ordered.length) % ordered.length];
+    if (next) void desks.setActiveSession(next);
+  };
+
+  const bindings: HotkeyBinding[] = [
+    {
+      id: 'chat.palette',
+      chord: 'mod+k',
+      label: 'Open the command palette',
+      group: 'Chat',
+      run: () => {
+        setView('chat');
+        commandPalettePulse.request();
+      },
+    },
+    {
+      id: 'chat.focusComposer',
+      chord: 'mod+l',
+      label: 'Focus the composer',
+      group: 'Chat',
+      run: () => {
+        setView('chat');
+        focusComposerPulse.request();
+      },
+    },
+    {
+      id: 'chat.search',
+      chord: 'mod+f',
+      label: 'Search this conversation',
+      group: 'Chat',
+      run: () => {
+        setView('chat');
+        transcriptSearchPulse.request();
+      },
+    },
+    {
+      id: 'chat.abort',
+      chord: 'mod+.',
+      label: 'Interrupt the running turn',
+      group: 'Chat',
+      run: () => abortTurnPulse.request(),
+    },
+    {
+      id: 'session.new',
+      chord: 'mod+n',
+      label: 'New session in this workspace',
+      group: 'Sessions',
+      disabled: desks.activeId === null,
+      run: () => {
+        const deskId = desks.activeId;
+        if (!deskId) return;
+        void (async () => {
+          const session = await desks.createSession(deskId);
+          if (session) await desks.setActiveSession(session.id);
+        })();
+      },
+    },
+    {
+      id: 'session.next',
+      chord: 'mod+alt+arrowdown',
+      label: 'Next session',
+      group: 'Sessions',
+      disabled: ordered.length < 2,
+      run: () => step(1),
+    },
+    {
+      id: 'session.prev',
+      chord: 'mod+alt+arrowup',
+      label: 'Previous session',
+      group: 'Sessions',
+      disabled: ordered.length < 2,
+      run: () => step(-1),
+    },
+    {
+      id: 'view.sidebar',
+      chord: 'mod+b',
+      label: 'Show or hide the workspace sidebar',
+      group: 'Navigation',
+      // ⌘B is bold inside a text field; leave typing alone (this preserves the
+      // behaviour of the hand-rolled handler this keymap replaced).
+      allowInEditable: false,
+      run: () => toggleSidebarCollapsed(),
+    },
+    {
+      id: 'view.workbench',
+      chord: 'mod+j',
+      label: 'Show or hide the workbench pane',
+      group: 'Navigation',
+      run: () => setBenchTab(benchTab ? null : 'files'),
+    },
+    {
+      id: 'view.settings',
+      chord: 'mod+,',
+      label: 'Open settings',
+      group: 'Navigation',
+      run: () => setView('settings'),
+    },
+    ...NUMBERED_VIEWS.map(({ view, label }, index) => ({
+      id: `view.${view}`,
+      chord: `mod+${index + 1}`,
+      label: `Go to ${label}`,
+      group: 'Navigation',
+      run: () => setView(view),
+    })),
+    {
+      id: 'help.shortcuts',
+      chord: 'mod+/',
+      label: 'Show keyboard shortcuts',
+      group: 'Help',
+      run: onShowShortcuts,
+    },
+  ];
+
+  useHotkeyList(bindings);
+}

--- a/apps/desktop/src/hotkeys/useHotkeys.test.tsx
+++ b/apps/desktop/src/hotkeys/useHotkeys.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ShortcutsSheet } from './ShortcutsSheet';
+import { useHotkey, useHotkeyDispatcher } from './useHotkeys';
+
+function Harness({
+  onRun,
+  chord = 'mod+k',
+}: {
+  readonly onRun: () => void;
+  readonly chord?: string;
+}): JSX.Element {
+  useHotkeyDispatcher();
+  useHotkey({ id: 'test.binding', chord, label: 'Do the thing', group: 'Testing', run: onRun });
+  return (
+    <div>
+      <button type="button" onKeyDown={(e) => e.preventDefault()}>
+        swallows keys
+      </button>
+      <textarea aria-label="draft" />
+    </div>
+  );
+}
+
+describe('useHotkeyDispatcher', () => {
+  it('runs the bound action on a matching key event', () => {
+    const run = vi.fn();
+    render(<Harness onRun={run} />);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it('ignores an event a component already handled', () => {
+    const run = vi.fn();
+    render(<Harness onRun={run} />);
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'k', metaKey: true });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('unregisters when the owner unmounts', () => {
+    const run = vi.fn();
+    const view = render(<Harness onRun={run} />);
+    view.unmount();
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('still fires a modified chord while the user is typing', () => {
+    const run = vi.fn();
+    render(<Harness onRun={run} />);
+    fireEvent.keyDown(screen.getByLabelText('draft'), { key: 'k', metaKey: true });
+    expect(run).toHaveBeenCalledOnce();
+  });
+});
+
+describe('ShortcutsSheet', () => {
+  it('lists what is actually bound, so the reference cannot drift', () => {
+    const run = vi.fn();
+    render(<Harness onRun={run} chord="mod+shift+p" />);
+    render(<ShortcutsSheet onClose={() => {}} />);
+    expect(screen.getByText('Do the thing')).toBeInTheDocument();
+    expect(screen.getByText('Testing')).toBeInTheDocument();
+    // The rendered chord matches the registered spec.
+    expect(screen.getByText(/[⌘⇧]P|Ctrl\+Shift\+P/)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/hotkeys/useHotkeys.ts
+++ b/apps/desktop/src/hotkeys/useHotkeys.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { hotkeys, type HotkeyBinding } from './registry';
+
+/**
+ * Register one binding for the lifetime of the calling component.
+ *
+ * `run` is held in a ref so an inline arrow doesn't re-register on every
+ * render. The binding stays stable while always calling the latest closure.
+ */
+export function useHotkey(
+  binding: Omit<HotkeyBinding, 'run'> & { readonly run: () => void },
+): void {
+  const run = useRef(binding.run);
+  run.current = binding.run;
+  const { id, chord, label, group, disabled, allowInEditable, priority, hidden } = binding;
+  useEffect(() => {
+    return hotkeys.register({
+      id,
+      chord,
+      label,
+      group,
+      run: () => run.current(),
+      ...(disabled === undefined ? {} : { disabled }),
+      ...(allowInEditable === undefined ? {} : { allowInEditable }),
+      ...(priority === undefined ? {} : { priority }),
+      ...(hidden === undefined ? {} : { hidden }),
+    });
+  }, [id, chord, label, group, disabled, allowInEditable, priority, hidden]);
+}
+
+/** Register several bindings at once. The array may change identity freely. */
+export function useHotkeyList(bindings: ReadonlyArray<HotkeyBinding>): void {
+  const latest = useRef(bindings);
+  latest.current = bindings;
+  // Re-arm only when the SHAPE changes (ids/chords/disabled), not when a
+  // handler closure is recreated by a parent re-render.
+  const shape = bindings
+    .map((b) => `${b.id}:${b.chord}:${b.disabled ? 0 : 1}:${b.priority ?? 0}`)
+    .join('|');
+  useEffect(() => {
+    const disposers = latest.current.map((binding, index) =>
+      hotkeys.register({
+        ...binding,
+        run: () => latest.current[index]?.run(),
+      }),
+    );
+    return () => {
+      for (const dispose of disposers) dispose();
+    };
+  }, [shape]);
+}
+
+/**
+ * Install the single window-level dispatcher. Called once, by the shell.
+ *
+ * BUBBLE phase, and `defaultPrevented` events are skipped: any component that
+ * already handled the key (the composer's Enter, a modal's Escape, the command
+ * palette's arrows) wins without having to know the global keymap exists.
+ */
+export function useHotkeyDispatcher(): void {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.defaultPrevented) return;
+      const binding = hotkeys.resolve(e, e.target);
+      if (!binding) return;
+      e.preventDefault();
+      binding.run();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+}
+
+/** Reactive view of the keymap, for the help sheet. */
+export function useHotkeyList$(): ReadonlyArray<HotkeyBinding> {
+  return useSyncExternalStore(
+    (fn) => hotkeys.subscribe(fn),
+    () => hotkeys.list(),
+    () => hotkeys.list(),
+  );
+}

--- a/apps/desktop/src/lib/chatPulses.ts
+++ b/apps/desktop/src/lib/chatPulses.ts
@@ -1,0 +1,18 @@
+import { createPulse } from './pulse';
+
+/**
+ * Shell → chat-surface signals for the keyboard shortcuts whose state belongs
+ * to the chat surface rather than to `App`. See {@link createPulse}.
+ */
+
+/** ⌘K opens the command palette over the composer. */
+export const commandPalettePulse = createPulse();
+
+/** ⌘F opens transcript search and focuses its field. */
+export const transcriptSearchPulse = createPulse();
+
+/** ⌘. interrupts the running turn. */
+export const abortTurnPulse = createPulse();
+
+/** ⌘L puts the caret in the composer. */
+export const focusComposerPulse = createPulse();

--- a/apps/desktop/src/lib/pulse.ts
+++ b/apps/desktop/src/lib/pulse.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useSyncExternalStore } from 'react';
+
+/**
+ * A one-shot "do this now" signal from the shell to whichever component owns
+ * the capability.
+ *
+ * The shell holds the keymap, but several actions live deep inside the chat
+ * surface (the palette, transcript search, aborting the running turn) and their
+ * state has no business moving up to `App`. A pulse is a counter the shell bumps
+ * and the owner watches. Same shape as `voiceCallRequest` already uses for the
+ * rail's voice button, generalized so each new shortcut isn't another bespoke
+ * module.
+ */
+export interface Pulse {
+  /** Fire the signal. */
+  readonly request: () => void;
+  /** Run `onRequested` once per `request()`. */
+  readonly use: (onRequested: () => void) => void;
+}
+
+export function createPulse(): Pulse {
+  let count = 0;
+  const listeners = new Set<() => void>();
+
+  const subscribe = (fn: () => void): (() => void) => {
+    listeners.add(fn);
+    return () => {
+      listeners.delete(fn);
+    };
+  };
+
+  return {
+    request(): void {
+      count += 1;
+      for (const fn of listeners) fn();
+    },
+    use(onRequested: () => void): void {
+      const current = useSyncExternalStore(subscribe, () => count, () => count);
+      const cb = useRef(onRequested);
+      cb.current = onRequested;
+      // Seed from the value at mount so a component mounting after a pulse
+      // doesn't immediately replay it.
+      const seen = useRef(current);
+      useEffect(() => {
+        if (seen.current === current) return;
+        seen.current = current;
+        cb.current();
+      }, [current]);
+    },
+  };
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@clack/prompts": "catalog:",
     "@moxxy/cache-strategy-stable-prefix": "workspace:*",
+    "@moxxy/compactor-segments": "workspace:*",
     "@moxxy/compactor-summarize": "workspace:*",
     "@moxxy/config": "workspace:*",
     "@moxxy/core": "workspace:*",

--- a/packages/cli/src/setup/apply-plugins-tree.test.ts
+++ b/packages/cli/src/setup/apply-plugins-tree.test.ts
@@ -100,3 +100,50 @@ describe('applyPluginsTree — synthesizer default', () => {
     expect(warns).toEqual([]);
   });
 });
+
+describe('applyPluginsTree: compactor default and floor', () => {
+  const compactor = (name: string) => ({
+    name,
+    shouldCompact: () => false,
+    compact: async () => ({}) as never,
+  });
+
+  /** Registration order mirrors a real boot: the floor first, then segments. */
+  function sessionWithBothCompactors(): Session {
+    const session = makeSession();
+    session.compactors.register(compactor('summarize-old-turns'));
+    session.compactors.register(compactor('segments'));
+    return session;
+  }
+
+  it('activates sub-session compaction by default', () => {
+    const session = sessionWithBothCompactors();
+    const { logger, warns } = warnCollector();
+    applyPluginsTree(session, {} as MoxxyConfig, logger);
+    // First-registered auto-activation would have left the floor active; the
+    // built-in default is what makes long sessions bounded out of the box.
+    expect(session.compactors.getActiveName()).toBe('segments');
+    expect(warns).toEqual([]);
+  });
+
+  it('honours an explicit opt-out back to summarize-old-turns', () => {
+    const session = sessionWithBothCompactors();
+    const { logger, warns } = warnCollector();
+    const config = {
+      plugins: { compactor: { default: 'summarize-old-turns' } },
+    } as unknown as MoxxyConfig;
+    applyPluginsTree(session, config, logger);
+    expect(session.compactors.getActiveName()).toBe('summarize-old-turns');
+    expect(warns).toEqual([]);
+  });
+
+  it('keeps the floor active when only the floor is installed', () => {
+    const session = makeSession();
+    session.compactors.register(compactor('summarize-old-turns'));
+    const { logger, warns } = warnCollector();
+    applyPluginsTree(session, {} as MoxxyConfig, logger);
+    // A built-in default whose plugin isn't installed is a silent skip.
+    expect(session.compactors.getActiveName()).toBe('summarize-old-turns');
+    expect(warns).toEqual([]);
+  });
+});

--- a/packages/cli/src/setup/apply-plugins-tree.ts
+++ b/packages/cli/src/setup/apply-plugins-tree.ts
@@ -25,7 +25,10 @@ interface FloorLike {
  */
 const BUILTIN_FLOORS: ReadonlyArray<{ registry: (s: Session) => FloorLike | undefined; name: string }> =
   [
-    { registry: (s) => s.compactors, name: 'summarize' },
+    // The def's own name. `summarize`, the old value here, matched nothing, so
+    // the floor was never actually marked. Harmless while one compactor
+    // existed; with a second one it decides where an unregister reverts to.
+    { registry: (s) => s.compactors, name: 'summarize-old-turns' },
     { registry: (s) => s.cacheStrategies, name: 'stable-prefix' },
     { registry: (s) => s.workflowExecutors, name: 'dag' },
   ];

--- a/packages/cli/src/setup/builtin-entries.ts
+++ b/packages/cli/src/setup/builtin-entries.ts
@@ -7,6 +7,7 @@ import { defaultModePlugin } from '@moxxy/mode-default';
 import { collaborativeModePlugin } from '@moxxy/mode-collaborative';
 import { collabPlugin } from '@moxxy/plugin-collab';
 import { summarizeCompactorPlugin } from '@moxxy/compactor-summarize';
+import { segmentsCompactorPlugin } from '@moxxy/compactor-segments';
 import { stablePrefixCacheStrategyPlugin } from '@moxxy/cache-strategy-stable-prefix';
 import { cliPlugin } from '@moxxy/plugin-cli';
 import { mobileChannelPlugin } from '@moxxy/plugin-channel-mobile';
@@ -93,6 +94,11 @@ export function buildBuiltinEntries(args: BuiltinEntriesArgs): BuiltinEntry[] {
     { name: '@moxxy/mode-collaborative', plugin: collaborativeModePlugin },
     { name: '@moxxy/plugin-collab', plugin: collabPlugin },
     { name: '@moxxy/compactor-summarize', plugin: summarizeCompactorPlugin },
+    // Sub-session compaction, the default. Records each finished turn as one
+    // outcome summary and folds old records into chapters, so a session's
+    // context is bounded by policy instead of by how long you've been talking.
+    // `summarize-old-turns` stays registered as the protected floor.
+    { name: '@moxxy/compactor-segments', plugin: segmentsCompactorPlugin },
     { name: '@moxxy/cache-strategy-stable-prefix', plugin: stablePrefixCacheStrategyPlugin },
     { name: '@moxxy/plugin-vault', plugin: vaultPlugin },
     // plugin-stt-whisper(+codex) are NOT bundled — install on demand / seeded

--- a/packages/cli/src/setup/builtins.ts
+++ b/packages/cli/src/setup/builtins.ts
@@ -64,6 +64,7 @@ export const BUILTIN_REQUIREMENT_DECISIONS: Readonly<Record<string, BuiltinRequi
   '@moxxy/mode-collaborative': { hardRequirements: false, reason: 'coordinator spawns separate agent processes; needs @moxxy/plugin-collab at runtime, surfaced if absent' },
   '@moxxy/plugin-collab': { hardRequirements: false, reason: 'collaboration hub + tools; inert outside a collaboration' },
   '@moxxy/compactor-summarize': { hardRequirements: false, reason: 'compactor has no plugin dependency' },
+  '@moxxy/compactor-segments': { hardRequirements: false, reason: 'compactor has no plugin dependency' },
   '@moxxy/cache-strategy-stable-prefix': { hardRequirements: false, reason: 'cache strategy has no plugin dependency' },
   '@moxxy/plugin-vault': { hardRequirements: false, reason: 'vault is the base secret store' },
   '@moxxy/plugin-cli': { hardRequirements: false, reason: 'TUI channel is standalone' },

--- a/packages/cli/src/setup/critical-floors.test.ts
+++ b/packages/cli/src/setup/critical-floors.test.ts
@@ -13,8 +13,9 @@ function makeSession(): Session {
   });
   // Seed the kernel-plugin-contributed defaults the kernel would register.
   session.modes.register({ name: 'default', run: async function* () {} });
+  // The real def name the kernel registers; the floor table matches on it.
   session.compactors.register({
-    name: 'summarize',
+    name: 'summarize-old-turns',
     shouldCompact: () => false,
     compact: async () => ({}) as never,
   });
@@ -59,7 +60,7 @@ describe('critical floors', () => {
     });
     session.compactors.setActive('other');
     session.compactors.unregister('other');
-    expect(session.compactors.getActiveName()).toBe('summarize');
+    expect(session.compactors.getActiveName()).toBe('summarize-old-turns');
   });
 
   it('throws when a non-nullable floor is missing', () => {

--- a/packages/cli/src/setup/resolve-plugins-tree.ts
+++ b/packages/cli/src/setup/resolve-plugins-tree.ts
@@ -18,7 +18,10 @@ import type {
 /** Built-in default contribution name per category, used when a slot omits `default`. */
 const BUILTIN_DEFAULTS: Partial<Record<PluginCategoryKey, string>> = {
   mode: 'default',
-  compactor: 'summarize',
+  // Sub-session compaction: bounds context by policy rather than by session
+  // length. `summarize-old-turns` remains registered as the protected floor and
+  // is selectable via `plugins.compactor.default`.
+  compactor: 'segments',
   cacheStrategy: 'stable-prefix',
   workflowExecutor: 'dag',
   embedder: 'tfidf',

--- a/packages/compactor-segments/package.json
+++ b/packages/compactor-segments/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@moxxy/compactor-segments",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Sub-session (segment) compactor for moxxy: one outcome summary per turn, folded into chapters, with session_recall over the history.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "moxxy": {
+    "plugin": {
+      "entry": "./dist/index.js",
+      "kind": "compactor"
+    }
+  },
+  "dependencies": {
+    "@moxxy/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@moxxy/tsconfig": "workspace:*",
+    "@moxxy/vitest-preset": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/compactor-segments/src/index.test.ts
+++ b/packages/compactor-segments/src/index.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+import {
+  estimateContextTokens,
+  projectMessagesFromLog,
+  type EventLogReader,
+  type MoxxyEvent,
+  type MoxxyEventOfType,
+  type MoxxyEventType,
+  type TurnId,
+} from '@moxxy/sdk';
+import { buildSessionDocs, createSegmentsCompactor, sessionRecallTool } from './index.js';
+
+function reader(events: ReadonlyArray<MoxxyEvent>): EventLogReader {
+  return {
+    length: events.length,
+    at: (seq) => events.find((e) => e.seq === seq),
+    slice: (from = 0, to = events.length) => events.slice(from, to),
+    ofType: <T extends MoxxyEventType>(type: T): ReadonlyArray<MoxxyEventOfType<T>> =>
+      events.filter((e): e is MoxxyEventOfType<T> => e.type === type),
+    byTurn: (turnId: TurnId) => events.filter((e) => e.turnId === turnId),
+    toJSON: () => events,
+  };
+}
+
+const CONTEXT_WINDOW = 200_000;
+
+function budgetFor(events: ReadonlyArray<MoxxyEvent>) {
+  return {
+    contextWindow: CONTEXT_WINDOW,
+    estimatedTokens: estimateContextTokens(reader(events)),
+    reserveForOutput: 4_000,
+  };
+}
+
+/**
+ * Drive the compactor the way a mode's loop does: after each turn, keep asking
+ * until it says there is nothing left to do.
+ */
+async function settle(
+  compactor: ReturnType<typeof createSegmentsCompactor>,
+  events: MoxxyEvent[],
+  nextSeq: () => number,
+): Promise<void> {
+  for (let guard = 0; guard < 10; guard++) {
+    const budget = budgetFor(events);
+    if (!compactor.shouldCompact(reader(events), budget)) return;
+    const result = await compactor.compact(events, {
+      log: reader(events),
+      budget,
+      signal: new AbortController().signal,
+    });
+    if (result.tokensSaved <= 0 || result.summary.trim().length === 0) return;
+    events.push({ ...result, id: `c${nextSeq.length}` as never, seq: nextSeq(), ts: 0 } as MoxxyEvent);
+  }
+  throw new Error('compaction did not settle; the plan is not converging');
+}
+
+interface Session {
+  readonly events: MoxxyEvent[];
+  turn(label: string, size?: number): Promise<void>;
+}
+
+function session(summary?: (text: string, kind: 'segment' | 'chapter') => string): Session {
+  const compactor = createSegmentsCompactor(
+    summary ? { summary } : { summary: (_t, kind) => `${kind} record ${'r'.repeat(560)}` },
+  );
+  const events: MoxxyEvent[] = [];
+  let seq = 0;
+  const next = (): number => seq++;
+  let turnNo = 0;
+  return {
+    events,
+    async turn(label, size = 1_500) {
+      turnNo += 1;
+      const turnId = `t${turnNo}` as never;
+      events.push({
+        id: `u${seq}` as never,
+        seq: next(),
+        ts: 0,
+        type: 'user_prompt',
+        sessionId: 'sess' as never,
+        turnId,
+        source: 'user',
+        text: label,
+      } as MoxxyEvent);
+      events.push({
+        id: `a${seq}` as never,
+        seq: next(),
+        ts: 0,
+        type: 'assistant_message',
+        sessionId: 'sess' as never,
+        turnId,
+        source: 'model',
+        content: `${label}: ${'x'.repeat(size)}`,
+        stopReason: 'end_turn',
+      } as MoxxyEvent);
+      await settle(compactor, events, next);
+    },
+  };
+}
+
+describe('segments compactor: long-session boundedness', () => {
+  it('keeps the projected context bounded over hundreds of turns', async () => {
+    const s = session();
+    const samples: number[] = [];
+    for (let i = 0; i < 200; i++) {
+      await s.turn(`task ${i}`);
+      if (i % 10 === 9) samples.push(estimateContextTokens(reader(s.events)));
+    }
+
+    // The honest claim: context size is governed by the policy, not by session
+    // length. Without compaction these 200 turns cost ~78k tokens and grow
+    // linearly; here the last sample is no larger than the first few.
+    const early = Math.max(...samples.slice(0, 3));
+    const late = Math.max(...samples.slice(-3));
+    expect(late).toBeLessThanOrEqual(early * 1.2);
+    expect(Math.max(...samples)).toBeLessThan(8_000);
+
+    // And it is genuinely doing the work, not just refusing to compact.
+    const compactions = s.events.filter((e) => e.type === 'compaction');
+    expect(compactions.length).toBeGreaterThan(50);
+    expect(compactions.some((e) => e.summary.startsWith('[chapter '))).toBe(true);
+  });
+
+  it('caps the live record index regardless of how long the session runs', async () => {
+    const s = session();
+    for (let i = 0; i < 120; i++) await s.turn(`task ${i}`);
+    // Live records = what projection actually emits as summaries.
+    expect(buildSessionDocs(s.events).length).toBeLessThanOrEqual(12);
+  });
+
+  it('drops superseded records from the projection once they fold', async () => {
+    const s = session();
+    for (let i = 0; i < 120; i++) await s.turn(`task ${i}`);
+    const messages = projectMessagesFromLog({ log: reader(s.events) });
+    const summaryMessages = messages.filter((m) =>
+      m.content.some((c) => c.type === 'text' && c.text.startsWith('[summary of earlier turns]')),
+    );
+    expect(summaryMessages.length).toBe(buildSessionDocs(s.events).length);
+  });
+});
+
+describe('segments compactor: the records themselves', () => {
+  it('stamps each record with the turns it replaces, so recall can address it', async () => {
+    const s = session();
+    for (let i = 0; i < 5; i++) await s.turn(`task ${i}`);
+    const first = s.events.find((e) => e.type === 'compaction');
+    expect(first).toBeDefined();
+    // These turns are individually below `minSegmentChars`, so the first
+    // sub-session spans two of them, and the header names both.
+    expect(first!.type === 'compaction' && first!.summary).toMatch(
+      /^\[segment 1 · turn t1, t2 · seq 0-3\]/,
+    );
+  });
+
+  it('never lets a verbose summarizer grow the context', async () => {
+    // A summarizer that ignores the brief and writes an essay.
+    const s = session(() => 'z'.repeat(50_000));
+    for (let i = 0; i < 6; i++) await s.turn(`task ${i}`);
+    const records = s.events.filter((e) => e.type === 'compaction');
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      if (record.type !== 'compaction') continue;
+      expect(record.tokensSaved).toBeGreaterThan(0);
+    }
+  });
+
+  it('re-throws when the turn is cancelled mid-summary instead of rewriting history', async () => {
+    const controller = new AbortController();
+    const compactor = createSegmentsCompactor({
+      summary: () => {
+        controller.abort();
+        return 'a record written just as the user hit stop';
+      },
+    });
+    const events: MoxxyEvent[] = [];
+    let seq = 0;
+    for (let i = 0; i < 5; i++) {
+      const turnId = `t${i}` as never;
+      events.push({
+        id: `u${seq}` as never, seq: seq++, ts: 0, type: 'user_prompt',
+        sessionId: 'sess' as never, turnId, source: 'user', text: 'q'.repeat(1_200),
+      } as MoxxyEvent);
+      events.push({
+        id: `a${seq}` as never, seq: seq++, ts: 0, type: 'assistant_message',
+        sessionId: 'sess' as never, turnId, source: 'model',
+        content: 'a'.repeat(1_200), stopReason: 'end_turn',
+      } as MoxxyEvent);
+    }
+    await expect(
+      compactor.compact(events, {
+        log: reader(events),
+        budget: budgetFor(events),
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/aborted/);
+  });
+});
+
+describe('session_recall', () => {
+  it('finds the sub-session that mentions what the user is asking about', async () => {
+    const compactor = createSegmentsCompactor({
+      summary: (digest) => `record of: ${digest.slice(0, 300)}`,
+    });
+    const events: MoxxyEvent[] = [];
+    let seq = 0;
+    const topics = ['postgres migration plan', 'stripe webhook retries', 'icon set redesign'];
+    for (let i = 0; i < topics.length + 3; i++) {
+      const turnId = `t${i}` as never;
+      events.push({
+        id: `u${seq}` as never, seq: seq++, ts: 0, type: 'user_prompt',
+        sessionId: 'sess' as never, turnId, source: 'user',
+        text: `${topics[i] ?? 'unrelated chatter'} ${'d'.repeat(1_100)}`,
+      } as MoxxyEvent);
+      events.push({
+        id: `a${seq}` as never, seq: seq++, ts: 0, type: 'assistant_message',
+        sessionId: 'sess' as never, turnId, source: 'model',
+        content: 'a'.repeat(1_200), stopReason: 'end_turn',
+      } as MoxxyEvent);
+      await settle(compactor, events, () => seq++);
+    }
+
+    const out = await sessionRecallTool.handler(
+      { query: 'what did we decide about the stripe webhooks?', limit: 3 },
+      { log: reader(events) } as never,
+    );
+    expect(typeof out).toBe('object');
+    const matches = (out as { matches: Array<{ turnIds: string[]; record: string }> }).matches;
+    expect(matches[0]!.record).toContain('stripe webhook retries');
+    expect(matches[0]!.turnIds).toEqual(['t1']);
+  });
+
+  it('says so plainly when nothing has been recorded yet', async () => {
+    const out = await sessionRecallTool.handler(
+      { query: 'anything', limit: 4 },
+      { log: reader([]) } as never,
+    );
+    expect(String(out)).toMatch(/still visible in your context/);
+  });
+});

--- a/packages/compactor-segments/src/index.ts
+++ b/packages/compactor-segments/src/index.ts
@@ -1,0 +1,315 @@
+import {
+  abortError,
+  activeCompactionRanges,
+  defineCompactor,
+  definePlugin,
+  defineTool,
+  summarizeWithProvider,
+  z,
+  type CompactContext,
+  type CompactorDef,
+  type EventLogReader,
+  type MoxxyEvent,
+  type TokenBudget,
+} from '@moxxy/sdk';
+import {
+  buildDigest,
+  chapterHeader,
+  planCompaction,
+  resolveOptions,
+  segmentHeader,
+  type ChapterPlan,
+  type SegmentOptions,
+  type SegmentPlan,
+} from './segments.js';
+import { rank, type SessionDoc } from './search.js';
+
+export {
+  planCompaction,
+  resolveOptions,
+  DEFAULTS,
+  type SegmentOptions,
+  type SegmentPlan,
+  type ChapterPlan,
+  type CompactionPlan,
+} from './segments.js';
+export { rank, tokenize, type SessionDoc, type RankedDoc } from './search.js';
+
+const MAX_SUMMARIZE_INPUT_CHARS = 48_000;
+const SEGMENT_MAX_TOKENS = 700;
+const CHAPTER_MAX_TOKENS = 900;
+
+/**
+ * Above this context fill the tail window collapses to a single turn. The
+ * verbatim window is a comfort, not a guarantee. Under real pressure, keeping
+ * three turns intact is what pushes a session over the edge.
+ */
+const PRESSURE_RATIO = 0.85;
+
+const SEGMENT_SYSTEM_PROMPT =
+  'You compress ONE completed sub-session of an AI agent (a user request and everything the agent ' +
+  'did to answer it) into a durable record the agent can rely on months later, without the transcript. ' +
+  'Write exactly these lines, each on one line, no preamble and no markdown headers:\n' +
+  'Asked: what the user actually wanted.\n' +
+  'Did: the concrete actions taken: files created/edited, commands run, decisions made.\n' +
+  'Outcome: what resulted, INCLUDING failures and what was abandoned.\n' +
+  'Facts: exact paths, identifiers, versions, numbers and names worth keeping. Omit the line if there are none.\n' +
+  'Open: anything unresolved or promised for later. Write "none" if nothing is open.\n' +
+  'Be dense and factual. Never invent detail that is not in the digest.';
+
+const CHAPTER_SYSTEM_PROMPT =
+  'You merge several sub-session records of an AI agent into ONE coarser record covering the same period. ' +
+  'Keep the same line structure (Asked / Did / Outcome / Facts / Open), but describe the PERIOD rather than ' +
+  'a single request: what the work was about, what got done, what the standing results are. ' +
+  'Preserve exact identifiers (paths, names, versions) that later work may still need, and preserve every ' +
+  'still-open thread. Drop step-by-step detail that has been superseded. Never invent anything.';
+
+export interface SegmentsCompactorOptions extends Partial<SegmentOptions> {
+  /** Custom summarizer, for tests and offline hosts. */
+  readonly summary?: (text: string, kind: 'segment' | 'chapter') => Promise<string> | string;
+}
+
+/**
+ * Sub-session compaction.
+ *
+ * Every completed turn (or a run of small consecutive turns) becomes a
+ * SEGMENT, one dense outcome record that replaces the turn's raw events in
+ * context. Once the index of records passes `maxSegments`, the oldest fold into
+ * a CHAPTER, so the index itself is bounded rather than merely slower-growing.
+ * The result is a context whose size is governed by the policy, not by how long
+ * the session has been running: summaries (bounded) + the verbatim tail
+ * (bounded) + the live turn.
+ *
+ * Nothing is lost: the event log keeps every original event. `session_recall`
+ * searches the records; `recall({ turnId })` pulls a whole sub-session back
+ * verbatim when the model needs the detail.
+ *
+ * Unlike `summarize-old-turns`, compaction here is driven by TURN BOUNDARIES
+ * rather than by a token threshold. That costs one summarization call per
+ * sub-session, and buys three things: the context never approaches the window
+ * in the first place; each emitted record is byte-stable and lands after the
+ * previous ones, so the projected prefix grows append-only and a cached prefix
+ * stays valid (a threshold compactor instead rewrites a large prefix in one
+ * late bulk step); and every past sub-session is individually addressable.
+ * A chapter fold DOES rewrite the head of the prefix, but that happens once per
+ * `foldSegments` sub-sessions, not once per turn.
+ */
+export function createSegmentsCompactor(opts: SegmentsCompactorOptions = {}): CompactorDef {
+  const base = resolveOptions(opts);
+
+  const effectiveOptions = (budget: TokenBudget | undefined): SegmentOptions => {
+    if (!budget || budget.contextWindow <= 0) return base;
+    if (budget.estimatedTokens <= PRESSURE_RATIO * budget.contextWindow) return base;
+    return { ...base, keepRecentTurns: 1 };
+  };
+
+  return defineCompactor({
+    name: 'segments',
+    shouldCompact(log: EventLogReader, budget: TokenBudget) {
+      return planCompaction(log.slice(), effectiveOptions(budget)) !== null;
+    },
+    async compact(events: ReadonlyArray<MoxxyEvent>, ctx?: CompactContext) {
+      if (events.length === 0) {
+        throw new Error('segments: compact() called with no events');
+      }
+      const plan = planCompaction(events, effectiveOptions(ctx?.budget));
+      if (!plan) return noOp(events);
+
+      const summary =
+        plan.kind === 'segment'
+          ? await summarizeSegment(plan, ctx, opts.summary)
+          : await summarizeChapter(plan, ctx, opts.summary);
+
+      // Final abort gate: a turn cancelled while the summary was in flight must
+      // not have its history rewritten underneath it.
+      if (ctx?.signal?.aborted) throw abortError('segments: compaction aborted');
+
+      const first = events[0]!;
+      const last = events[events.length - 1]!;
+      return {
+        type: 'compaction' as const,
+        sessionId: first.sessionId,
+        turnId: last.turnId,
+        source: 'compactor' as const,
+        compactor: 'segments',
+        replacedRange: [plan.from, plan.to] as const,
+        summary,
+        tokensSaved: Math.max(0, Math.ceil((plan.originalChars - summary.length) / 4)),
+      };
+    },
+  });
+}
+
+async function summarizeSegment(
+  plan: SegmentPlan,
+  ctx: CompactContext | undefined,
+  custom: SegmentsCompactorOptions['summary'],
+): Promise<string> {
+  const digest = buildDigest(plan.events);
+  const header = segmentHeader(plan);
+  const body = custom
+    ? await custom(digest, 'segment')
+    : ((await summarizeWithProvider(digest, {
+        system: SEGMENT_SYSTEM_PROMPT,
+        prompt: (d) => `Sub-session transcript to record:\n\n${d}`,
+        maxInputChars: MAX_SUMMARIZE_INPUT_CHARS,
+        maxTokens: SEGMENT_MAX_TOKENS,
+        ...providerOpts(ctx),
+      })) ?? fallbackDigest(digest));
+  // Budget the body against what it replaces so a verbose summarizer can never
+  // make the context BIGGER, which would leave the plan permanently unmet and
+  // re-summarize the same sub-session on every iteration.
+  return `${header}\n${clampSummary(body, budgetFor(plan.originalChars, 0.6, header.length))}`;
+}
+
+async function summarizeChapter(
+  plan: ChapterPlan,
+  ctx: CompactContext | undefined,
+  custom: SegmentsCompactorOptions['summary'],
+): Promise<string> {
+  const digest = plan.summaries.join('\n\n');
+  const header = chapterHeader(plan, plan.summaries.length);
+  const body = custom
+    ? await custom(digest, 'chapter')
+    : ((await summarizeWithProvider(digest, {
+        system: CHAPTER_SYSTEM_PROMPT,
+        prompt: (d) => `Sub-session records to merge, oldest first:\n\n${d}`,
+        maxInputChars: MAX_SUMMARIZE_INPUT_CHARS,
+        maxTokens: CHAPTER_MAX_TOKENS,
+        ...providerOpts(ctx),
+      })) ?? fallbackDigest(digest));
+  return `${header}\n${clampSummary(body, budgetFor(plan.originalChars, 0.5, header.length))}`;
+}
+
+function providerOpts(ctx: CompactContext | undefined): {
+  provider?: CompactContext['provider'];
+  model?: string;
+  signal?: AbortSignal;
+} {
+  return {
+    ...(ctx?.provider ? { provider: ctx.provider } : {}),
+    ...(ctx?.model ? { model: ctx.model } : {}),
+    ...(ctx?.signal ? { signal: ctx.signal } : {}),
+  };
+}
+
+/** Char budget for a summary body: a fixed fraction of what it replaces, so
+ *  every compaction step is guaranteed to shrink the context. */
+function budgetFor(originalChars: number, ratio: number, headerChars: number): number {
+  return Math.max(200, Math.floor(originalChars * ratio) - headerChars - 1);
+}
+
+function clampSummary(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxChars) return trimmed;
+  return `${trimmed.slice(0, maxChars - 24).trimEnd()}\n[… record truncated …]`;
+}
+
+let warnedFallback = false;
+
+function fallbackDigest(text: string): string {
+  if (!warnedFallback) {
+    warnedFallback = true;
+    console.warn(
+      '[compactor-segments] no provider available for summarization; recording a labeled digest truncation instead',
+    );
+  }
+  return `[no summarizer available: truncated digest of this sub-session, not a summary]\n${text}`;
+}
+
+/** The "nothing to compact" event: an empty window that can never alias a live
+ *  seq, discarded by the dispatcher's tokensSaved<=0 guard. */
+function noOp(events: ReadonlyArray<MoxxyEvent>) {
+  const first = events[0]!;
+  const last = events[events.length - 1]!;
+  return {
+    type: 'compaction' as const,
+    sessionId: first.sessionId,
+    turnId: last.turnId,
+    source: 'compactor' as const,
+    compactor: 'segments',
+    replacedRange: [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER] as const,
+    summary: '',
+    tokensSaved: 0,
+  };
+}
+
+/**
+ * The searchable index of past sub-sessions, derived from the log. Reads the
+ * compaction events directly (rather than parsing their headers) so the seq
+ * range and the covered turns come from structured data; only the kind and
+ * ordinal are read off the header this compactor wrote.
+ */
+export function buildSessionDocs(events: ReadonlyArray<MoxxyEvent>): SessionDoc[] {
+  const live = activeCompactionRanges(events);
+  return live.map((range, index) => {
+    const covered = events.filter((e) => e.seq >= range.from && e.seq <= range.to);
+    const turnIds = [...new Set(covered.map((e) => e.turnId))];
+    const prompts = covered
+      .filter((e): e is Extract<MoxxyEvent, { type: 'user_prompt' }> => e.type === 'user_prompt')
+      .map((e) => e.text)
+      .join('\n');
+    const head = /^\[(segment|chapter) (\d+)/.exec(range.summary);
+    return {
+      kind: head?.[1] === 'chapter' ? ('chapter' as const) : ('segment' as const),
+      ordinal: head ? Number(head[2]) : index + 1,
+      turnIds,
+      from: range.from,
+      to: range.to,
+      summary: range.summary,
+      searchText: `${range.summary}\n${prompts}`,
+    };
+  });
+}
+
+export const sessionRecallTool = defineTool({
+  name: 'session_recall',
+  icon: 'search',
+  description:
+    'Search the record of THIS session\'s earlier sub-sessions. Older parts of the conversation are ' +
+    'kept as one dense record per sub-session (a user request and everything you did for it) rather ' +
+    'than verbatim, so use this whenever the user refers to something from earlier that you cannot ' +
+    'see in the visible context ("what did we decide about X", "the file you changed yesterday", ' +
+    '"go back to the thing before this"). Returns the matching records; call `recall({ turnId })` ' +
+    'afterwards to pull one sub-session back verbatim when you need the exact detail.',
+  inputSchema: z.object({
+    query: z.string().min(1).describe('What you are looking for, in the user\'s own words if possible.'),
+    limit: z.number().int().min(1).max(10).optional().default(4),
+  }),
+  permission: { action: 'allow' },
+  isolation: {
+    // Reads ctx.log, which an out-of-process isolator would not carry.
+    required: 'inproc',
+    capabilities: { net: { mode: 'none' }, timeMs: 5_000 },
+  },
+  handler: ({ query, limit }, ctx) => {
+    const docs = buildSessionDocs(ctx.log.slice());
+    if (docs.length === 0) {
+      return 'No earlier sub-sessions have been recorded yet; the whole conversation so far is still visible in your context.';
+    }
+    const matches = rank(docs, query, limit);
+    if (matches.length === 0) {
+      return `No recorded sub-session matches "${query}". ${docs.length} record(s) exist, covering seq 0-${docs[docs.length - 1]!.to}.`;
+    }
+    return {
+      matches: matches.map(({ doc, score }) => ({
+        kind: doc.kind,
+        ordinal: doc.ordinal,
+        turnIds: doc.turnIds,
+        seqRange: [doc.from, doc.to],
+        record: doc.summary,
+        score: Math.round(score * 1000) / 1000,
+      })),
+      hint: 'Call recall({ turnId: "<one of turnIds>" }) to bring that sub-session back verbatim, or recall({ seq: N }) for a single message.',
+    };
+  },
+});
+
+export const segmentsCompactorPlugin = definePlugin({
+  name: '@moxxy/compactor-segments',
+  version: '0.0.0',
+  compactors: [createSegmentsCompactor()],
+  tools: [sessionRecallTool],
+});
+
+export default segmentsCompactorPlugin;

--- a/packages/compactor-segments/src/search.ts
+++ b/packages/compactor-segments/src/search.ts
@@ -1,0 +1,63 @@
+/**
+ * Ranking for `session_recall`. Zero-dependency idf-weighted overlap over the
+ * session's own summaries, deliberately NOT the embeddings path: recall over a
+ * few dozen short summaries must be instant, offline, and free, and it runs
+ * inside a turn the user is waiting on.
+ */
+
+export interface SessionDoc {
+  readonly kind: 'segment' | 'chapter';
+  readonly ordinal: number;
+  readonly turnIds: ReadonlyArray<string>;
+  readonly from: number;
+  readonly to: number;
+  readonly summary: string;
+  /** Summary plus the raw prompts it covers, which is what gets matched against. */
+  readonly searchText: string;
+}
+
+export interface RankedDoc {
+  readonly doc: SessionDoc;
+  readonly score: number;
+}
+
+export function tokenize(text: string): string[] {
+  return (text.toLowerCase().match(/[\p{L}\p{N}]{2,}/gu) ?? []) as string[];
+}
+
+export function rank(docs: ReadonlyArray<SessionDoc>, query: string, limit: number): RankedDoc[] {
+  const terms = new Set(tokenize(query));
+  if (terms.size === 0 || docs.length === 0) return [];
+
+  const tokenized = docs.map((doc) => {
+    const counts = new Map<string, number>();
+    for (const t of tokenize(doc.searchText)) counts.set(t, (counts.get(t) ?? 0) + 1);
+    return { doc, counts, length: Math.max(1, counts.size) };
+  });
+
+  const df = new Map<string, number>();
+  for (const term of terms) {
+    let n = 0;
+    for (const entry of tokenized) if (entry.counts.has(term)) n += 1;
+    df.set(term, n);
+  }
+
+  const scored: RankedDoc[] = [];
+  for (const entry of tokenized) {
+    let score = 0;
+    for (const term of terms) {
+      const tf = entry.counts.get(term);
+      if (!tf) continue;
+      const idf = Math.log(1 + docs.length / (1 + (df.get(term) ?? 0)));
+      score += idf * (1 + Math.log(tf));
+    }
+    if (score <= 0) continue;
+    // Length-normalize so a long chapter doesn't outrank the one segment that
+    // actually answers the question just by containing more words.
+    scored.push({ doc: entry.doc, score: score / Math.sqrt(entry.length) });
+  }
+  // Ties break toward the more recent sub-session, because later work usually
+  // supersedes earlier work on the same subject.
+  scored.sort((a, b) => b.score - a.score || b.doc.ordinal - a.doc.ordinal);
+  return scored.slice(0, limit);
+}

--- a/packages/compactor-segments/src/segments.test.ts
+++ b/packages/compactor-segments/src/segments.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import type { MoxxyEvent } from '@moxxy/sdk';
+import { planCompaction, resolveOptions, DEFAULTS } from './segments.js';
+
+function userPrompt(seq: number, turnId: string, text: string): MoxxyEvent {
+  return {
+    id: `u${seq}` as never,
+    seq,
+    ts: 0,
+    type: 'user_prompt',
+    sessionId: 'sess' as never,
+    turnId: turnId as never,
+    source: 'user',
+    text,
+  } as MoxxyEvent;
+}
+
+function assistant(seq: number, turnId: string, text: string): MoxxyEvent {
+  return {
+    id: `a${seq}` as never,
+    seq,
+    ts: 0,
+    type: 'assistant_message',
+    sessionId: 'sess' as never,
+    turnId: turnId as never,
+    source: 'model',
+    content: text,
+    stopReason: 'end_turn',
+  } as MoxxyEvent;
+}
+
+function compaction(
+  seq: number,
+  range: [number, number],
+  summary: string,
+  turnId = 't-last',
+): MoxxyEvent {
+  return {
+    id: `c${seq}` as never,
+    seq,
+    ts: 0,
+    type: 'compaction',
+    sessionId: 'sess' as never,
+    turnId: turnId as never,
+    source: 'compactor',
+    compactor: 'segments',
+    replacedRange: range,
+    summary,
+    tokensSaved: 100,
+  } as MoxxyEvent;
+}
+
+/** A turn big enough to clear `minSegmentChars` on its own. */
+function fatTurn(startSeq: number, turnId: string, label: string): MoxxyEvent[] {
+  return [
+    userPrompt(startSeq, turnId, `${label}: ${'q'.repeat(1_200)}`),
+    assistant(startSeq + 1, turnId, `${label} answer: ${'a'.repeat(1_200)}`),
+  ];
+}
+
+const opts = resolveOptions();
+
+describe('planCompaction: the verbatim window', () => {
+  it('plans nothing while every turn is inside the window', () => {
+    const events = [...fatTurn(0, 't1', 'one'), ...fatTurn(2, 't2', 'two'), ...fatTurn(4, 't3', 'three')];
+    expect(planCompaction(events, opts)).toBeNull();
+  });
+
+  it('compacts the oldest turn once it falls out of the window', () => {
+    const events = [
+      ...fatTurn(0, 't1', 'one'),
+      ...fatTurn(2, 't2', 'two'),
+      ...fatTurn(4, 't3', 'three'),
+      ...fatTurn(6, 't4', 'four'),
+    ];
+    const plan = planCompaction(events, opts);
+    expect(plan).not.toBeNull();
+    expect(plan!.kind).toBe('segment');
+    expect(plan).toMatchObject({ from: 0, to: 1 });
+    expect((plan as { turnIds: string[] }).turnIds).toEqual(['t1']);
+  });
+
+  it('never touches the in-progress (last) turn even under pressure', () => {
+    const events = [...fatTurn(0, 't1', 'one'), ...fatTurn(2, 't2', 'live')];
+    const plan = planCompaction(events, { ...opts, keepRecentTurns: 1 });
+    // keepRecentTurns=1 protects only the live turn, so t1 is eligible…
+    expect(plan).toMatchObject({ kind: 'segment', from: 0, to: 1 });
+    // …and the live turn's events are never inside the window.
+    expect(plan!.to).toBeLessThan(2);
+  });
+
+  it('skips a turn that is already covered by a live summary', () => {
+    const events = [
+      ...fatTurn(0, 't1', 'one'),
+      ...fatTurn(2, 't2', 'two'),
+      ...fatTurn(4, 't3', 'three'),
+      ...fatTurn(6, 't4', 'four'),
+      compaction(8, [0, 1], '[segment 1 · turn t1 · seq 0-1]\nrecord'),
+    ];
+    const plan = planCompaction(events, opts);
+    expect(plan).toMatchObject({ kind: 'segment', from: 2, to: 3 });
+  });
+});
+
+describe('planCompaction: small turns', () => {
+  it('waits rather than summarizing a sub-session that saves nothing', () => {
+    const tiny = (seq: number, turn: string): MoxxyEvent[] => [
+      userPrompt(seq, turn, 'ok'),
+      assistant(seq + 1, turn, 'done'),
+    ];
+    const events = [...tiny(0, 't1'), ...tiny(2, 't2'), ...tiny(4, 't3'), ...tiny(6, 't4')];
+    expect(planCompaction(events, opts)).toBeNull();
+  });
+
+  it('groups consecutive small turns into one sub-session once they add up', () => {
+    const medium = (seq: number, turn: string): MoxxyEvent[] => [
+      userPrompt(seq, turn, 'q'.repeat(400)),
+      assistant(seq + 1, turn, 'a'.repeat(400)),
+    ];
+    const events = [
+      ...medium(0, 't1'),
+      ...medium(2, 't2'),
+      ...medium(4, 't3'),
+      ...medium(6, 't4'),
+      ...medium(8, 't5'),
+      ...medium(10, 't6'),
+    ];
+    const plan = planCompaction(events, opts);
+    expect(plan).not.toBeNull();
+    expect((plan as { turnIds: string[] }).turnIds).toEqual(['t1', 't2', 't3']);
+    expect(plan).toMatchObject({ from: 0, to: 5 });
+  });
+});
+
+describe('planCompaction: chapter folding', () => {
+  it('folds the oldest summaries once the index passes the cap', () => {
+    const events: MoxxyEvent[] = [];
+    // 13 summarized sub-sessions (cap is 12) covering seq 0..25, then a live turn.
+    for (let i = 0; i < 13; i++) {
+      events.push(userPrompt(i * 2, `t${i}`, 'x'.repeat(10)));
+      events.push(assistant(i * 2 + 1, `t${i}`, 'y'.repeat(10)));
+    }
+    for (let i = 0; i < 13; i++) {
+      events.push(
+        compaction(100 + i, [i * 2, i * 2 + 1], `[segment ${i + 1} · turn t${i} · seq ${i * 2}-${i * 2 + 1}]\nrecord ${i}`),
+      );
+    }
+    const plan = planCompaction(events, opts);
+    expect(plan).not.toBeNull();
+    expect(plan!.kind).toBe('chapter');
+    // The oldest `foldSegments` records, and only those.
+    expect(plan).toMatchObject({ from: 0, to: 11, ordinal: 1 });
+    expect((plan as { summaries: string[] }).summaries).toHaveLength(DEFAULTS.foldSegments);
+  });
+
+  it('stops a fold before a window that would swallow an unsummarized turn', () => {
+    const events: MoxxyEvent[] = [];
+    // 14 turns, but t3 is never summarized. It sits verbatim in the middle of
+    // the record index, so a fold spanning past it would drop it from context.
+    for (let i = 0; i < 14; i++) {
+      events.push(userPrompt(i * 2, `t${i}`, 'x'.repeat(10)));
+      events.push(assistant(i * 2 + 1, `t${i}`, 'y'.repeat(10)));
+    }
+    for (let i = 0; i < 14; i++) {
+      if (i === 3) continue;
+      events.push(
+        compaction(100 + i, [i * 2, i * 2 + 1], `[segment ${i + 1} · turn t${i} · seq ${i * 2}-${i * 2 + 1}]\nrecord ${i}`),
+      );
+    }
+    const plan = planCompaction(events, opts);
+    expect(plan!.kind).toBe('chapter');
+    // Folds t0-t2 and stops: t3 (seq 6-7) is uncovered, so the window may not
+    // reach t4's record.
+    expect(plan).toMatchObject({ from: 0, to: 5 });
+    expect((plan as { summaries: string[] }).summaries).toHaveLength(3);
+  });
+});
+
+describe('resolveOptions', () => {
+  it('clamps hostile values instead of disabling the bound', () => {
+    const resolved = resolveOptions({
+      keepRecentTurns: 0,
+      maxSegments: Number.NaN,
+      foldSegments: 1,
+      minSegmentChars: -5,
+    });
+    expect(resolved.keepRecentTurns).toBe(1);
+    expect(resolved.maxSegments).toBe(DEFAULTS.maxSegments);
+    expect(resolved.foldSegments).toBe(2);
+    expect(resolved.minSegmentChars).toBe(200);
+  });
+
+  it('never lets a fold exceed the cap it is restoring', () => {
+    expect(resolveOptions({ maxSegments: 3, foldSegments: 50 }).foldSegments).toBe(3);
+  });
+});

--- a/packages/compactor-segments/src/segments.ts
+++ b/packages/compactor-segments/src/segments.ts
@@ -1,0 +1,304 @@
+import { activeCompactionRanges, toolResultBytes, type MoxxyEvent } from '@moxxy/sdk';
+
+/**
+ * Pure log analysis behind the `segments` compactor. No provider, no I/O, so
+ * the policy (what becomes a sub-session, when it folds into a chapter, what
+ * the window may swallow) is testable without a model.
+ */
+
+export interface SegmentOptions {
+  /** Turns kept verbatim at the tail, including the in-progress one. */
+  readonly keepRecentTurns: number;
+  /** A sub-session must carry at least this many context chars to be worth summarizing. */
+  readonly minSegmentChars: number;
+  /** Live summaries tolerated before the oldest fold into a chapter. */
+  readonly maxSegments: number;
+  /** How many of the oldest live summaries one chapter absorbs. */
+  readonly foldSegments: number;
+}
+
+export const DEFAULTS: SegmentOptions = {
+  keepRecentTurns: 3,
+  minSegmentChars: 2_000,
+  maxSegments: 12,
+  foldSegments: 6,
+};
+
+export function resolveOptions(opts: Partial<SegmentOptions> = {}): SegmentOptions {
+  // Clamp every knob: a programmatic caller passing NaN/0 must not be able to
+  // disable the bound (which is the whole point of this compactor) or compact
+  // the turn that is still running.
+  const num = (v: number | undefined, fallback: number, min: number): number =>
+    Number.isFinite(v) ? Math.max(min, Math.floor(v!)) : fallback;
+  const maxSegments = num(opts.maxSegments, DEFAULTS.maxSegments, 2);
+  return {
+    keepRecentTurns: num(opts.keepRecentTurns, DEFAULTS.keepRecentTurns, 1),
+    minSegmentChars: num(opts.minSegmentChars, DEFAULTS.minSegmentChars, 200),
+    maxSegments,
+    // Folding must consume at least two summaries (folding one is a rename) and
+    // can never exceed the cap it is trying to get back under.
+    foldSegments: Math.min(maxSegments, num(opts.foldSegments, DEFAULTS.foldSegments, 2)),
+  };
+}
+
+/** Event types that actually reach the model, and so must never be silently
+ *  swallowed by a compaction window they aren't summarized into. */
+const PROJECTED_TYPES = new Set([
+  'user_prompt',
+  'assistant_message',
+  'reasoning_message',
+  'tool_call_requested',
+  'tool_result',
+]);
+
+function isProjected(e: MoxxyEvent): boolean {
+  return PROJECTED_TYPES.has(e.type);
+}
+
+/** Chars this event contributes to the projected context. Mirrors the SDK's
+ *  per-event costing so `tokensSaved` reflects the real context delta. */
+export function contextChars(e: MoxxyEvent): number {
+  switch (e.type) {
+    case 'user_prompt': {
+      let n = e.text.length;
+      for (const att of e.attachments ?? []) {
+        if (att.kind === 'file' || att.kind === 'stdin') n += att.content.length;
+      }
+      return n;
+    }
+    case 'assistant_message':
+      return e.content.length;
+    case 'tool_call_requested':
+      return e.name.length + safeJsonLen(e.input);
+    case 'tool_result':
+      if (e.error) return (e.error.message?.length ?? 0) + 12;
+      return toolResultBytes(e.output);
+    default:
+      return 0;
+  }
+}
+
+function safeJsonLen(v: unknown): number {
+  try {
+    return JSON.stringify(v ?? '').length;
+  } catch {
+    return 0;
+  }
+}
+
+export interface SegmentPlan {
+  readonly kind: 'segment';
+  /** Inclusive seq window this summary will replace. */
+  readonly from: number;
+  readonly to: number;
+  /** Turns folded into this sub-session, oldest first. */
+  readonly turnIds: ReadonlyArray<string>;
+  /** 1-based ordinal, never reused across a session. */
+  readonly ordinal: number;
+  /** Context chars the window costs today. */
+  readonly originalChars: number;
+  readonly events: ReadonlyArray<MoxxyEvent>;
+}
+
+export interface ChapterPlan {
+  readonly kind: 'chapter';
+  readonly from: number;
+  readonly to: number;
+  readonly ordinal: number;
+  /** The live summaries being folded, oldest first. */
+  readonly summaries: ReadonlyArray<string>;
+  readonly originalChars: number;
+}
+
+export type CompactionPlan = SegmentPlan | ChapterPlan;
+
+/**
+ * Decide the next compaction step, or null when the log is already as compact
+ * as this policy wants it.
+ *
+ * Order matters: an over-cap summary index is folded FIRST, so the index can
+ * never grow past `maxSegments` even while new sub-sessions keep arriving.
+ */
+export function planCompaction(
+  events: ReadonlyArray<MoxxyEvent>,
+  opts: SegmentOptions,
+): CompactionPlan | null {
+  if (events.length === 0) return null;
+  const live = activeCompactionRanges(events);
+  if (live.length > opts.maxSegments) {
+    const chapter = planChapter(events, live, opts);
+    if (chapter) return chapter;
+  }
+  return planSegment(events, live, opts);
+}
+
+function planChapter(
+  events: ReadonlyArray<MoxxyEvent>,
+  live: ReadonlyArray<{ from: number; to: number; summary: string }>,
+  opts: SegmentOptions,
+): ChapterPlan | null {
+  const ordered = [...live].sort((a, b) => a.from - b.from);
+  const candidates = ordered.slice(0, opts.foldSegments);
+  if (candidates.length < 2) return null;
+
+  // Grow the fold one summary at a time, stopping before any window that would
+  // swallow a projected event no summary covers. Compaction/elision bookkeeping
+  // events inside the window are fine; projection ignores them.
+  const covered = (seq: number): boolean =>
+    ordered.some((r) => seq >= r.from && seq <= r.to);
+  let taken = 0;
+  let to = -1;
+  for (let i = 0; i < candidates.length; i++) {
+    const next = candidates[i]!;
+    const clean = events.every(
+      (e) => !isProjected(e) || e.seq < candidates[0]!.from || e.seq > next.to || covered(e.seq),
+    );
+    if (!clean) break;
+    taken = i + 1;
+    to = next.to;
+  }
+  if (taken < 2) return null;
+
+  const folded = candidates.slice(0, taken);
+  return {
+    kind: 'chapter',
+    from: folded[0]!.from,
+    to,
+    ordinal: countSummaries(events, '[chapter ') + 1,
+    summaries: folded.map((r) => r.summary),
+    originalChars: folded.reduce((n, r) => n + r.summary.length, 0),
+  };
+}
+
+function planSegment(
+  events: ReadonlyArray<MoxxyEvent>,
+  live: ReadonlyArray<{ from: number; to: number }>,
+  opts: SegmentOptions,
+): SegmentPlan | null {
+  const covered = (seq: number): boolean => live.some((r) => seq >= r.from && seq <= r.to);
+
+  // Distinct turns in log order. The LAST `keepRecentTurns` of them (which
+  // includes the in-progress turn, since it is appending right now) stay
+  // verbatim. This is what keeps "no, the other one" answerable without a
+  // recall round-trip.
+  const turnOrder: string[] = [];
+  const seen = new Set<string>();
+  for (const e of events) {
+    if (!seen.has(e.turnId)) {
+      seen.add(e.turnId);
+      turnOrder.push(e.turnId);
+    }
+  }
+  const eligible = turnOrder.slice(0, Math.max(0, turnOrder.length - opts.keepRecentTurns));
+  if (eligible.length === 0) return null;
+
+  // Skip turns already summarized: a turn counts as done when it has no
+  // uncovered projected event left.
+  const uncoveredOf = (turnId: string): ReadonlyArray<MoxxyEvent> =>
+    events.filter((e) => e.turnId === turnId && !covered(e.seq));
+  let start = 0;
+  while (start < eligible.length && uncoveredOf(eligible[start]!).every((e) => !isProjected(e))) {
+    start += 1;
+  }
+  if (start >= eligible.length) return null;
+
+  // Accumulate consecutive eligible turns until the sub-session is substantial
+  // enough that a summary is smaller than what it replaces. Without this, a
+  // one-word turn would be re-summarized on every iteration forever (its
+  // summary can never be shorter than "ok").
+  const turnIds: string[] = [];
+  let originalChars = 0;
+  let from = Number.MAX_SAFE_INTEGER;
+  let to = -1;
+  for (let i = start; i < eligible.length; i++) {
+    const turnId = eligible[i]!;
+    const turnEvents = events.filter((e) => e.turnId === turnId);
+    if (turnEvents.length === 0) continue;
+    turnIds.push(turnId);
+    for (const e of turnEvents) {
+      from = Math.min(from, e.seq);
+      to = Math.max(to, e.seq);
+      if (!covered(e.seq)) originalChars += contextChars(e);
+    }
+    if (originalChars >= opts.minSegmentChars) break;
+  }
+  if (turnIds.length === 0 || to < 0) return null;
+  // Still too small even after taking every eligible turn, so wait for more
+  // history rather than paying a summarization call that saves nothing.
+  if (originalChars < opts.minSegmentChars) return null;
+
+  // The window must not swallow a projected event belonging to a turn outside
+  // this segment (possible when turns interleave, e.g. concurrent HTTP turns).
+  const inSegment = new Set(turnIds);
+  const trespass = events.find(
+    (e) => isProjected(e) && e.seq >= from && e.seq <= to && !inSegment.has(e.turnId) && !covered(e.seq),
+  );
+  if (trespass) {
+    to = trespass.seq - 1;
+    if (to < from) return null;
+  }
+
+  const windowEvents = events.filter((e) => e.seq >= from && e.seq <= to && !covered(e.seq));
+  if (!windowEvents.some(isProjected)) return null;
+
+  return {
+    kind: 'segment',
+    from,
+    to,
+    turnIds,
+    ordinal: countSummaries(events, '[segment ') + 1,
+    originalChars: windowEvents.reduce((n, e) => n + contextChars(e), 0),
+    events: windowEvents,
+  };
+}
+
+/** Ordinals are derived from history (including summaries later superseded by a
+ *  chapter) so a number is never reused and a stale reference stays unambiguous. */
+function countSummaries(events: ReadonlyArray<MoxxyEvent>, prefix: string): number {
+  let n = 0;
+  for (const e of events) {
+    if (e.type === 'compaction' && e.summary.startsWith(prefix)) n += 1;
+  }
+  return n;
+}
+
+export function segmentHeader(plan: SegmentPlan): string {
+  const turns = plan.turnIds.join(', ');
+  return `[segment ${plan.ordinal} · turn ${turns} · seq ${plan.from}-${plan.to}]`;
+}
+
+export function chapterHeader(plan: ChapterPlan, coveredSegments: number): string {
+  return `[chapter ${plan.ordinal} · folds ${coveredSegments} earlier summaries · seq ${plan.from}-${plan.to}]`;
+}
+
+/** One line per event: the input the summarizer compresses. */
+export function buildDigest(events: ReadonlyArray<MoxxyEvent>): string {
+  return events.map(describeEvent).filter(Boolean).join('\n');
+}
+
+function describeEvent(e: MoxxyEvent): string | null {
+  switch (e.type) {
+    case 'user_prompt':
+      // The prompt IS the sub-session's brief, so it gets a far longer window
+      // than the surrounding chatter.
+      return `[user] ${e.text.slice(0, 2_000)}`;
+    case 'assistant_message':
+      return `[assistant] ${e.content.slice(0, 800)}`;
+    case 'tool_call_requested':
+      return `[tool_use] ${e.name}(${safeJsonStr(e.input).slice(0, 160)})`;
+    case 'tool_result':
+      return `[tool_result ${e.ok ? 'ok' : 'err'}] ${
+        typeof e.output === 'string' ? e.output.slice(0, 200) : ''
+      }${e.error?.message?.slice(0, 200) ?? ''}`;
+    default:
+      return null;
+  }
+}
+
+function safeJsonStr(v: unknown): string {
+  try {
+    return JSON.stringify(v ?? {}) ?? '{}';
+  } catch {
+    return '[unserializable]';
+  }
+}

--- a/packages/compactor-segments/tsconfig.json
+++ b/packages/compactor-segments/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@moxxy/tsconfig/lib.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/compactor-segments/vitest.config.ts
+++ b/packages/compactor-segments/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@moxxy/vitest-preset';

--- a/packages/compactor-summarize/src/index.ts
+++ b/packages/compactor-summarize/src/index.ts
@@ -1,6 +1,8 @@
 import {
+  abortError,
   defineCompactor,
   definePlugin,
+  summarizeWithProvider,
   toolResultBytes,
   type CompactContext,
   type CompactorDef,
@@ -120,7 +122,7 @@ export function createSummarizeCompactor(opts: SummarizeOptions = {}): Compactor
       // Final abort gate: if the turn was cancelled while the summary was being
       // produced (incl. via a custom `opts.summary`), don't rewrite history the
       // user is abandoning — let the dispatcher no-op / the caller surface it.
-      if (ctx?.signal?.aborted) throwAbort();
+      if (ctx?.signal?.aborted) throw abortError('summarize-old-turns: compaction aborted');
       // Honest accounting: tokens saved = what the replaced events would have
       // cost the context minus what the summary costs (chars/4, matching
       // `estimateContextTokens`'s heuristic) — NOT the old fabricated
@@ -147,70 +149,20 @@ export function createSummarizeCompactor(opts: SummarizeOptions = {}): Compactor
  * provider/model is available or the call genuinely fails — callers fall back to
  * the labeled digest truncation. A turn CANCELLATION, however, must NOT degrade
  * to a lossy fallback that silently rewrites history the user is trying to
- * abandon: when `ctx.signal` is aborted the AbortError is re-thrown so
- * `compact()` propagates it (the auto dispatcher then no-ops; the manual caller
- * surfaces it) instead of producing a truncated digest with tokensSaved > 0.
+ * abandon: the shared helper re-throws the AbortError so `compact()` propagates
+ * it (the auto dispatcher then no-ops; the manual caller surfaces it) instead of
+ * producing a truncated digest with tokensSaved > 0.
  */
-async function providerSummary(text: string, ctx?: CompactContext): Promise<string | null> {
-  if (!ctx?.provider) return null;
-  // Already cancelled before we even start — don't fabricate a fallback digest.
-  if (ctx.signal?.aborted) throwAbort();
-  const provider = ctx.provider;
-  const model = ctx.model ?? provider.models[0]?.id;
-  if (!model) return null;
-  const input =
-    text.length > MAX_SUMMARIZE_INPUT_CHARS
-      ? `${text.slice(0, MAX_SUMMARIZE_INPUT_CHARS / 2)}\n[... digest truncated ...]\n${text.slice(-MAX_SUMMARIZE_INPUT_CHARS / 2)}`
-      : text;
-  try {
-    let out = '';
-    for await (const event of provider.stream({
-      model,
-      system: SUMMARY_SYSTEM_PROMPT,
-      messages: [
-        {
-          role: 'user',
-          content: [{ type: 'text', text: `Digest of the turns to compress:\n\n${input}` }],
-        },
-      ],
-      maxTokens: SUMMARY_MAX_TOKENS,
-      ...(ctx.signal ? { signal: ctx.signal } : {}),
-    })) {
-      // Stop consuming (and accumulating `out`) the moment the turn is
-      // cancelled, even if the provider keeps yielding — the final abort gate
-      // in compact() will then no-op rather than rewrite abandoned history.
-      if (ctx.signal?.aborted) throwAbort();
-      if (event.type === 'text_delta') out += event.delta;
-      if (event.type === 'error') {
-        // An `error` event during an aborted turn is the cancellation, not a
-        // transient provider failure — propagate rather than degrade.
-        if (ctx.signal?.aborted) throwAbort();
-        return null;
-      }
-    }
-    const trimmed = out.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  } catch (err) {
-    // Distinguish a user/turn cancellation (re-throw) from a transient provider
-    // failure (fall back). Re-throw if the thrown error is an abort OR the
-    // signal fired mid-stream.
-    if (isAbort(err) || ctx.signal?.aborted) throw err instanceof Error ? err : abortError();
-    return null;
-  }
-}
-
-function isAbort(err: unknown): boolean {
-  return err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
-}
-
-function abortError(): Error {
-  const e = new Error('summarize-old-turns: compaction aborted');
-  e.name = 'AbortError';
-  return e;
-}
-
-function throwAbort(): never {
-  throw abortError();
+function providerSummary(text: string, ctx?: CompactContext): Promise<string | null> {
+  return summarizeWithProvider(text, {
+    system: SUMMARY_SYSTEM_PROMPT,
+    prompt: (digest) => `Digest of the turns to compress:\n\n${digest}`,
+    maxInputChars: MAX_SUMMARIZE_INPUT_CHARS,
+    maxTokens: SUMMARY_MAX_TOKENS,
+    ...(ctx?.provider ? { provider: ctx.provider } : {}),
+    ...(ctx?.model ? { model: ctx.model } : {}),
+    ...(ctx?.signal ? { signal: ctx.signal } : {}),
+  });
 }
 
 function describeEvent(e: MoxxyEvent): string | null {

--- a/packages/sdk/src/compaction-state.test.ts
+++ b/packages/sdk/src/compaction-state.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { activeCompactionRanges, makeCompactionLookup } from './compaction-state.js';
+import { estimateContextTokens } from './compactor-helpers.js';
+import { asEventId, asSessionId, asTurnId } from './ids.js';
+import type { EventLogReader } from './log.js';
+import type { MoxxyEvent, MoxxyEventOfType, MoxxyEventType } from './events.js';
+import type { TurnId } from './ids.js';
+
+const sid = asSessionId('s1');
+
+function event(seq: number, partial: Omit<MoxxyEvent, 'id' | 'seq' | 'ts' | 'sessionId'>): MoxxyEvent {
+  return { id: asEventId(`e${seq}`), seq, ts: seq, sessionId: sid, ...partial } as MoxxyEvent;
+}
+
+function compaction(
+  seq: number,
+  range: readonly [number, number],
+  summary: string,
+  tokensSaved = 100,
+): MoxxyEvent {
+  return event(seq, {
+    type: 'compaction',
+    turnId: asTurnId('t1'),
+    source: 'compactor',
+    compactor: 'test',
+    replacedRange: range,
+    summary,
+    tokensSaved,
+  } as Omit<MoxxyEvent, 'id' | 'seq' | 'ts' | 'sessionId'>);
+}
+
+function prompt(seq: number, turnId: string, text: string): MoxxyEvent {
+  return event(seq, { type: 'user_prompt', turnId: asTurnId(turnId), source: 'user', text } as Omit<
+    MoxxyEvent,
+    'id' | 'seq' | 'ts' | 'sessionId'
+  >);
+}
+
+function reader(events: ReadonlyArray<MoxxyEvent>): EventLogReader {
+  return {
+    length: events.length,
+    at: (seq) => events[seq],
+    slice: (from = 0, to = events.length) => events.slice(from, to),
+    ofType: <T extends MoxxyEventType>(type: T): ReadonlyArray<MoxxyEventOfType<T>> =>
+      events.filter((e): e is MoxxyEventOfType<T> => e.type === type),
+    byTurn: (turnId: TurnId) => events.filter((e) => e.turnId === turnId),
+    toJSON: () => events,
+  };
+}
+
+describe('activeCompactionRanges', () => {
+  it('keeps every well-formed, non-overlapping range', () => {
+    const ranges = activeCompactionRanges([
+      compaction(10, [0, 4], 'first'),
+      compaction(11, [5, 9], 'second'),
+    ]);
+    expect(ranges.map((r) => r.summary)).toEqual(['first', 'second']);
+  });
+
+  it('drops inert compactions (no savings, empty summary, inverted range)', () => {
+    const ranges = activeCompactionRanges([
+      compaction(10, [0, 4], 'saved nothing', 0),
+      compaction(11, [5, 9], '   '),
+      compaction(12, [9, 5], 'inverted'),
+      compaction(13, [10, 14], 'kept'),
+    ]);
+    expect(ranges.map((r) => r.summary)).toEqual(['kept']);
+  });
+
+  it('supersedes ranges a LATER range fully contains (chapter rollup)', () => {
+    const ranges = activeCompactionRanges([
+      compaction(10, [0, 4], 'segment 1'),
+      compaction(11, [5, 9], 'segment 2'),
+      compaction(12, [0, 9], 'chapter of 1-2'),
+      compaction(13, [20, 24], 'segment 3'),
+    ]);
+    expect(ranges.map((r) => r.summary)).toEqual(['chapter of 1-2', 'segment 3']);
+  });
+
+  it('does not let an EARLIER wide range swallow a later one', () => {
+    // Order matters: only a range emitted after the one it contains supersedes
+    // it. The reverse would drop a fresh summary in favour of a stale rollup.
+    const ranges = activeCompactionRanges([
+      compaction(10, [0, 9], 'wide first'),
+      compaction(11, [2, 4], 'narrow later'),
+    ]);
+    expect(ranges.map((r) => r.summary)).toEqual(['wide first', 'narrow later']);
+  });
+
+  it('a superseded range stays covered by the rollup that replaced it', () => {
+    const ranges = activeCompactionRanges([
+      compaction(10, [0, 4], 'segment 1'),
+      compaction(11, [0, 9], 'chapter'),
+    ]);
+    const lookup = makeCompactionLookup(ranges);
+    expect(lookup(3)?.summary).toBe('chapter');
+    expect(lookup(7)?.summary).toBe('chapter');
+    expect(lookup(12)).toBeNull();
+  });
+});
+
+describe('estimateContextTokens with superseded ranges', () => {
+  it('counts the rollup summary once, not the summaries it replaced', () => {
+    const events = [
+      prompt(0, 't1', 'a'.repeat(400)),
+      prompt(1, 't2', 'b'.repeat(400)),
+      compaction(2, [0, 0], 'S'.repeat(100)),
+      compaction(3, [1, 1], 'T'.repeat(100)),
+      compaction(4, [0, 1], 'C'.repeat(40)),
+    ];
+    // Only the chapter summary is live: 40 chars / 4 = 10 tokens. The replaced
+    // prompts and the superseded segment summaries contribute nothing.
+    expect(estimateContextTokens(reader(events))).toBe(10);
+  });
+});

--- a/packages/sdk/src/compaction-state.ts
+++ b/packages/sdk/src/compaction-state.ts
@@ -1,0 +1,124 @@
+import type { CompactionEvent, MoxxyEvent } from './events.js';
+
+/**
+ * Shared compaction decision logic: the single source of truth for "which
+ * summary ranges are live", consumed by BOTH `projectMessagesFromLog` (what we
+ * send) and `estimateContextTokens` (what we think we send). Same reasoning as
+ * the sibling `elision-state` module: one leaf module keeps the estimate and
+ * the projection from drifting, and avoids a circular import between them.
+ */
+
+export interface CompactionRange {
+  readonly from: number;
+  readonly to: number;
+  readonly summary: string;
+}
+
+/**
+ * The compaction ranges that still contribute a summary to the projection.
+ *
+ * Two filters:
+ *  1. Well-formedness. A compaction that saved nothing, carries an empty
+ *     summary, or has an inverted range is inert (this is what lets the
+ *     "nothing to compact" no-op event exist without affecting projection).
+ *  2. **Supersession**. A range fully contained in a LATER range is dropped.
+ *     This is what lets a compactor fold its own earlier summaries into a
+ *     coarser one (segment summaries → a chapter summary). Without it, the
+ *     rolled-up range and every range it swallowed would both project, so the
+ *     summary index could only ever grow, and an index that grows without
+ *     bound defeats the point of compacting in the first place.
+ *
+ * For a well-formed log written by a compactor that never re-compacts, no range
+ * contains another and this is exactly the old unconditional filter. The scan is
+ * O(n²) in the number of compaction events, which is bounded by the active
+ * compactor's segment cap (tens), not by the length of the session.
+ */
+export function activeCompactionRanges(
+  events: ReadonlyArray<MoxxyEvent>,
+): ReadonlyArray<CompactionRange> {
+  const wellFormed = events.filter(
+    (event): event is CompactionEvent =>
+      event.type === 'compaction' &&
+      event.tokensSaved > 0 &&
+      event.summary.trim().length > 0 &&
+      event.replacedRange[0] <= event.replacedRange[1],
+  );
+  const live: CompactionRange[] = [];
+  for (let i = 0; i < wellFormed.length; i++) {
+    const range = wellFormed[i]!.replacedRange;
+    let superseded = false;
+    for (let j = i + 1; j < wellFormed.length; j++) {
+      const later = wellFormed[j]!.replacedRange;
+      if (later[0] <= range[0] && range[1] <= later[1]) {
+        superseded = true;
+        break;
+      }
+    }
+    if (superseded) continue;
+    live.push({ from: range[0], to: range[1], summary: wellFormed[i]!.summary });
+  }
+  return live;
+}
+
+function eventInCompactionRange(
+  seq: number,
+  ranges: ReadonlyArray<CompactionRange>,
+): CompactionRange | null {
+  for (const range of ranges) {
+    if (seq >= range.from && seq <= range.to) return range;
+  }
+  return null;
+}
+
+/**
+ * A compaction lookup that answers "which range (if any) contains `seq`" in
+ * O(log ranges) instead of {@link eventInCompactionRange}'s O(ranges) linear
+ * scan per event. Compaction ranges are non-overlapping ascending seq prefixes,
+ * so a seq belongs to at most one range and binary search over the
+ * sorted-by-`from` array returns the SAME range the linear first-match did,
+ * byte-identical projection.
+ *
+ * Defensive fallback: if the ranges are NOT strictly non-overlapping (which the
+ * compaction invariant forbids, but a hand-crafted/corrupt log could violate),
+ * we keep the exact linear first-match semantics so the projection can never
+ * diverge from the old code.
+ */
+export function makeCompactionLookup(
+  ranges: ReadonlyArray<CompactionRange>,
+): (seq: number) => CompactionRange | null {
+  if (ranges.length === 0) return () => null;
+  if (ranges.length === 1) {
+    const only = ranges[0]!;
+    return (seq) => (seq >= only.from && seq <= only.to ? only : null);
+  }
+  // Sort a copy by `from` (stable enough: ranges are non-overlapping). Verify
+  // the non-overlap invariant on the sorted copy; only then is binary search
+  // provably equivalent to the linear first-match.
+  const sorted = [...ranges].sort((a, b) => a.from - b.from);
+  let nonOverlapping = true;
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i]!.from <= sorted[i - 1]!.to) {
+      nonOverlapping = false;
+      break;
+    }
+  }
+  if (!nonOverlapping) return (seq) => eventInCompactionRange(seq, ranges);
+  return (seq) => {
+    // Largest `from <= seq`, then a single containment check.
+    let lo = 0;
+    let hi = sorted.length - 1;
+    let cand = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (sorted[mid]!.from <= seq) {
+        cand = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    if (cand < 0) return null;
+    const range = sorted[cand]!;
+    return seq <= range.to ? range : null;
+  };
+}

--- a/packages/sdk/src/compactor-helpers.ts
+++ b/packages/sdk/src/compactor-helpers.ts
@@ -7,6 +7,7 @@ import {
   toolResultStubbed,
   type ElisionState,
 } from './elision-state.js';
+import { activeCompactionRanges } from './compaction-state.js';
 import type { CompactorDef, TokenBudget } from './compactor.js';
 import type { EmittedEvent, MoxxyEvent } from './events.js';
 import type { EventLogReader } from './log.js';
@@ -48,15 +49,12 @@ export function estimateContextTokens(
   // thousands of seqs after several compactions, and this runs every iteration.
   // The ranges are disjoint, so a small per-event interval check is equivalent
   // to the old Set membership test but allocates O(#compactions), not O(#seqs).
-  const compactedRanges: Array<readonly [number, number]> = [];
-  for (const e of events) {
-    if (e.type === 'compaction') {
-      compactedRanges.push([e.replacedRange[0], e.replacedRange[1]]);
-      chars += e.summary.length;
-    }
-  }
+  // Shares `activeCompactionRanges` with projection so a SUPERSEDED summary
+  // (one folded into a coarser range) is neither counted here nor sent there.
+  const compactedRanges = activeCompactionRanges(events);
+  for (const range of compactedRanges) chars += range.summary.length;
   const isCompacted = (seq: number): boolean =>
-    compactedRanges.some(([from, to]) => seq >= from && seq <= to);
+    compactedRanges.some(({ from, to }) => seq >= from && seq <= to);
   for (const e of events) {
     if (isCompacted(e.seq)) continue;
     if (e.type === 'tool_result' && toolResultStubbed(e, el)) {

--- a/packages/sdk/src/compactor-summary.ts
+++ b/packages/sdk/src/compactor-summary.ts
@@ -1,0 +1,94 @@
+import type { LLMProvider } from './provider.js';
+
+/**
+ * Ask the session's own provider to write a summary of a digest.
+ *
+ * Shared by every compactor that compresses history with the model rather than
+ * by truncation, because the CONTRACT here is subtle enough that a second copy
+ * would drift:
+ *
+ *  - No provider / no model / an empty or failed completion → `null`, so the
+ *    caller can degrade to an honest, clearly-labeled truncation.
+ *  - A turn CANCELLATION is NOT a failure: it re-throws, because degrading to a
+ *    lossy digest would silently rewrite history the user is abandoning. The
+ *    signal is checked before the call, on every streamed event, and again in
+ *    the catch (a provider that swallows the abort still yields an `error`
+ *    event, which is the cancellation when the signal has fired).
+ */
+export interface ProviderSummaryOptions {
+  /** System prompt describing what kind of summary to write. */
+  readonly system: string;
+  /** Wrap the (possibly truncated) digest into the user message text. */
+  readonly prompt: (digest: string) => string;
+  /** Hard ceiling on digest chars sent upstream; the middle is dropped. */
+  readonly maxInputChars: number;
+  /** Output budget for the summary. */
+  readonly maxTokens: number;
+  readonly provider?: LLMProvider;
+  readonly model?: string;
+  readonly signal?: AbortSignal;
+}
+
+export async function summarizeWithProvider(
+  digest: string,
+  opts: ProviderSummaryOptions,
+): Promise<string | null> {
+  const provider = opts.provider;
+  if (!provider) return null;
+  // Already cancelled before we even start; don't fabricate a fallback digest.
+  if (opts.signal?.aborted) throwAbort();
+  const model = opts.model ?? provider.models[0]?.id;
+  if (!model) return null;
+  const input = truncateMiddle(digest, opts.maxInputChars);
+  try {
+    let out = '';
+    for await (const event of provider.stream({
+      model,
+      system: opts.system,
+      messages: [{ role: 'user', content: [{ type: 'text', text: opts.prompt(input) }] }],
+      maxTokens: opts.maxTokens,
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    })) {
+      // Stop consuming (and accumulating `out`) the moment the turn is
+      // cancelled, even if the provider keeps yielding, so the caller's final
+      // abort gate then no-ops rather than rewriting abandoned history.
+      if (opts.signal?.aborted) throwAbort();
+      if (event.type === 'text_delta') out += event.delta;
+      if (event.type === 'error') {
+        // An `error` event during an aborted turn is the cancellation, not a
+        // transient provider failure, so propagate rather than degrade.
+        if (opts.signal?.aborted) throwAbort();
+        return null;
+      }
+    }
+    const trimmed = out.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch (err) {
+    // Distinguish a user/turn cancellation (re-throw) from a transient provider
+    // failure (fall back). Re-throw if the thrown error is an abort OR the
+    // signal fired mid-stream.
+    if (isAbort(err) || opts.signal?.aborted) throw err instanceof Error ? err : abortError();
+    return null;
+  }
+}
+
+/** Head+tail window of `text`, with the dropped middle called out. */
+export function truncateMiddle(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const half = Math.floor(maxChars / 2);
+  return `${text.slice(0, half)}\n[... digest truncated ...]\n${text.slice(-half)}`;
+}
+
+export function isAbort(err: unknown): boolean {
+  return err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
+}
+
+export function abortError(message = 'compaction aborted'): Error {
+  const e = new Error(message);
+  e.name = 'AbortError';
+  return e;
+}
+
+function throwAbort(): never {
+  throw abortError();
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -350,6 +350,18 @@ export {
   type ManualCompactionResult,
 } from './compactor-helpers.js';
 export {
+  activeCompactionRanges,
+  makeCompactionLookup,
+  type CompactionRange,
+} from './compaction-state.js';
+export {
+  summarizeWithProvider,
+  truncateMiddle,
+  isAbort,
+  abortError,
+  type ProviderSummaryOptions,
+} from './compactor-summary.js';
+export {
   runElisionIfNeeded,
   resolveElisionSettings,
   type ResolvedElisionSettings,

--- a/packages/sdk/src/mode/project-messages.ts
+++ b/packages/sdk/src/mode/project-messages.ts
@@ -1,7 +1,12 @@
 import type { ContentBlock, ProviderMessage } from '../provider.js';
 import type { ModeContext } from '../mode.js';
 import type { Skill } from '../skill.js';
-import type { CompactionEvent, MoxxyEvent, UserPromptEvent } from '../events.js';
+import type { MoxxyEvent, UserPromptEvent } from '../events.js';
+import {
+  activeCompactionRanges,
+  makeCompactionLookup,
+  type CompactionRange,
+} from '../compaction-state.js';
 import {
   computeElisionState,
   conversationalStub,
@@ -114,90 +119,6 @@ export interface ProjectMessagesOptions {
    * recomputes (memoized on the log version), byte-identically.
    */
   readonly precomputedElisionState?: ElisionState;
-}
-
-interface CompactionRange {
-  readonly from: number;
-  readonly to: number;
-  readonly summary: string;
-}
-
-function activeCompactionRanges(events: ReadonlyArray<MoxxyEvent>): ReadonlyArray<CompactionRange> {
-  return events
-    .filter((event): event is CompactionEvent =>
-      event.type === 'compaction' &&
-      event.tokensSaved > 0 &&
-      event.summary.trim().length > 0 &&
-      event.replacedRange[0] <= event.replacedRange[1],
-    )
-    .map((event) => ({
-      from: event.replacedRange[0],
-      to: event.replacedRange[1],
-      summary: event.summary,
-    }));
-}
-
-function eventInCompactionRange(
-  seq: number,
-  ranges: ReadonlyArray<CompactionRange>,
-): CompactionRange | null {
-  for (const range of ranges) {
-    if (seq >= range.from && seq <= range.to) return range;
-  }
-  return null;
-}
-
-/**
- * A compaction lookup that answers "which range (if any) contains `seq`" in
- * O(log ranges) instead of {@link eventInCompactionRange}'s O(ranges) linear
- * scan per event. Compaction ranges are non-overlapping ascending seq prefixes,
- * so a seq belongs to at most one range and binary search over the
- * sorted-by-`from` array returns the SAME range the linear first-match did —
- * byte-identical projection.
- *
- * Defensive fallback: if the ranges are NOT strictly non-overlapping (which the
- * compaction invariant forbids, but a hand-crafted/corrupt log could violate),
- * we keep the exact linear first-match semantics so the projection can never
- * diverge from the old code.
- */
-function makeCompactionLookup(
-  ranges: ReadonlyArray<CompactionRange>,
-): (seq: number) => CompactionRange | null {
-  if (ranges.length === 0) return () => null;
-  if (ranges.length === 1) {
-    const only = ranges[0]!;
-    return (seq) => (seq >= only.from && seq <= only.to ? only : null);
-  }
-  // Sort a copy by `from` (stable enough — ranges are non-overlapping). Verify
-  // the non-overlap invariant on the sorted copy; only then is binary search
-  // provably equivalent to the linear first-match.
-  const sorted = [...ranges].sort((a, b) => a.from - b.from);
-  let nonOverlapping = true;
-  for (let i = 1; i < sorted.length; i++) {
-    if (sorted[i]!.from <= sorted[i - 1]!.to) {
-      nonOverlapping = false;
-      break;
-    }
-  }
-  if (!nonOverlapping) return (seq) => eventInCompactionRange(seq, ranges);
-  return (seq) => {
-    // Largest `from <= seq`, then a single containment check.
-    let lo = 0;
-    let hi = sorted.length - 1;
-    let cand = -1;
-    while (lo <= hi) {
-      const mid = (lo + hi) >> 1;
-      if (sorted[mid]!.from <= seq) {
-        cand = mid;
-        lo = mid + 1;
-      } else {
-        hi = mid - 1;
-      }
-    }
-    if (cand < 0) return null;
-    const range = sorted[cand]!;
-    return seq <= range.to ? range : null;
-  };
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,6 +568,9 @@ importers:
       '@moxxy/cache-strategy-stable-prefix':
         specifier: workspace:*
         version: link:../cache-strategy-stable-prefix
+      '@moxxy/compactor-segments':
+        specifier: workspace:*
+        version: link:../compactor-segments
       '@moxxy/compactor-summarize':
         specifier: workspace:*
         version: link:../compactor-summarize
@@ -769,6 +772,28 @@ importers:
       '@moxxy/e2e':
         specifier: workspace:*
         version: link:../e2e
+    devDependencies:
+      '@moxxy/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      '@moxxy/vitest-preset':
+        specifier: workspace:*
+        version: link:../../tooling/vitest-preset
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+
+  packages/compactor-segments:
+    dependencies:
+      '@moxxy/sdk':
+        specifier: workspace:*
+        version: link:../sdk
     devDependencies:
       '@moxxy/tsconfig':
         specifier: workspace:*
@@ -15448,7 +15473,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.18
+      '@types/node': 24.12.3
 
   '@types/yargs-parser@21.0.3': {}
 


### PR DESCRIPTION
## What

Two independent changes, one per commit.

**Context.** The default compactor is now `segments`. Each finished turn (or a run of small consecutive ones) becomes one dense record - Asked / Did / Outcome / Facts / Open - replacing the turn's raw events in context. Once the record index passes its cap the oldest fold into a chapter, so the index is bounded too. Nothing is lost: the log keeps every original event, `session_recall` searches the records, `recall({ turnId })` restores one sub-session verbatim. `summarize-old-turns` stays registered as the protected floor.

**Desktop.** One registry-backed keymap with a single window dispatcher: Cmd+K palette, Cmd+L composer, Cmd+F search, Cmd+. interrupt, Cmd+N session, Cmd+Alt+Up/Down session switching, Cmd+B sidebar, Cmd+J workbench, Cmd+1-5 destinations, Cmd+, settings, Cmd+/ sheet. Previously the app had exactly one shortcut.

## Why

A long-running session was bounded only by a token threshold, so context grew with conversation length until one late bulk compaction rewrote a large prefix. Now size is governed by policy: bounded records plus a bounded verbatim tail.

## Reviewer notes

- **This changes the default compactor for everyone.** One config line reverts it: `plugins.compactor.default: 'summarize-old-turns'`.
- Compaction is turn-driven, not threshold-driven, so it costs one summarization call per sub-session. The trade is that each record is byte-stable and appended after the previous ones, so the projected prefix grows append-only and a cached prefix stays valid. A chapter fold does rewrite the head of the prefix, but that happens once per `foldSegments` sub-sessions, not per turn.
- The SDK change is load-bearing: a compaction range fully contained in a **later** range is now superseded, which is what lets a compactor re-compact its own summaries. Projection and the token estimate now share that one decision (`activeCompactionRanges`) instead of each filtering compactions themselves.
- Also fixes a pre-existing drift: the CLI's compactor floor and built-in default said `summarize`, but the def is named `summarize-old-turns`, so neither ever matched. The test covering it registered its fixture under the wrong name, pinning the drift rather than the behaviour.
- Known limits are logged in TECH_DEBT.md rather than papered over: a single runaway turn is still unbounded (compaction and elision only advance on completed-turn boundaries), chapter fidelity degrades as folds compound, and the keymap is renderer-only so the Electron menu still lists just Focus Mode.

## Verification

- `pnpm build` / `typecheck` / `test` / `lint` / `check:deps` all green on this branch, rebased on latest `development`. Lint and check:deps report only pre-existing warnings, 0 errors.
- The boundedness claim is a test, not an assertion: 200 turns driven through the real compactor, real projection and real token estimate. Context at the end is no larger than at the start and stays under 8k tokens, with 50+ compactions and chapter folds actually firing. The live record index is asserted to stay at or below its cap over 120 turns.
- A verbose-summarizer test proves a compaction step can never grow the context, which is what stops the same sub-session being re-summarized every iteration.
- Smoke on the built CLI: the real plugin host activates `segments` and registers `session_recall`.
- Desktop: 18 new tests over chord matching, registry resolution and the dispatcher, including that an already-handled event is ignored and that the shortcut sheet renders from the live registry. Full desktop suite (625 tests) green.