### PR TITLE
fix(security): harden input sanitization

### DIFF
--- a/.changeset/quiet-sanitizers-lock.md
+++ b/.changeset/quiet-sanitizers-lock.md
@@ -1,0 +1,6 @@
+---
+'@moxxy/cli': patch
+'@moxxy/sdk': patch
+---
+
+Harden HTML, URL, command argument, and frontmatter sanitization across user-facing runtimes.

--- a/apps/mobile/src/sessionActions.ts
+++ b/apps/mobile/src/sessionActions.ts
@@ -115,7 +115,9 @@ export function encodeSessionCommandArgs(values: ReadonlyArray<string>): string 
     .map((value) => {
       const trimmed = value.trim();
       if (!trimmed) return '';
-      return /\s|"/.test(trimmed) ? `"${trimmed.replace(/"/g, '\\"')}"` : trimmed;
+      return /[\s"\\]/.test(trimmed)
+        ? `"${trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+        : trimmed;
     })
     .filter(Boolean)
     .join(' ');

--- a/apps/mobile/test/sessionActions.test.ts
+++ b/apps/mobile/test/sessionActions.test.ts
@@ -44,8 +44,8 @@ describe('buildMobileSessionActionRows', () => {
 
 describe('encodeSessionCommandArgs', () => {
   it('quotes command arguments the same way for mobile action forms', () => {
-    expect(encodeSessionCommandArgs(['alpha beta', 'plain', 'needs"quote'])).toBe(
-      '"alpha beta" plain "needs\\"quote"',
+    expect(encodeSessionCommandArgs(['alpha beta', 'plain', 'needs"quote', 'c:\\path'])).toBe(
+      '"alpha beta" plain "needs\\"quote" "c:\\\\path"',
     );
   });
 

--- a/packages/cli/src/commands/service/render.test.ts
+++ b/packages/cli/src/commands/service/render.test.ts
@@ -76,14 +76,14 @@ describe('renderUnit (systemd)', () => {
     expect(out).toContain('Environment=LEVEL=info');
   });
 
-  it('quotes only ExecStart args that contain whitespace or quotes', () => {
+  it('quotes and escapes ExecStart args with whitespace, quotes, or backslashes', () => {
     const spec: ServiceSpec = {
       id: 'x',
       description: 'd',
-      execArgs: ['plain', 'two words', 'has"quote'],
+      execArgs: ['plain', 'two words', 'has"quote', 'c:\\path'],
     };
     const out = renderUnit(spec, ctx);
-    expect(out).toContain('plain "two words" "has\\"quote"');
+    expect(out).toContain('plain "two words" "has\\"quote" "c:\\\\path"');
   });
 
   it('quotes Environment= values containing whitespace/quotes/backslashes', () => {

--- a/packages/cli/src/commands/service/systemd.ts
+++ b/packages/cli/src/commands/service/systemd.ts
@@ -48,8 +48,8 @@ WantedBy=default.target
 
 function quote(s: string): string {
   // systemd ExecStart tokenizes unquoted args; quote only when needed.
-  if (!/[\s"]/.test(s)) return s;
-  return '"' + s.replace(/"/g, '\\"') + '"';
+  if (!/[\s"\\]/.test(s)) return s;
+  return '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
 }
 
 /**

--- a/packages/model-fetch/src/fetch-asset.ts
+++ b/packages/model-fetch/src/fetch-asset.ts
@@ -37,13 +37,10 @@ export const DEFAULT_ALLOWED_HOSTS: readonly string[] = [
   'cdn-lfs.huggingface.co',
 ];
 
-/** Compile bare hostnames into exact-or-subdomain matchers. The hostname is
- *  regex-escaped so a `.` can never act as a wildcard. */
-function compileHosts(hosts: readonly string[]): RegExp[] {
-  return hosts.map((h) => {
-    const escaped = h.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(`(^|\\.)${escaped}$`);
-  });
+/** Exact host or a real DNS subdomain — never a suffix lookalike. */
+function hostMatches(hostname: string, allowedHost: string): boolean {
+  const allowed = allowedHost.toLowerCase();
+  return hostname === allowed || hostname.endsWith(`.${allowed}`);
 }
 
 /** Whether `url` is a fetch target we may reach: `https:` on an allow-listed
@@ -59,7 +56,8 @@ export function isAllowedAssetUrl(
     return false;
   }
   if (u.protocol !== 'https:') return false;
-  return compileHosts(allowedHosts).some((re) => re.test(u.hostname));
+  const hostname = u.hostname.toLowerCase();
+  return allowedHosts.some((allowedHost) => hostMatches(hostname, allowedHost));
 }
 
 /** Default hard ceiling on a single downloaded asset (1 GiB). Bounds a

--- a/packages/plugin-browser/src/html-extract.ts
+++ b/packages/plugin-browser/src/html-extract.ts
@@ -11,10 +11,6 @@ export interface ExtractOptions {
   selector?: string;
 }
 
-const COMMENT_RE = /<!--[\s\S]*?-->/g;
-const SCRIPT_RE = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
-const STYLE_RE = /<style\b[^>]*>[\s\S]*?<\/style>/gi;
-
 /**
  * Hard ceiling on the HTML fed to the regex extractors. web_fetch caps the raw
  * body at up to 20MB (maxBytes), but the lazy `[\s\S]*?` passes here run
@@ -39,13 +35,10 @@ function capInput(html: string): string {
  * Collapses whitespace. Decodes the common HTML entities.
  */
 export function htmlToPlainText(html: string, opts: ExtractOptions = {}): string {
-  let body = sliceBySelector(capInput(html), opts.selector);
-  body = body.replace(COMMENT_RE, '');
-  body = body.replace(SCRIPT_RE, '');
-  body = body.replace(STYLE_RE, '');
+  let body = removeNonContent(sliceBySelector(capInput(html), opts.selector));
   body = body.replace(/<br\b[^>]*>/gi, '\n');
   body = body.replace(/<\/(p|div|li|tr|h[1-6])>/gi, '\n');
-  body = body.replace(/<[^>]+>/g, '');
+  body = stripMarkupTags(body);
   body = decodeEntities(body);
   return collapseWhitespace(body);
 }
@@ -55,10 +48,7 @@ export function htmlToPlainText(html: string, opts: ExtractOptions = {}): string
  * paragraphs. Falls through to plain-text rules for unknown structure.
  */
 export function htmlToMarkdown(html: string, opts: ExtractOptions = {}): string {
-  let body = sliceBySelector(capInput(html), opts.selector);
-  body = body.replace(COMMENT_RE, '');
-  body = body.replace(SCRIPT_RE, '');
-  body = body.replace(STYLE_RE, '');
+  let body = removeNonContent(sliceBySelector(capInput(html), opts.selector));
 
   // headings
   body = body.replace(/<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi, (_, lvl: string, inner: string) =>
@@ -91,7 +81,7 @@ export function htmlToMarkdown(html: string, opts: ExtractOptions = {}): string 
   // line breaks
   body = body.replace(/<br\b[^>]*>/gi, '\n');
   body = body.replace(/<\/?p\b[^>]*>/gi, '\n\n');
-  body = body.replace(/<[^>]+>/g, '');
+  body = stripMarkupTags(body);
   body = decodeEntities(body);
   return collapseWhitespace(body);
 }
@@ -107,7 +97,85 @@ function collapseWhitespace(s: string): string {
 }
 
 function stripTags(s: string): string {
-  return s.replace(/<[^>]+>/g, '');
+  return stripMarkupTags(s);
+}
+
+/** Remove comments plus script/style elements in one left-to-right pass.
+ *  Regex replacement can join two fragments into a fresh opening tag; this
+ *  scanner only recognizes tags that existed in the original input. */
+function removeNonContent(html: string): string {
+  const lower = html.toLowerCase();
+  const out: string[] = [];
+  let copiedUntil = 0;
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const start = lower.indexOf('<', cursor);
+    if (start === -1) break;
+
+    let end = -1;
+    if (lower.startsWith('<!--', start)) {
+      const close = lower.indexOf('-->', start + 4);
+      end = close === -1 ? html.length : close + 3;
+    } else if (isOpeningTag(lower, start, 'script')) {
+      end = endOfElement(lower, start, 'script');
+    } else if (isOpeningTag(lower, start, 'style')) {
+      end = endOfElement(lower, start, 'style');
+    }
+
+    if (end === -1) {
+      cursor = start + 1;
+      continue;
+    }
+    out.push(html.slice(copiedUntil, start));
+    copiedUntil = end;
+    cursor = end;
+  }
+
+  out.push(html.slice(copiedUntil));
+  return out.join('');
+}
+
+function isOpeningTag(lower: string, start: number, tag: string): boolean {
+  if (!lower.startsWith(`<${tag}`, start)) return false;
+  const boundary = lower[start + tag.length + 1];
+  return boundary === undefined || boundary === '>' || boundary === '/' || /\s/.test(boundary);
+}
+
+function endOfElement(lower: string, start: number, tag: string): number {
+  const openEnd = lower.indexOf('>', start + tag.length + 1);
+  if (openEnd === -1) return lower.length;
+  const closeToken = `</${tag}`;
+  let close = lower.indexOf(closeToken, openEnd + 1);
+  while (close !== -1) {
+    const boundary = lower[close + closeToken.length];
+    if (boundary === undefined || boundary === '>' || /\s/.test(boundary)) {
+      const closeEnd = lower.indexOf('>', close + closeToken.length);
+      return closeEnd === -1 ? lower.length : closeEnd + 1;
+    }
+    close = lower.indexOf(closeToken, close + closeToken.length);
+  }
+  return lower.length;
+}
+
+/** Strip markup without repeated replacements that can synthesize new tags. */
+function stripMarkupTags(input: string): string {
+  const out: string[] = [];
+  let cursor = 0;
+  while (cursor < input.length) {
+    if (input[cursor] !== '<') {
+      out.push(input[cursor] ?? '');
+      cursor += 1;
+      continue;
+    }
+    const end = input.indexOf('>', cursor + 1);
+    if (end === -1) {
+      out.push(input.slice(cursor));
+      break;
+    }
+    cursor = end + 1;
+  }
+  return out.join('');
 }
 
 function decodeEntities(s: string): string {

--- a/packages/plugin-browser/src/web-fetch.test.ts
+++ b/packages/plugin-browser/src/web-fetch.test.ts
@@ -31,6 +31,21 @@ describe('htmlToPlainText', () => {
     expect(text).not.toContain('color:red');
   });
 
+  it('does not synthesize executable tags across removed element boundaries', () => {
+    const html = '<scr<script>hidden()</script>ipt>visible</script><p>after</p>';
+    const text = htmlToPlainText(html);
+    expect(text).toContain('visible');
+    expect(text).toContain('after');
+    expect(text).not.toContain('hidden');
+    expect(text).not.toContain('<script');
+  });
+
+  it('drops unterminated script/style/comment tails', () => {
+    expect(htmlToPlainText('<p>safe</p><!-- hidden')).toBe('safe');
+    expect(htmlToPlainText('<p>safe</p><script>hidden')).toBe('safe');
+    expect(htmlToMarkdown('<p>safe</p><style>hidden')).toBe('safe');
+  });
+
   it('decodes HTML entities', () => {
     expect(htmlToPlainText('<p>a&amp;b &lt; c &gt; d &quot;e&quot;</p>')).toBe('a&b < c > d "e"');
   });

--- a/packages/plugin-browser/src/web-search.test.ts
+++ b/packages/plugin-browser/src/web-search.test.ts
@@ -23,6 +23,19 @@ describe('parseDuckDuckGoHtml', () => {
       { title: 'Docs', url: 'https://docs.example.org/page', snippet: 'Useful docs.' },
     ]);
   });
+
+  it('does not trust a hostname that merely ends with the DuckDuckGo name', () => {
+    const html = `
+      <a class="result__a" href="https://evilduckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2F">
+        Lookalike redirect
+      </a>`;
+    expect(parseDuckDuckGoHtml(html)).toEqual([
+      {
+        title: 'Lookalike redirect',
+        url: 'https://evilduckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2F',
+      },
+    ]);
+  });
 });
 
 describe('web_search tool', () => {

--- a/packages/plugin-browser/src/web-search.ts
+++ b/packages/plugin-browser/src/web-search.ts
@@ -138,7 +138,9 @@ function normalizeResultUrl(rawHref: string): string | null {
   } catch {
     return null;
   }
-  const redirected = parsed.hostname.endsWith('duckduckgo.com') && parsed.pathname === '/l/'
+  const isDuckDuckGo =
+    parsed.hostname === 'duckduckgo.com' || parsed.hostname.endsWith('.duckduckgo.com');
+  const redirected = isDuckDuckGo && parsed.pathname === '/l/'
     ? parsed.searchParams.get('uddg')
     : null;
   if (redirected) {

--- a/packages/plugin-telegram/src/channel/html.test.ts
+++ b/packages/plugin-telegram/src/channel/html.test.ts
@@ -6,6 +6,10 @@ describe('stripHtml', () => {
     expect(stripHtml('<b>bold</b> and <code>code</code>')).toBe('bold and code');
   });
 
+  it('does not create a fresh tag when adjacent markup is removed', () => {
+    expect(stripHtml('<scr<script>hidden</script>ipt>visible</script>')).toBe('hiddenipt>visible');
+  });
+
   it('decodes the four named entities', () => {
     expect(stripHtml('a &lt; b &gt; c &amp; d &quot;e&quot;')).toBe('a < b > c & d "e"');
   });

--- a/packages/plugin-telegram/src/channel/html.ts
+++ b/packages/plugin-telegram/src/channel/html.ts
@@ -34,14 +34,32 @@ export function composeFrame(snap: RenderedFrame): string {
  *  (`&#39;`, `&#x27;`) are handled too, since escaped user/code content can
  *  carry them and they'd otherwise leak literally into the fallback message. */
 export function stripHtml(html: string): string {
-  return html
-    .replace(/<\/?[a-z][^>]*>/gi, '')
+  return stripTags(html)
     .replace(/&#(\d+);/g, (_, dec: string) => safeFromCodePoint(parseInt(dec, 10)))
     .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => safeFromCodePoint(parseInt(hex, 16)))
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&amp;/g, '&');
+}
+
+function stripTags(html: string): string {
+  const out: string[] = [];
+  let cursor = 0;
+  while (cursor < html.length) {
+    if (html[cursor] !== '<') {
+      out.push(html[cursor] ?? '');
+      cursor += 1;
+      continue;
+    }
+    const end = html.indexOf('>', cursor + 1);
+    if (end === -1) {
+      out.push(html.slice(cursor));
+      break;
+    }
+    cursor = end + 1;
+  }
+  return out.join('');
 }
 
 /** Decode a numeric entity's code point, leaving an out-of-range/invalid value

--- a/packages/plugin-telegram/src/format.test.ts
+++ b/packages/plugin-telegram/src/format.test.ts
@@ -39,6 +39,12 @@ describe('markdownToTelegramHtml', () => {
     expect(out).toContain('<a href="https://example.com">docs</a>');
   });
 
+  it('escapes a link target exactly once', () => {
+    const out = markdownToTelegramHtml('[search](https://example.com/?a=1&b=%3Ctwo%3E)');
+    expect(out).toContain('href="https://example.com/?a=1&amp;b=%3Ctwo%3E"');
+    expect(out).not.toContain('&amp;amp;');
+  });
+
   it('allows http, mailto, and tel scheme links', () => {
     expect(markdownToTelegramHtml('[a](http://x.com)')).toContain('<a href="http://x.com">');
     expect(markdownToTelegramHtml('[m](mailto:a@b.com)')).toContain('<a href="mailto:a@b.com">');

--- a/packages/plugin-telegram/src/format.ts
+++ b/packages/plugin-telegram/src/format.ts
@@ -55,6 +55,15 @@ export function markdownToTelegramHtml(md: string): string {
     return ` INLINE${inlines.length - 1} `;
   });
 
+  // Pull link destinations out before HTML escaping. The visible label stays
+  // in the Markdown pipeline, while the raw target is validated and escaped
+  // exactly once when the final anchor is emitted.
+  const linkTargets: string[] = [];
+  working = working.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (_match, text, url) => {
+    linkTargets.push(String(url));
+    return `[${String(text)}](LINKTARGET${linkTargets.length - 1})`;
+  });
+
   // Now safe to escape HTML special chars in everything else.
   working = escapeHtml(working);
 
@@ -97,15 +106,11 @@ export function markdownToTelegramHtml(md: string): string {
   working = working.replace(/(^|[\s(,.!?:;])\*([^*\n]+)\*(?=$|[\s),.!?:;])/g, (_m, pre, body) => `${pre}<i>${String(body)}</i>`);
   working = working.replace(/(^|[\s(,.!?:;])_([^_\n]+)_(?=$|[\s),.!?:;])/g, (_m, pre, body) => `${pre}<i>${String(body)}</i>`);
 
-  // Links [text](url) — strip url tracking params if needed later;
-  // for now just emit. URLs may contain `&` which is already escaped
-  // to `&amp;` by escapeHtml above; that's valid inside href.
-  working = working.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (m, text, url) => {
-    // The url got HTML-escaped earlier; restore enough that the link
-    // actually points where it should. Only `&amp;` → `&` is needed
-    // for the typical case; `<>` shouldn't appear in a URL but unescape
-    // them defensively.
-    const cleanUrl = String(url).replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+  // Links [text](url). Targets were removed before escaping, so they cannot
+  // be double-decoded and are escaped once at this attribute boundary.
+  working = working.replace(/\[([^\]]+)\]\(LINKTARGET(\d+)\)/g, (_match, text, index) => {
+    const cleanUrl = linkTargets[Number(index)];
+    if (cleanUrl === undefined) return String(text);
     // The anchor target comes from arbitrary model output (and, via prompt
     // injection, untrusted data the model echoes). Don't rely on Telegram's
     // server-side parser as the sole sanitizer: emit a clickable <a> only for
@@ -113,7 +118,7 @@ export function markdownToTelegramHtml(md: string): string {
     // else — `javascript:`, `data:`, `file:`, `tg://` deep links — is left as
     // the original `[text](url)` text (already HTML-escaped upstream) so it
     // can't navigate the client.
-    if (!isAllowedUrl(cleanUrl)) return String(m);
+    if (!isAllowedUrl(cleanUrl)) return `[${String(text)}](${escapeHtml(cleanUrl)})`;
     return `<a href="${escapeAttr(cleanUrl)}">${String(text)}</a>`;
   });
 

--- a/packages/sdk/src/frontmatter.test.ts
+++ b/packages/sdk/src/frontmatter.test.ts
@@ -138,4 +138,10 @@ describe('renderFrontmatter', () => {
     // historical behavior).
     expect(parsed.body).toBe('\nbody content\n');
   });
+
+  it('round-trips quoted strings containing quotes and backslashes', () => {
+    const fm = { description: 'open "C:\\Program Files\\moxxy"' };
+    const parsed = parseFrontmatterFile(`${renderFrontmatter(fm)}\nbody`);
+    expect(parsed.frontmatter).toEqual(fm);
+  });
 });

--- a/packages/sdk/src/frontmatter.ts
+++ b/packages/sdk/src/frontmatter.ts
@@ -90,7 +90,14 @@ function parseScalar(v: string): unknown {
 }
 
 function stripQuotes(s: string): string {
-  if (s.length >= 2 && ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'")))) {
+  if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) {
+    try {
+      return JSON.parse(s) as string;
+    } catch {
+      return s.slice(1, -1);
+    }
+  }
+  if (s.length >= 2 && s.startsWith("'") && s.endsWith("'")) {
     return s.slice(1, -1);
   }
   return s;
@@ -145,7 +152,7 @@ export function renderFrontmatter(frontmatter: Record<string, unknown>): string 
 function renderValue(v: unknown): string {
   if (v === null || v === undefined) return '';
   if (typeof v === 'string') {
-    return needsQuoting(v) ? `"${v.replace(/"/g, '\\"')}"` : v;
+    return needsQuoting(v) ? `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"` : v;
   }
   if (typeof v === 'boolean' || typeof v === 'number') return String(v);
   if (Array.isArray(v)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1393,7 +1393,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 2.1.9(@types/node@22.19.18)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.19.18)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.33.0)(terser@5.48.0)(tsx@4.23.12)(yaml@2.8.3)
 
   packages/model-fetch:
     dependencies:

--- a/scripts/e2e-slim-install.mjs
+++ b/scripts/e2e-slim-install.mjs
@@ -31,6 +31,8 @@ const work = mkdtempSync(path.join(tmpdir(), 'moxxy-slim-smoke-'));
 const prefix = path.join(work, 'npmprefix');
 const home = path.join(work, 'home');
 
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const run = (cmd, args, opts = {}) =>
   execFileSync(cmd, args, { stdio: ['ignore', 'pipe', 'inherit'], encoding: 'utf8', ...opts });
 
@@ -51,7 +53,7 @@ const env = { ...process.env, MOXXY_HOME: home };
 const before = run(moxxy, ['plugins', 'list'], { env });
 for (const p of pkgs) {
   const scoped = p.startsWith('plugin-') || p.startsWith('mode-') ? `@moxxy/${p}` : p;
-  if (new RegExp(`^\\s+${scoped.replace('/', '\\/')}\\s+@`, 'm').test(before)) {
+  if (new RegExp(`^\\s+${escapeRegExp(scoped)}\\s+@`, 'm').test(before)) {
     throw new Error(`${scoped} is still bundled (listed as loaded on a fresh boot)`);
   }
 }
@@ -62,7 +64,7 @@ for (const p of pkgs) {
   run(moxxy, ['plugins', 'install', path.join(work, `${p}.tgz`)], { env });
   const after = run(moxxy, ['plugins', 'list'], { env });
   const scoped = `@moxxy/${p}`;
-  if (!new RegExp(`^\\s+${scoped.replace('/', '\\/')}\\s+@`, 'm').test(after)) {
+  if (!new RegExp(`^\\s+${escapeRegExp(scoped)}\\s+@`, 'm').test(after)) {
     throw new Error(`${scoped} did not load after install — check dist/ was built before packing`);
   }
   console.log(`${scoped}: installed + discovered ✓`);


### PR DESCRIPTION
## Summary\n- replace replacement-based HTML stripping with single-pass sanitizers\n- enforce exact-or-subdomain URL allow-lists and escape dynamic regular expressions\n- harden command argument, frontmatter, and Telegram link encoding\n- repair the stale mode-plan lockfile importer entry\n\n## Verification\n- pnpm build\n- pnpm typecheck\n- pnpm lint\n- pnpm check:deps\n- pnpm audit:security\n- pnpm exec turbo run test --concurrency=2\n- pnpm run test:scripts