### PR TITLE
fix(security): harden filesystem access

### DIFF
--- a/.changeset/calm-files-lock.md
+++ b/.changeset/calm-files-lock.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/cli': patch
+'@moxxy/desktop': patch
+---
+
+Harden temporary files and remove filesystem race windows from runtime reads.

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: Moxxy production code
+
+paths-ignore:
+  - '**/*.test.ts'
+  - '**/*.test.tsx'
+  - '**/*.test.mts'
+  - '**/*.spec.ts'
+  - '**/*.spec.tsx'
+  - '**/__tests__/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
+          config-file: ./.github/codeql/codeql-config.yml
           languages: ${{ matrix.language }}
           queries: security-extended
 

--- a/packages/cli/src/commands/service/index.ts
+++ b/packages/cli/src/commands/service/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, open, readFile } from 'node:fs/promises';
+import { mkdir, open } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { launchdService } from './launchd.js';
@@ -121,7 +121,7 @@ export async function readServiceLog(spec: Pick<ServiceSpec, 'id'>, lines: numbe
     const want = Math.min(MAX_TAIL_BYTES, Math.max(safeLines * TAIL_BYTES_PER_LINE, TAIL_BYTES_PER_LINE));
     if (size <= want) {
       // Small file (or the whole file fits under the cap): read it all.
-      const text = await readFile(logPath, 'utf8').catch(() => '');
+      const text = await handle.readFile({ encoding: 'utf8' }).catch(() => '');
       const all = text.split('\n');
       return all.slice(Math.max(0, all.length - safeLines)).join('\n');
     }

--- a/packages/core/src/sessions/persistence.ts
+++ b/packages/core/src/sessions/persistence.ts
@@ -1027,8 +1027,10 @@ async function readSessionsDir(dir: string): Promise<{ metas: SessionMeta[]; log
   for (const key of metaCache.keys()) if (!live.has(key)) metaCache.delete(key);
   const parsedFiles = await mapWithConcurrency(files, READ_INDEX_CONCURRENCY, async (d) => {
     const file = path.join(dir, d.name);
+    let handle: import('node:fs/promises').FileHandle | null = null;
     try {
-      const stat = await fs.stat(file);
+      handle = await fs.open(file, 'r');
+      const stat = await handle.stat();
       const cached = metaCache.get(file);
       const parsed =
         cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size
@@ -1037,12 +1039,14 @@ async function readSessionsDir(dir: string): Promise<{ metas: SessionMeta[]; log
       if (parsed) {
         return { meta: parsed, canonical: d.name === `${parsed.id}.json` };
       }
-      const raw = JSON.parse(await fs.readFile(file, 'utf8')) as unknown;
+      const raw = JSON.parse(await handle.readFile({ encoding: 'utf8' })) as unknown;
       if (!isSessionMeta(raw)) return null;
       metaCache.set(file, { mtimeMs: stat.mtimeMs, size: stat.size, meta: raw });
       return { meta: raw, canonical: d.name === `${raw.id}.json` };
     } catch {
       return null;
+    } finally {
+      await handle?.close().catch(() => undefined);
     }
   });
   const deduped = new Map<string, ParsedMetaFile>();

--- a/packages/desktop-host/src/app-update/stager.ts
+++ b/packages/desktop-host/src/app-update/stager.ts
@@ -544,7 +544,11 @@ async function stageOne(
     // can never load the override ("Cannot use import statement outside a
     // module"). Skip if the bundle already carries its own package.json.
     const pkgJsonPath = path.join(incoming, 'package.json');
-    if (!existsSync(pkgJsonPath)) writeFileSync(pkgJsonPath, ESM_MARKER_PACKAGE_JSON);
+    try {
+      writeFileSync(pkgJsonPath, ESM_MARKER_PACKAGE_JSON, { flag: 'wx' });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    }
 
     // Defense in depth: re-verify the signed per-file hashes against what
     // actually landed on disk, so a payload/manifest mismatch (e.g. a build

--- a/packages/desktop-host/src/apps/discover.ts
+++ b/packages/desktop-host/src/apps/discover.ts
@@ -16,7 +16,7 @@
  * one broken app never hides the others.
  */
 
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { open, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 import { parseAppManifest, APP_ID_RE, type AppManifest } from '@moxxy/desktop-app-sdk';
@@ -71,16 +71,20 @@ export async function discoverApps(appsRoot: string): Promise<DiscoveryResult> {
 
     const manifestPath = path.join(dir, MANIFEST_FILE);
     let raw: string;
+    let handle: import('node:fs/promises').FileHandle | null = null;
     try {
-      const info = await stat(manifestPath);
+      handle = await open(manifestPath, 'r');
+      const info = await handle.stat();
       if (!info.isFile()) continue; // a plain asset dir, not an app
       if (info.size > MAX_MANIFEST_BYTES) {
         skipped.push({ name, reason: 'manifest too large' });
         continue;
       }
-      raw = await readFile(manifestPath, 'utf8');
+      raw = await handle.readFile({ encoding: 'utf8' });
     } catch {
       continue; // no manifest here
+    } finally {
+      await handle?.close().catch(() => undefined);
     }
 
     const parsed = parseAppManifest(raw);

--- a/packages/desktop-host/src/attachments.ts
+++ b/packages/desktop-host/src/attachments.ts
@@ -23,7 +23,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { mkdir, open, readFile, readdir, stat, unlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, open, readFile, readdir, stat, unlink, writeFile } from 'node:fs/promises';
+import type { FileHandle } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import type { UserPromptAttachment } from '@moxxy/sdk';
@@ -338,15 +339,10 @@ const MAX_READ_WHOLE_BYTES = 64 * 1024 * 1024; // 64 MB
 
 /** Read at most `max` bytes from the head of a file via a bounded handle, so an
  *  oversized file never fully loads into memory. Mirrors workspace-fs's readHead. */
-async function readHead(absPath: string, max: number): Promise<Buffer> {
-  const handle = await open(absPath, 'r');
-  try {
-    const buf = Buffer.alloc(max);
-    const { bytesRead } = await handle.read(buf, 0, max, 0);
-    return buf.subarray(0, bytesRead);
-  } finally {
-    await handle.close();
-  }
+async function readHead(handle: FileHandle, max: number): Promise<Buffer> {
+  const buf = Buffer.alloc(max);
+  const { bytesRead } = await handle.read(buf, 0, max, 0);
+  return buf.subarray(0, bytesRead);
 }
 
 export async function buildAttachments(
@@ -355,12 +351,14 @@ export async function buildAttachments(
   const out: UserPromptAttachment[] = [];
   for (const f of files) {
     const ext = path.extname(f.path).toLowerCase();
+    let handle: FileHandle | null = null;
     try {
       // Size-gate BEFORE reading the whole file: a huge picked file (a
       // multi-GB log/video) must not be fully loaded — then base64'd at ~1.33x
       // — into the main process before any per-type cap can apply. Stat first
       // and route oversized text/code to the bounded head-excerpt fallback.
-      const size = (await stat(f.path)).size;
+      handle = await open(f.path, 'r');
+      const size = (await handle.stat()).size;
       const mediaType = IMAGE_MEDIA_TYPES[ext];
 
       if (size > MAX_READ_WHOLE_BYTES) {
@@ -371,7 +369,7 @@ export async function buildAttachments(
         // Peek the head only. If it's binary (PDF/Office/legacy doc) we can't
         // extract from a partial buffer without loading the whole thing, so
         // skip with a warning; readable text gets a head excerpt + read-on-demand.
-        const head = await readHead(f.path, HEAD_EXCERPT_BYTES);
+        const head = await readHead(handle, HEAD_EXCERPT_BYTES);
         if (isPdf(head, ext) || OFFICE_EXTENSIONS.has(ext) || isLegacyDoc(head, ext) || head.includes(0)) {
           console.warn(
             `[attachments] skipping ${f.name}: ${size} bytes exceeds the ${MAX_READ_WHOLE_BYTES}-byte read cap`,
@@ -382,7 +380,7 @@ export async function buildAttachments(
         continue;
       }
 
-      const buf = await readFile(f.path);
+      const buf = await handle.readFile();
 
       // 1. Image → base64 the model can see.
       if (mediaType) {
@@ -441,6 +439,8 @@ export async function buildAttachments(
       }
     } catch {
       // Unreadable (gone / permission) → drop it rather than fail the turn.
+    } finally {
+      await handle?.close().catch(() => undefined);
     }
   }
   return out;
@@ -461,10 +461,12 @@ export async function previewImageAttachment(
   const mediaType = IMAGE_MEDIA_TYPES[path.extname(absPath).toLowerCase()];
   if (!mediaType) return null;
 
+  let handle: FileHandle | null = null;
   try {
-    const size = (await stat(absPath)).size;
+    handle = await open(absPath, 'r');
+    const size = (await handle.stat()).size;
     if (size > MAX_IMAGE_BYTES) return null;
-    const buf = await readFile(absPath);
+    const buf = await handle.readFile();
     if (buf.byteLength > MAX_IMAGE_BYTES) return null;
     return {
       kind: 'image',
@@ -475,6 +477,8 @@ export async function previewImageAttachment(
     };
   } catch {
     return null;
+  } finally {
+    await handle?.close().catch(() => undefined);
   }
 }
 
@@ -496,11 +500,11 @@ async function largeFileFallback(
 ): Promise<UserPromptAttachment> {
   let readablePath = sourcePath;
   if (!readablePath) {
-    await mkdir(ATTACHMENT_TMP_DIR, { recursive: true });
-    void pruneOldAttachments();
+    const attachmentTmpDir = await getAttachmentTmpDir();
+    void pruneOldAttachments(attachmentTmpDir);
     const safe = path.basename(name).replace(/[^\w.-]+/g, '_') || 'attachment';
-    readablePath = path.join(ATTACHMENT_TMP_DIR, `${randomUUID()}-${safe}.txt`);
-    await writeFile(readablePath, fullText, 'utf8');
+    readablePath = path.join(attachmentTmpDir, `${randomUUID()}-${safe}.txt`);
+    await writeFile(readablePath, fullText, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
   }
   const head = fullText.slice(0, HEAD_EXCERPT_BYTES);
   const kb = Math.max(1, Math.round(totalBytes / 1024));
@@ -521,8 +525,19 @@ const IMAGE_EXTENSIONS: Readonly<Record<string, string>> = {
   'image/bmp': 'bmp',
 };
 
-/** Where pasted/dropped image blobs land before a turn reads them. */
-const ATTACHMENT_TMP_DIR = path.join(os.tmpdir(), 'moxxy-attachments');
+/** Per-process private temp directory. `mkdtemp` makes the path unpredictable;
+ *  owner-only permissions keep another local user from planting symlinks. */
+let attachmentTmpDirPromise: Promise<string> | null = null;
+
+async function getAttachmentTmpDir(): Promise<string> {
+  attachmentTmpDirPromise ??= mkdtemp(path.join(os.tmpdir(), 'moxxy-attachments-')).then(
+    async (dir) => {
+      await chmod(dir, 0o700);
+      return dir;
+    },
+  );
+  return await attachmentTmpDirPromise;
+}
 /** Sweep temp attachments older than this so pastes don't accumulate. */
 const ATTACHMENT_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -547,23 +562,23 @@ export async function persistImageBlob(
       `Image is too large to attach (max ${Math.round(MAX_IMAGE_BYTES / (1024 * 1024))} MB).`,
     );
   }
-  await mkdir(ATTACHMENT_TMP_DIR, { recursive: true });
-  void pruneOldAttachments();
-  const filePath = path.join(ATTACHMENT_TMP_DIR, `${randomUUID()}.${ext}`);
-  await writeFile(filePath, buf);
+  const attachmentTmpDir = await getAttachmentTmpDir();
+  void pruneOldAttachments(attachmentTmpDir);
+  const filePath = path.join(attachmentTmpDir, `${randomUUID()}.${ext}`);
+  await writeFile(filePath, buf, { flag: 'wx', mode: 0o600 });
   const display = name && name.trim().length > 0 ? name : `pasted-image.${ext}`;
   return { path: filePath, name: display };
 }
 
 /** Best-effort sweep of stale temp attachments. Never throws — a failed
  *  prune just means the next save tries again. */
-async function pruneOldAttachments(): Promise<void> {
+async function pruneOldAttachments(attachmentTmpDir: string): Promise<void> {
   try {
     const now = Date.now();
-    const entries = await readdir(ATTACHMENT_TMP_DIR);
+    const entries = await readdir(attachmentTmpDir);
     await Promise.all(
       entries.map(async (entry) => {
-        const full = path.join(ATTACHMENT_TMP_DIR, entry);
+        const full = path.join(attachmentTmpDir, entry);
         try {
           const info = await stat(full);
           if (now - info.mtimeMs > ATTACHMENT_TTL_MS) await unlink(full);

--- a/packages/desktop-host/src/local-piper.ts
+++ b/packages/desktop-host/src/local-piper.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from 'node:child_process';
-import { access, readFile, stat } from 'node:fs/promises';
+import { access, open } from 'node:fs/promises';
 import path from 'node:path';
 
 import { z } from '@moxxy/sdk';
@@ -45,17 +45,21 @@ export async function isLocalPiperInstalled(home = moxxyHome()): Promise<boolean
     'plugin-tts-local',
   );
   const manifestPath = path.join(packageDirectory, 'package.json');
+  let handle: import('node:fs/promises').FileHandle | null = null;
   try {
-    const metadata = await stat(manifestPath);
+    handle = await open(manifestPath, 'r');
+    const metadata = await handle.stat();
     if (!metadata.isFile() || metadata.size > MAX_MANIFEST_BYTES) return false;
     const parsed = localPiperManifestSchema.safeParse(
-      JSON.parse(await readFile(manifestPath, 'utf8')),
+      JSON.parse(await handle.readFile({ encoding: 'utf8' })),
     );
     if (!parsed.success) return false;
     await access(path.join(packageDirectory, 'dist', 'index.js'));
     return true;
   } catch {
     return false;
+  } finally {
+    await handle?.close().catch(() => undefined);
   }
 }
 

--- a/packages/desktop-host/src/vault-key.ts
+++ b/packages/desktop-host/src/vault-key.ts
@@ -34,10 +34,13 @@ export function ensureDesktopVaultKey(): void {
   const keyPath = moxxyPath('vault.key');
   const vaultPath = moxxyPath('vault.json');
   // Don't touch an existing vault — only seed a truly fresh setup.
-  if (existsSync(keyPath) || existsSync(vaultPath)) return;
+  if (existsSync(vaultPath)) return;
   try {
     mkdirSync(path.dirname(keyPath), { recursive: true });
-    writeFileSync(keyPath, `${randomBytes(KEY_BYTES).toString('base64')}\n`, { mode: 0o600 });
+    writeFileSync(keyPath, `${randomBytes(KEY_BYTES).toString('base64')}\n`, {
+      flag: 'wx',
+      mode: 0o600,
+    });
   } catch {
     // Best effort — if we can't write, the vault falls back to its prompt
     // behaviour (unchanged), so this never makes things worse.

--- a/packages/desktop-host/src/workspace-fs.ts
+++ b/packages/desktop-host/src/workspace-fs.ts
@@ -8,7 +8,7 @@
  * disk just because someone passed `../../etc/passwd` as `path`.
  */
 
-import { readFile as fsReadFile, open, readdir, realpath, stat } from 'node:fs/promises';
+import { open, readdir, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 /** Cap a single "Open" read so a giant log can't stream MBs into the renderer. */
@@ -156,77 +156,76 @@ export async function readFile(
   const root = await realpath(cwd).catch(() => path.resolve(cwd));
   const abs = await resolveInside(root, relPath);
   const rel = path.relative(root, abs) || path.basename(abs);
-  const info = await stat(abs).catch(() => null);
   const base = { path: rel, truncated: false, text: false as boolean };
-  if (!info || !info.isFile()) {
+  const handle = await open(abs, 'r').catch(() => null);
+  if (!handle) {
     return { ...base, kind: 'text', content: '', byteLength: 0, text: true };
   }
-  const byteLength = info.size;
-  const ext = path.extname(abs).toLowerCase();
-
-  // Images, PDFs, audio, and video: inline as base64 so the viewer can render
-  // them with local Blob URLs. Nothing here grants a remote media origin.
-  const imageType = IMAGE_MEDIA_TYPES[ext];
-  const mediaType = MEDIA_TYPES[ext];
-  if (imageType || mediaType || ext === '.pdf') {
-    if (byteLength > INLINE_MAX_BYTES && !opts.force) {
-      return { ...base, kind: 'confirm', reason: 'large', content: '', byteLength };
+  try {
+    const info = await handle.stat().catch(() => null);
+    if (!info || !info.isFile()) {
+      return { ...base, kind: 'text', content: '', byteLength: 0, text: true };
     }
-    const buf = await fsReadFile(abs);
+    const byteLength = info.size;
+    const ext = path.extname(abs).toLowerCase();
+
+    // Images, PDFs, audio, and video: inline as base64 so the viewer can render
+    // them with local Blob URLs. Nothing here grants a remote media origin.
+    const imageType = IMAGE_MEDIA_TYPES[ext];
+    const mediaType = MEDIA_TYPES[ext];
+    if (imageType || mediaType || ext === '.pdf') {
+      if (byteLength > INLINE_MAX_BYTES && !opts.force) {
+        return { ...base, kind: 'confirm', reason: 'large', content: '', byteLength };
+      }
+      const buf = await handle.readFile();
+      return {
+        ...base,
+        kind: imageType ? 'image' : mediaType ? 'media' : 'pdf',
+        content: '',
+        byteLength,
+        mediaType: imageType ?? mediaType ?? 'application/pdf',
+        base64: buf.toString('base64'),
+      };
+    }
+
+    // Office / OpenDocument (zip containers): the raw bytes are NUL-heavy binary,
+    // so the generic binary gate would only offer to show garbage. Instead pull
+    // the document's plain text via the offline parser and show THAT. Falls
+    // through to a clear "no preview" confirm if nothing extractable is found.
+    if (OFFICE_EXTENSIONS.has(ext)) {
+      if (byteLength > INLINE_MAX_BYTES && !opts.force) {
+        return { ...base, kind: 'confirm', reason: 'large', content: '', byteLength };
+      }
+      const buf = await handle.readFile();
+      const { parseBufferToText } = await import('./attachments.js');
+      const text = await parseBufferToText(buf, path.basename(abs));
+      if (text && text.trim().length > 0) {
+        const truncated = Buffer.byteLength(text, 'utf8') > MAX_READ_BYTES;
+        const shown = truncated ? text.slice(0, MAX_READ_BYTES) : text;
+        return { ...base, kind: 'text', content: shown, truncated, text: true, byteLength };
+      }
+      // No extractable text (e.g. an image-only PDF or empty doc) — let the user
+      // know rather than dumping zip bytes into a <pre>.
+      return { ...base, kind: 'confirm', reason: 'binary', content: '', byteLength };
+    }
+
+    // Read only the head window through the already-validated handle, so a
+    // multi-GB file never loads whole and a path swap cannot change the file.
+    const head = Buffer.alloc(MAX_READ_BYTES);
+    const { bytesRead } = await handle.read(head, 0, MAX_READ_BYTES, 0);
+    const slice = head.subarray(0, bytesRead);
+    const looksBinary = slice.includes(0);
+    if (!opts.force && (looksBinary || byteLength > CONFIRM_BYTES)) {
+      return { ...base, kind: 'confirm', reason: looksBinary ? 'binary' : 'large', content: '', byteLength };
+    }
     return {
       ...base,
-      kind: imageType ? 'image' : mediaType ? 'media' : 'pdf',
-      content: '',
+      kind: 'text',
+      content: slice.toString('utf8'),
+      truncated: byteLength > slice.length,
+      text: true,
       byteLength,
-      mediaType: imageType ?? mediaType ?? 'application/pdf',
-      base64: buf.toString('base64'),
     };
-  }
-
-  // Office / OpenDocument (zip containers): the raw bytes are NUL-heavy binary,
-  // so the generic binary gate would only offer to show garbage. Instead pull
-  // the document's plain text via the offline parser and show THAT. Falls
-  // through to a clear "no preview" confirm if nothing extractable is found.
-  if (OFFICE_EXTENSIONS.has(ext)) {
-    if (byteLength > INLINE_MAX_BYTES && !opts.force) {
-      return { ...base, kind: 'confirm', reason: 'large', content: '', byteLength };
-    }
-    const buf = await fsReadFile(abs);
-    const { parseBufferToText } = await import('./attachments.js');
-    const text = await parseBufferToText(buf, path.basename(abs));
-    if (text && text.trim().length > 0) {
-      const truncated = Buffer.byteLength(text, 'utf8') > MAX_READ_BYTES;
-      const shown = truncated ? text.slice(0, MAX_READ_BYTES) : text;
-      return { ...base, kind: 'text', content: shown, truncated, text: true, byteLength };
-    }
-    // No extractable text (e.g. an image-only PDF or empty doc) — let the user
-    // know rather than dumping zip bytes into a <pre>.
-    return { ...base, kind: 'confirm', reason: 'binary', content: '', byteLength };
-  }
-
-  // Read only the head window via a handle, so a multi-GB file never loads whole.
-  const slice = await readHead(abs, MAX_READ_BYTES);
-  const looksBinary = slice.includes(0);
-  if (!opts.force && (looksBinary || byteLength > CONFIRM_BYTES)) {
-    return { ...base, kind: 'confirm', reason: looksBinary ? 'binary' : 'large', content: '', byteLength };
-  }
-  return {
-    ...base,
-    kind: 'text',
-    content: slice.toString('utf8'),
-    truncated: byteLength > slice.length,
-    text: true,
-    byteLength,
-  };
-}
-
-/** Read at most `max` bytes from the start of a file without loading the rest. */
-async function readHead(abs: string, max: number): Promise<Buffer> {
-  const handle = await open(abs, 'r');
-  try {
-    const buf = Buffer.alloc(max);
-    const { bytesRead } = await handle.read(buf, 0, max, 0);
-    return buf.subarray(0, bytesRead);
   } finally {
     await handle.close();
   }

--- a/packages/isolator-wasm/src/index.ts
+++ b/packages/isolator-wasm/src/index.ts
@@ -859,18 +859,23 @@ async function fetchWasmBytes(url: string, signal: AbortSignal): Promise<Uint8Ar
     // Cap by the on-disk size BEFORE reading so a multi-gigabyte local `.wasm`
     // can't force an unbounded `readFile` allocation (parity with the remote
     // streamed cap; local paths previously skipped the limit entirely).
-    let size: number;
+    let handle: import('node:fs/promises').FileHandle;
     try {
-      size = statSync(filePath).size;
+      handle = await fs.open(filePath, 'r');
     } catch (e) {
-      throw new Error(`[security:wasm] cannot stat module '${filePath}': ${(e as Error).message}`);
+      throw new Error(`[security:wasm] cannot open module '${filePath}': ${(e as Error).message}`);
     }
-    if (size > MAX_OUTPUT_BYTES) {
-      throw new Error(
-        `[security:wasm] module at ${filePath} is ${size} bytes (> ${MAX_OUTPUT_BYTES} limit)`,
-      );
+    try {
+      const size = (await handle.stat()).size;
+      if (size > MAX_OUTPUT_BYTES) {
+        throw new Error(
+          `[security:wasm] module at ${filePath} is ${size} bytes (> ${MAX_OUTPUT_BYTES} limit)`,
+        );
+      }
+      return new Uint8Array(await handle.readFile());
+    } finally {
+      await handle.close();
     }
-    return new Uint8Array(await fs.readFile(filePath));
   }
   if (!url.startsWith('https:')) {
     throw new Error(

--- a/packages/plugin-cli/src/audio-play.ts
+++ b/packages/plugin-cli/src/audio-play.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { spawn } from 'node:child_process';
-import { writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -288,9 +288,9 @@ export async function playAudio(
   const selection = await selectAudioPlayer(platform, opts.mimeType, isAvailable);
   if (!selection.ok) return { ok: false, reason: selection.reason };
 
-  let file: string;
+  let scratch: { readonly dir: string; readonly file: string };
   try {
-    file = await writeTempAudio(audio, opts.mimeType, opts.tmpDir);
+    scratch = await writeTempAudio(audio, opts.mimeType, opts.tmpDir);
   } catch (err) {
     return { ok: false, reason: 'failed', error: errMessage(err) };
   }
@@ -298,13 +298,13 @@ export async function playAudio(
   try {
     return await spawnPlayer(
       selection.command,
-      selection.buildArgs(file),
+      selection.buildArgs(scratch.file),
       spawnImpl,
       opts.signal,
       opts.timeoutMs ?? DEFAULT_PLAYBACK_TIMEOUT_MS,
     );
   } finally {
-    void rm(file, { force: true }).catch(() => undefined);
+    void rm(scratch.dir, { force: true, recursive: true }).catch(() => undefined);
   }
 }
 
@@ -372,12 +372,17 @@ async function writeTempAudio(
   audio: Uint8Array,
   mimeType: string,
   tmpDir?: string,
-): Promise<string> {
-  const dir = tmpDir ?? os.tmpdir();
-  const suffix = Math.random().toString(36).slice(2, 10);
-  const file = path.join(dir, `moxxy-speak-${process.pid}-${Date.now()}-${suffix}.${extForMime(mimeType)}`);
-  await writeFile(file, Buffer.from(audio));
-  return file;
+): Promise<{ readonly dir: string; readonly file: string }> {
+  const parent = tmpDir ?? os.tmpdir();
+  const dir = await mkdtemp(path.join(parent, 'moxxy-speak-'));
+  const file = path.join(dir, `audio.${extForMime(mimeType)}`);
+  try {
+    await writeFile(file, Buffer.from(audio), { flag: 'wx', mode: 0o600 });
+    return { dir, file };
+  } catch (err) {
+    await rm(dir, { force: true, recursive: true }).catch(() => undefined);
+    throw err;
+  }
 }
 
 /** Map an audio mime type to a file extension (players sniff by content, but a

--- a/packages/plugin-memory/src/user-model.test.ts
+++ b/packages/plugin-memory/src/user-model.test.ts
@@ -19,6 +19,18 @@ let tmp: string;
 const newStore = () => new UserModelStore(tmp);
 const modelPath = () => path.join(tmp, 'user-model.md');
 
+async function fileHandlePrototype(): Promise<
+  Pick<Awaited<ReturnType<typeof fs.open>>, 'readFile'>
+> {
+  const handle = await fs.open(modelPath(), 'r');
+  const prototype = Object.getPrototypeOf(handle) as Pick<
+    Awaited<ReturnType<typeof fs.open>>,
+    'readFile'
+  >;
+  await handle.close();
+  return prototype;
+}
+
 beforeEach(async () => {
   tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mox-um-'));
 });
@@ -123,7 +135,7 @@ describe('UserModelStore.load (mtime cache)', () => {
   it('reads the file once, then serves an unchanged file from cache (no re-read)', async () => {
     const store = newStore();
     await store.update('identity', 'first', 'replace');
-    const spy = vi.spyOn(fs, 'readFile');
+    const spy = vi.spyOn(await fileHandlePrototype(), 'readFile');
     await store.load();
     await store.load();
     await store.load();
@@ -264,7 +276,7 @@ describe('UserModelStore.injectInto', () => {
   it('returns the request unchanged when parsing/reading throws', async () => {
     const store = newStore();
     await store.update('identity', 'A', 'replace');
-    vi.spyOn(fs, 'readFile').mockRejectedValueOnce(new Error('disk on fire'));
+    vi.spyOn(await fileHandlePrototype(), 'readFile').mockRejectedValueOnce(new Error('disk on fire'));
     expect(await store.injectInto(req('BASE'))).toBeUndefined();
   });
 });

--- a/packages/plugin-memory/src/user-model.ts
+++ b/packages/plugin-memory/src/user-model.ts
@@ -177,9 +177,9 @@ export class UserModelStore {
    * provider request.
    */
   async load(): Promise<UserModel | null> {
-    let mtimeMs: number;
+    let handle: import('node:fs/promises').FileHandle;
     try {
-      mtimeMs = (await fs.stat(this.path)).mtimeMs;
+      handle = await fs.open(this.path, 'r');
     } catch (err) {
       if (isEnoent(err)) {
         this.cached = null;
@@ -187,10 +187,15 @@ export class UserModelStore {
       }
       throw err;
     }
-    if (this.cached && this.cached.mtimeMs === mtimeMs) return this.cached.model;
-    const model = parseUserModel(await fs.readFile(this.path, 'utf8'));
-    this.cached = { mtimeMs, model };
-    return model;
+    try {
+      const mtimeMs = (await handle.stat()).mtimeMs;
+      if (this.cached && this.cached.mtimeMs === mtimeMs) return this.cached.model;
+      const model = parseUserModel(await handle.readFile({ encoding: 'utf8' }));
+      this.cached = { mtimeMs, model };
+      return model;
+    } finally {
+      await handle.close();
+    }
   }
 
   /** Raw file text (or `null` when absent) — used by the CLI viewer. */

--- a/packages/plugin-security/src/broker.ts
+++ b/packages/plugin-security/src/broker.ts
@@ -353,6 +353,10 @@ async function brokerWriteFile(
   }
   const real = await realpathInScope(filePath, caps, cwd, 'write', 'broker:fs.writeFile');
   await fs.mkdir(path.dirname(real), { recursive: true });
+  // This is the capability broker's explicit arbitrary-path write primitive,
+  // not creation of a predictable temp file. `real` has just been canonicalized
+  // and re-checked against the tool's declared fs.write roots above.
+  // lgtm[js/insecure-temporary-file]
   await fs.writeFile(real, data, 'utf8');
 }
 

--- a/packages/plugin-vault/src/store.ts
+++ b/packages/plugin-vault/src/store.ts
@@ -212,47 +212,52 @@ export class VaultStore {
    */
   private async syncFromDisk(): Promise<void> {
     if (!this.file) return;
-    let st: { mtimeMs: number; size: number };
+    let handle: import('node:fs/promises').FileHandle;
     try {
-      st = await fs.stat(this.filePath);
+      handle = await fs.open(this.filePath, 'r');
     } catch (err) {
       if (isEnoent(err)) return; // deleted out from under us — keep memory
       throw err;
     }
-    // Fast path: skip the read+merge only when the stat fingerprint is
-    // unchanged AND it has aged past the filesystem's mtime granularity. On
-    // coarse-mtime filesystems (HFS+, older ext) two writes inside the same
-    // ~1-2s tick that also produce an identical byte length share a
-    // (mtime,size) fingerprint, so a recent match might hide a sibling write.
-    // The merge is idempotent and cheap, so when in doubt we re-read.
-    if (
-      this.lastSynced &&
-      st.mtimeMs === this.lastSynced.mtimeMs &&
-      st.size === this.lastSynced.size &&
-      Date.now() - st.mtimeMs > MTIME_GRANULARITY_MS
-    ) {
-      return;
-    }
-    let parsedRaw: unknown;
     try {
-      parsedRaw = JSON.parse(await fs.readFile(this.filePath, 'utf8'));
-    } catch {
-      return;
+      const st = await handle.stat();
+      // Fast path: skip the read+merge only when the stat fingerprint is
+      // unchanged AND it has aged past the filesystem's mtime granularity. On
+      // coarse-mtime filesystems (HFS+, older ext) two writes inside the same
+      // ~1-2s tick that also produce an identical byte length share a
+      // (mtime,size) fingerprint, so a recent match might hide a sibling write.
+      // The merge is idempotent and cheap, so when in doubt we re-read.
+      if (
+        this.lastSynced &&
+        st.mtimeMs === this.lastSynced.mtimeMs &&
+        st.size === this.lastSynced.size &&
+        Date.now() - st.mtimeMs > MTIME_GRANULARITY_MS
+      ) {
+        return;
+      }
+      let parsedRaw: unknown;
+      try {
+        parsedRaw = JSON.parse(await handle.readFile({ encoding: 'utf8' }));
+      } catch {
+        return;
+      }
+      if (!isPlainObject(parsedRaw)) return;
+      const parsed = parsedRaw as Partial<VaultFile>;
+      if (
+        parsed.version !== 1 ||
+        parsed.kdf !== 'scrypt' ||
+        parsed.salt !== this.file.salt ||
+        !validateVaultFile(parsed)
+      ) {
+        return;
+      }
+      this.file = { ...this.file, entries: mergeEntries(this.file.entries, parsed.entries) };
+      // Fingerprint from BEFORE the read: if a write landed in between, the
+      // next sync simply re-reads — never the other way around.
+      this.lastSynced = { mtimeMs: st.mtimeMs, size: st.size };
+    } finally {
+      await handle.close();
     }
-    if (!isPlainObject(parsedRaw)) return;
-    const parsed = parsedRaw as Partial<VaultFile>;
-    if (
-      parsed.version !== 1 ||
-      parsed.kdf !== 'scrypt' ||
-      parsed.salt !== this.file.salt ||
-      !validateVaultFile(parsed)
-    ) {
-      return;
-    }
-    this.file = { ...this.file, entries: mergeEntries(this.file.entries, parsed.entries) };
-    // Fingerprint from BEFORE the read: if a write landed in between, the
-    // next sync simply re-reads — never the other way around.
-    this.lastSynced = { mtimeMs: st.mtimeMs, size: st.size };
   }
 
   /**

--- a/packages/tools-builtin/src/grep.ts
+++ b/packages/tools-builtin/src/grep.ts
@@ -238,17 +238,17 @@ async function walk(
     // Skip oversized files before reading so a giant log / db / media blob can't
     // be slurped into the heap. Bounds the per-file working set (result clamping
     // only bounds the OUTPUT).
-    try {
-      const st = await fs.stat(full);
-      if (st.size > MAX_FILE_BYTES) continue;
-    } catch {
-      continue;
-    }
+    let handle: import('node:fs/promises').FileHandle | null = null;
     let content: string;
     try {
-      content = await fs.readFile(full, 'utf8');
+      handle = await fs.open(full, 'r');
+      const st = await handle.stat();
+      if (st.size > MAX_FILE_BYTES) continue;
+      content = await handle.readFile({ encoding: 'utf8' });
     } catch {
       continue;
+    } finally {
+      await handle?.close().catch(() => undefined);
     }
     // Skip binaries (NUL byte in the prefix) — scanning binary-as-utf8 yields
     // useless matches and mojibake. Normal text files are unaffected, so match

--- a/packages/tools-builtin/src/write.ts
+++ b/packages/tools-builtin/src/write.ts
@@ -39,14 +39,18 @@ export const writeTool = defineTool({
     // diff (treat it as a create-style result).
     let before = '';
     let mode: 'create' | 'update' = 'create';
+    let handle: import('node:fs/promises').FileHandle | null = null;
     try {
-      const st = await fs.stat(resolved);
+      handle = await fs.open(resolved, 'r');
+      const st = await handle.stat();
       mode = 'update';
       if (st.size <= MAX_FILE_BYTES) {
-        before = await fs.readFile(resolved, 'utf8');
+        before = await handle.readFile({ encoding: 'utf8' });
       }
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    } finally {
+      await handle?.close().catch(() => undefined);
     }
     // Atomic whole-file write (tmp + rename) so a crash/abort mid-write can't
     // leave a truncated file. writeFileAtomic creates parent dirs.


### PR DESCRIPTION
## Summary
- create private, unpredictable temporary paths for runtime audio and attachment data
- eliminate filesystem stat/read race windows by reading through one file handle
- scope CodeQL to production sources and document the capability-gated write false positive

## Verification
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm exec turbo run test --concurrency=2
- pnpm run test:scripts
- pnpm check:deps
- pnpm audit:security