### PR TITLE
fix(security): eliminate regex denial of service

### DIFF
--- a/.changeset/linear-input-parsers.md
+++ b/.changeset/linear-input-parsers.md
@@ -1,0 +1,7 @@
+---
+'@moxxy/cli': patch
+'@moxxy/sdk': patch
+'@moxxy/desktop': patch
+---
+
+Replace vulnerable regular-expression parsers with bounded linear-time input scanners.

--- a/packages/chat-model/src/markdown/inline.test.ts
+++ b/packages/chat-model/src/markdown/inline.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { stripInline, tokenizeInline } from './inline.js';
+
+describe('tokenizeInline', () => {
+  it('parses the supported inline constructs without changing plain text', () => {
+    expect(tokenizeInline('a `code` **bold** *italic* [link](https://example.com) z')).toEqual([
+      { kind: 'text', value: 'a ' },
+      { kind: 'code', value: 'code' },
+      { kind: 'text', value: ' ' },
+      { kind: 'bold', value: 'bold' },
+      { kind: 'text', value: ' ' },
+      { kind: 'italic', value: 'italic' },
+      { kind: 'text', value: ' ' },
+      { kind: 'link', label: 'link', url: 'https://example.com' },
+      { kind: 'text', value: ' z' },
+    ]);
+  });
+
+  it('handles long unmatched delimiters as literal text', () => {
+    const input = '['.repeat(50_000) + '*'.repeat(50_001);
+    expect(tokenizeInline(input)).toEqual([{ kind: 'text', value: input }]);
+    expect(stripInline(input)).toBe(input);
+  });
+});

--- a/packages/chat-model/src/markdown/inline.ts
+++ b/packages/chat-model/src/markdown/inline.ts
@@ -1,4 +1,3 @@
-import { assertDefined } from '../assert.js';
 import type { InlineTok } from './types.js';
 
 /**
@@ -8,37 +7,102 @@ import type { InlineTok } from './types.js';
  * renderers map the token stream to their own elements.
  */
 export function tokenizeInline(input: string): InlineTok[] {
-  const re = /(`[^`\n]+`)|(\*\*([^*\n]+)\*\*)|(\*([^*\n]+)\*)|(\[([^\]]+)\]\(([^)\s]+)\))/g;
   const out: InlineTok[] = [];
-  let lastIdx = 0;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(input)) !== null) {
-    if (match.index > lastIdx) {
-      out.push({ kind: 'text', value: input.slice(lastIdx, match.index) });
+  const next = buildNextIndexes(input);
+  let textStart = 0;
+  let cursor = 0;
+  while (cursor < input.length) {
+    const parsed = parseAt(input, cursor, next);
+    if (!parsed) {
+      cursor += 1;
+      continue;
     }
-    if (match[1]) {
-      out.push({ kind: 'code', value: match[1].slice(1, -1) });
-    } else if (match[2]) {
-      const value = match[3];
-      assertDefined(value, 'bold inner group is captured when the bold group matches');
-      out.push({ kind: 'bold', value });
-    } else if (match[4]) {
-      const value = match[5];
-      assertDefined(value, 'italic inner group is captured when the italic group matches');
-      out.push({ kind: 'italic', value });
-    } else if (match[6]) {
-      const label = match[7];
-      const url = match[8];
-      assertDefined(label, 'link label group is captured when the link group matches');
-      assertDefined(url, 'link url group is captured when the link group matches');
-      out.push({ kind: 'link', label, url });
-    }
-    lastIdx = match.index + match[0].length;
+    if (cursor > textStart) out.push({ kind: 'text', value: input.slice(textStart, cursor) });
+    out.push(parsed.token);
+    cursor = parsed.end;
+    textStart = cursor;
   }
-  if (lastIdx < input.length) {
-    out.push({ kind: 'text', value: input.slice(lastIdx) });
-  }
+  if (textStart < input.length) out.push({ kind: 'text', value: input.slice(textStart) });
   return out;
+}
+
+interface NextIndexes {
+  readonly backtick: Int32Array;
+  readonly star: Int32Array;
+  readonly closeBracket: Int32Array;
+  readonly closeParen: Int32Array;
+  readonly newline: Int32Array;
+  readonly whitespace: Int32Array;
+}
+
+function buildNextIndexes(input: string): NextIndexes {
+  const backtick = new Int32Array(input.length + 1).fill(-1);
+  const star = new Int32Array(input.length + 1).fill(-1);
+  const closeBracket = new Int32Array(input.length + 1).fill(-1);
+  const closeParen = new Int32Array(input.length + 1).fill(-1);
+  const newline = new Int32Array(input.length + 1).fill(-1);
+  const whitespace = new Int32Array(input.length + 1).fill(-1);
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    backtick[index] = input[index] === '`' ? index : (backtick[index + 1] ?? -1);
+    star[index] = input[index] === '*' ? index : (star[index + 1] ?? -1);
+    closeBracket[index] = input[index] === ']' ? index : (closeBracket[index + 1] ?? -1);
+    closeParen[index] = input[index] === ')' ? index : (closeParen[index + 1] ?? -1);
+    newline[index] = input[index] === '\n' ? index : (newline[index + 1] ?? -1);
+    whitespace[index] = isWhitespace(input[index]) ? index : (whitespace[index + 1] ?? -1);
+  }
+  return { backtick, star, closeBracket, closeParen, newline, whitespace };
+}
+
+function parseAt(
+  input: string,
+  start: number,
+  next: NextIndexes,
+): { readonly token: InlineTok; readonly end: number } | null {
+  const marker = input[start];
+  if (marker === '`') {
+    const close = next.backtick[start + 1] ?? -1;
+    const newline = next.newline[start + 1] ?? -1;
+    if (close > start + 1 && (newline === -1 || close < newline)) {
+      return { token: { kind: 'code', value: input.slice(start + 1, close) }, end: close + 1 };
+    }
+  }
+  if (marker === '*') {
+    const bold = input[start + 1] === '*';
+    const innerStart = start + (bold ? 2 : 1);
+    const close = next.star[innerStart] ?? -1;
+    const newline = next.newline[innerStart] ?? -1;
+    if (close > innerStart && (newline === -1 || close < newline)) {
+      if (bold && input[close + 1] === '*') {
+        return { token: { kind: 'bold', value: input.slice(innerStart, close) }, end: close + 2 };
+      }
+      if (!bold) {
+        return { token: { kind: 'italic', value: input.slice(innerStart, close) }, end: close + 1 };
+      }
+    }
+  }
+  if (marker === '[') {
+    const labelEnd = next.closeBracket[start + 1] ?? -1;
+    if (labelEnd > start + 1 && input[labelEnd + 1] === '(') {
+      const urlStart = labelEnd + 2;
+      const urlEnd = next.closeParen[urlStart] ?? -1;
+      const whitespace = next.whitespace[urlStart] ?? -1;
+      if (urlEnd > urlStart && (whitespace === -1 || urlEnd < whitespace)) {
+        return {
+          token: {
+            kind: 'link',
+            label: input.slice(start + 1, labelEnd),
+            url: input.slice(urlStart, urlEnd),
+          },
+          end: urlEnd + 1,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function isWhitespace(char: string | undefined): boolean {
+  return char !== undefined && /\s/u.test(char);
 }
 
 /** Drop inline markdown markup, leaving the bare text. The patterns mirror
@@ -47,9 +111,7 @@ export function tokenizeInline(input: string): InlineTok[] {
  *  as markup — otherwise a string could strip a span that tokenize leaves as
  *  plain text, or vice versa. */
 export function stripInline(s: string): string {
-  return s
-    .replace(/`([^`\n]+)`/g, '$1')
-    .replace(/\*\*([^*\n]+)\*\*/g, '$1')
-    .replace(/\*([^*\n]+)\*/g, '$1')
-    .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, '$1');
+  return tokenizeInline(s)
+    .map((token) => token.kind === 'link' ? stripInline(token.label) : token.value)
+    .join('');
 }

--- a/packages/chat-model/src/markdown/parse-blocks.test.ts
+++ b/packages/chat-model/src/markdown/parse-blocks.test.ts
@@ -8,6 +8,11 @@ describe('parseBlocks — paragraph breaks', () => {
       text: 'first line\nsecond line soft continuation',
     });
   });
+
+  it('handles a long non-list prefix as a plain paragraph', () => {
+    const input = `${' '.repeat(50_000)}${'1'.repeat(50_000)}x`;
+    expect(parseBlocks(input)).toEqual([{ kind: 'paragraph', text: input }]);
+  });
 });
 
 describe('parseBlocks — GFM tables', () => {

--- a/packages/chat-model/src/markdown/parse-blocks.ts
+++ b/packages/chat-model/src/markdown/parse-blocks.ts
@@ -56,32 +56,24 @@ export function parseBlocks(src: string): Block[] {
     }
 
     // ATX heading
-    const heading = /^(#{1,6})\s+(.*)$/.exec(line);
+    const heading = parseHeading(line);
     if (heading) {
-      const hashes = heading[1];
-      assertDefined(hashes, 'heading hash group is captured when the heading matches');
-      const text = heading[2];
-      assertDefined(text, 'heading text group is captured when the heading matches');
-      const level = Math.min(6, Math.max(1, hashes.length)) as 1 | 2 | 3 | 4 | 5 | 6;
-      blocks.push({ kind: 'heading', level, text: text.trim() });
+      blocks.push({ kind: 'heading', level: heading.level, text: heading.text });
       i++;
       continue;
     }
 
     // List (bullet or numbered) — consume consecutive list lines
-    if (/^\s*[-*+]\s+/.test(line) || /^\s*\d+\.\s+/.test(line)) {
-      const ordered = /^\s*\d+\.\s+/.test(line);
+    const firstItem = parseListItem(line);
+    if (firstItem) {
+      const ordered = firstItem.ordered;
       const items: string[] = [];
       while (i < lines.length) {
         const cur = lines[i];
         assertDefined(cur, 'line index within bounds');
-        const m = ordered
-          ? /^\s*\d+\.\s+(.*)$/.exec(cur)
-          : /^\s*[-*+]\s+(.*)$/.exec(cur);
-        if (!m) break;
-        const item = m[1];
-        assertDefined(item, 'list item capture group is present when the item matches');
-        items.push(item.trim());
+        const item = parseListItem(cur);
+        if (!item || item.ordered !== ordered) break;
+        items.push(item.text);
         i++;
       }
       blocks.push({ kind: 'list', ordered, items });
@@ -103,9 +95,8 @@ export function parseBlocks(src: string): Block[] {
       if (next.trim() === '') break;
       if (
         /^```/.test(next) ||
-        /^#{1,6}\s+/.test(next) ||
-        /^\s*[-*+]\s+/.test(next) ||
-        /^\s*\d+\.\s+/.test(next)
+        parseHeading(next) !== null ||
+        parseListItem(next) !== null
       ) {
         break;
       }
@@ -124,13 +115,48 @@ export function parseBlocks(src: string): Block[] {
   return blocks;
 }
 
+function parseHeading(line: string): { readonly level: 1 | 2 | 3 | 4 | 5 | 6; readonly text: string } | null {
+  let hashes = 0;
+  while (hashes < line.length && line[hashes] === '#') hashes += 1;
+  if (hashes < 1 || hashes > 6 || !isWhitespace(line[hashes])) return null;
+  let textStart = hashes;
+  while (textStart < line.length && isWhitespace(line[textStart])) textStart += 1;
+  return { level: hashes as 1 | 2 | 3 | 4 | 5 | 6, text: line.slice(textStart).trim() };
+}
+
+function parseListItem(line: string): { readonly ordered: boolean; readonly text: string } | null {
+  let cursor = 0;
+  while (cursor < line.length && isWhitespace(line[cursor])) cursor += 1;
+  let ordered = false;
+  if (line[cursor] === '-' || line[cursor] === '*' || line[cursor] === '+') {
+    cursor += 1;
+  } else {
+    const digitsStart = cursor;
+    while (cursor < line.length && isDigit(line[cursor])) cursor += 1;
+    if (cursor === digitsStart || line[cursor] !== '.') return null;
+    ordered = true;
+    cursor += 1;
+  }
+  if (!isWhitespace(line[cursor])) return null;
+  while (cursor < line.length && isWhitespace(line[cursor])) cursor += 1;
+  return { ordered, text: line.slice(cursor).trim() };
+}
+
+function isWhitespace(char: string | undefined): boolean {
+  return char !== undefined && /\s/u.test(char);
+}
+
+function isDigit(char: string | undefined): boolean {
+  return char !== undefined && char >= '0' && char <= '9';
+}
+
 /** Soft Markdown line breaks become spaces; two trailing spaces are an
  * explicit hard break and must remain a newline for terminal/DOM renderers. */
 function joinParagraphLines(lines: ReadonlyArray<string>): string {
   let text = '';
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index]!;
-    const hardBreak = / {2,}$/.test(line);
+    const hardBreak = line.endsWith('  ');
     text += line.trimEnd();
     if (index < lines.length - 1) text += hardBreak ? '\n' : ' ';
   }

--- a/packages/client-core/src/speech-prosody.ts
+++ b/packages/client-core/src/speech-prosody.ts
@@ -9,7 +9,7 @@ const MIN_RATE = 0.94;
 const MAX_RATE = 1.08;
 const LONG_SENTENCE_WORDS = 16;
 const WORD_RE = /\p{L}+(?:[-'’]\p{L}+)*/gu;
-const CLOSING_PUNCTUATION_RE = /["'”’\])]+$/u;
+const CLOSING_PUNCTUATION = new Set(['"', "'", '”', '’', ']', ')']);
 
 /**
  * Derive a subtle, deterministic cadence from one speakable chunk. This is
@@ -19,7 +19,7 @@ const CLOSING_PUNCTUATION_RE = /["'”’\])]+$/u;
  * within conservative bounds that do not distort its voices.
  */
 export function planSpeechProsody(text: string): SpeechProsody {
-  const normalized = text.trim().replace(CLOSING_PUNCTUATION_RE, '');
+  const normalized = stripClosingPunctuation(text.trim());
   const words = normalized.match(WORD_RE) ?? [];
 
   let rate = 1;
@@ -52,6 +52,12 @@ export function planSpeechProsody(text: string): SpeechProsody {
     rate: roundRate(Math.min(MAX_RATE, Math.max(MIN_RATE, rate))),
     pauseAfterMs,
   });
+}
+
+function stripClosingPunctuation(text: string): string {
+  let end = text.length;
+  while (end > 0 && CLOSING_PUNCTUATION.has(text[end - 1] ?? '')) end -= 1;
+  return text.slice(0, end);
 }
 
 function roundRate(rate: number): number {

--- a/packages/core/src/plugins/package-requirements.ts
+++ b/packages/core/src/plugins/package-requirements.ts
@@ -41,10 +41,16 @@ export async function readPackageMoxxyRequirements(
 }
 
 function resolvePackageJson(packageName: string, fromDir: string): string | null {
-  const require_ = createRequire(`${fromDir.replace(/\/+$/, '')}/`);
+  const require_ = createRequire(`${trimTrailing(fromDir, '/')}/`);
   try {
     return require_.resolve(`${packageName}/package.json`);
   } catch {
     return null;
   }
+}
+
+function trimTrailing(value: string, char: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === char) end -= 1;
+  return value.slice(0, end);
 }

--- a/packages/desktop-host/src/security.ts
+++ b/packages/desktop-host/src/security.ts
@@ -171,8 +171,14 @@ export function clerkFrontendApiHost(publishableKey?: string | null): string | n
   // The encoded value is the host with a trailing `$` delimiter. Guard that
   // what we decoded is a plain dotted hostname so a corrupt key can't smuggle
   // arbitrary CSP source tokens (spaces, schemes, paths) into the header.
-  const host = decoded.replace(/\$+$/, '');
+  const host = trimTrailing(decoded, '$');
   return /^[a-z0-9-]+(?:\.[a-z0-9-]+)+$/i.test(host) ? host : null;
+}
+
+function trimTrailing(value: string, char: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === char) end -= 1;
+  return value.slice(0, end);
 }
 
 /**

--- a/packages/mode-deep-research/src/index.test.ts
+++ b/packages/mode-deep-research/src/index.test.ts
@@ -40,6 +40,10 @@ describe('parseQueries', () => {
     expect(parseQueries('No queries here.')).toEqual([]);
   });
 
+  it('rejects a long unterminated numeric marker without backtracking', () => {
+    expect(parseQueries(`QUERIES:\n${'1'.repeat(50_000)}x`)).toEqual([]);
+  });
+
   it('joins a wrapped continuation onto the prior item instead of truncating it', () => {
     // Worst case: the planner wraps a long query across two lines. The
     // continuation must be re-joined, not dropped — a truncated half-question

--- a/packages/mode-deep-research/src/parse-queries.ts
+++ b/packages/mode-deep-research/src/parse-queries.ts
@@ -50,9 +50,9 @@ function parseNumberedBlock(text: string, headerRegex: RegExp): string[] {
       continuationOpen = false;
       continue;
     }
-    const m = /^(?:\d+[.)]|[-*•])\s*(.+)$/.exec(line);
-    if (m) {
-      items.push(m[1]!.trim());
+    const item = parseListItem(line);
+    if (item !== null) {
+      items.push(item);
       continuationOpen = true;
       continue;
     }
@@ -69,4 +69,22 @@ function parseNumberedBlock(text: string, headerRegex: RegExp): string[] {
     }
   }
   return items;
+}
+
+function parseListItem(line: string): string | null {
+  let cursor = 0;
+  if (line[0] === '-' || line[0] === '*' || line[0] === '•') {
+    cursor = 1;
+  } else {
+    while (isAsciiDigit(line[cursor])) cursor += 1;
+    if (cursor === 0 || (line[cursor] !== '.' && line[cursor] !== ')')) return null;
+    cursor += 1;
+  }
+  while (cursor < line.length && /\s/u.test(line[cursor] ?? '')) cursor += 1;
+  const item = line.slice(cursor).trim();
+  return item.length > 0 ? item : null;
+}
+
+function isAsciiDigit(char: string | undefined): boolean {
+  return char !== undefined && char >= '0' && char <= '9';
 }

--- a/packages/plugin-channel-imessage/src/bluebubbles-client.ts
+++ b/packages/plugin-channel-imessage/src/bluebubbles-client.ts
@@ -71,7 +71,7 @@ export class BlueBubblesClient implements BlueBubblesClientLike {
   constructor(opts: BlueBubblesClientOptions) {
     this.opts = opts;
     // Normalize the base URL once (strip a trailing slash) so path joins are clean.
-    this.base = opts.serverUrl.trim().replace(/\/+$/, '');
+    this.base = trimTrailingSlashes(opts.serverUrl.trim());
   }
 
   async ping(): Promise<void> {
@@ -157,6 +157,12 @@ export class BlueBubblesClient implements BlueBubblesClientLike {
     url.searchParams.set('password', this.opts.password);
     return url.toString();
   }
+}
+
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
 }
 
 /** Read the sent message's permanent guid from the send response, if present. */

--- a/packages/plugin-channel-imessage/src/keys.ts
+++ b/packages/plugin-channel-imessage/src/keys.ts
@@ -42,12 +42,23 @@ export const IMESSAGE_OWNER_HANDLES_KEY = 'imessage_owner_handles';
 /** E.164 shape: `+` then 7–15 digits, no leading zero. */
 export const E164_RE = /^\+[1-9]\d{6,14}$/;
 
-/** Pragmatic email shape (Apple-ID handles). Deliberately loose but anchored. */
-export const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+/** Pragmatic email matcher (Apple-ID handles), implemented as a linear scan. */
+export const EMAIL_RE = Object.freeze({ test: isEmail });
 
 /** Whether a normalized string is a plausible iMessage handle. */
 export function isHandle(value: string): boolean {
   return E164_RE.test(value) || EMAIL_RE.test(value);
+}
+
+function isEmail(value: string): boolean {
+  const at = value.indexOf('@');
+  if (at <= 0 || at !== value.lastIndexOf('@')) return false;
+  const dot = value.indexOf('.', at + 1);
+  if (dot <= at + 1 || dot === value.length - 1) return false;
+  for (const char of value) {
+    if (/\s/u.test(char)) return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/plugin-channel-slack/src/channel/slack-client.ts
+++ b/packages/plugin-channel-slack/src/channel/slack-client.ts
@@ -44,7 +44,7 @@ export class SlackClient {
 
   constructor(opts: SlackClientOptions) {
     this.token = opts.token;
-    this.baseUrl = (opts.baseUrl ?? SLACK_API_BASE).replace(/\/+$/, '');
+    this.baseUrl = trimTrailingSlashes(opts.baseUrl ?? SLACK_API_BASE);
     this.fetchImpl = opts.fetchImpl ?? fetch;
   }
 
@@ -120,4 +120,10 @@ export class SlackClient {
     const messages = json['messages'];
     return Array.isArray(messages) ? (messages as Array<Record<string, unknown>>) : [];
   }
+}
+
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
 }

--- a/packages/plugin-collab/src/state.ts
+++ b/packages/plugin-collab/src/state.ts
@@ -51,7 +51,11 @@ const MAX_MESSAGES_HARD = MAX_MESSAGES * 4;
 
 /** Normalize a claim/file path for prefix comparison. */
 function normPath(p: string): string {
-  return p.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+  let normalized = p.replace(/\\/g, '/');
+  if (normalized.startsWith('./')) normalized = normalized.slice(2);
+  let end = normalized.length;
+  while (end > 0 && normalized[end - 1] === '/') end -= 1;
+  return normalized.slice(0, end);
 }
 
 /** De-duplicate a list of path claims by their normalized form, preserving order. */

--- a/packages/plugin-memory/src/user-model.ts
+++ b/packages/plugin-memory/src/user-model.ts
@@ -2,7 +2,6 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import {
   z,
-  assertDefined,
   defineTool,
   createMutex,
   type Mutex,
@@ -77,8 +76,6 @@ function templateModel(): UserModel {
 
 // ── parse / serialize (round-trips unknown sections) ─────────────────────────
 
-const HEADING_RE = /^##\s+(.+?)\s*$/;
-
 /**
  * Parse the user-model Markdown into a preamble + ordered H2 sections. Any
  * section title is preserved (not just the fixed four), so a user's hand-added
@@ -91,13 +88,11 @@ export function parseUserModel(text: string): UserModel {
   let seenHeading = false;
 
   for (const line of text.split('\n')) {
-    const m = HEADING_RE.exec(line);
-    if (m) {
+    const title = parseHeading(line);
+    if (title !== null) {
       seenHeading = true;
       if (current) sections.push({ title: current.title, content: current.body.join('\n').trim() });
-      const title = m[1];
-      assertDefined(title, 'HEADING_RE capture group 1 is present on any match');
-      current = { title: title.trim(), body: [] };
+      current = { title, body: [] };
     } else if (!seenHeading) {
       preambleLines.push(line);
     } else if (current) {
@@ -106,6 +101,14 @@ export function parseUserModel(text: string): UserModel {
   }
   if (current) sections.push({ title: current.title, content: current.body.join('\n').trim() });
   return { preamble: preambleLines.join('\n').trim(), sections };
+}
+
+function parseHeading(line: string): string | null {
+  if (!line.startsWith('##') || !/\s/u.test(line[2] ?? '')) return null;
+  let titleStart = 2;
+  while (titleStart < line.length && /\s/u.test(line[titleStart] ?? '')) titleStart += 1;
+  const title = line.slice(titleStart).trim();
+  return title.length > 0 ? title : null;
 }
 
 /** Serialize back to Markdown, preserving the preamble and every section. */

--- a/packages/plugin-plugins-admin/src/catalog.ts
+++ b/packages/plugin-plugins-admin/src/catalog.ts
@@ -395,9 +395,10 @@ export function buildInstallSpec(input: {
 }
 
 export function applyGitRef(spec: string, ref: string): string {
-  const trimmed = ref.replace(/^#/, '');
+  const trimmed = ref.startsWith('#') ? ref.slice(1) : ref;
   if (trimmed.length === 0) return spec;
-  return spec.replace(/#.*$/, '') + `#${trimmed}`;
+  const fragment = spec.indexOf('#');
+  return (fragment === -1 ? spec : spec.slice(0, fragment)) + `#${trimmed}`;
 }
 
 function isGitLikeSpec(spec: string): boolean {

--- a/packages/plugin-telegram/src/format.test.ts
+++ b/packages/plugin-telegram/src/format.test.ts
@@ -34,6 +34,11 @@ describe('markdownToTelegramHtml', () => {
     expect(out).toContain('**not bold**');
   });
 
+  it('leaves a long unterminated fence literal', () => {
+    const input = `\`\`\`${'a'.repeat(50_000)}`;
+    expect(markdownToTelegramHtml(input)).toBe(input);
+  });
+
   it('converts links to <a href="...">', () => {
     const out = markdownToTelegramHtml('See [docs](https://example.com).');
     expect(out).toContain('<a href="https://example.com">docs</a>');

--- a/packages/plugin-telegram/src/format.ts
+++ b/packages/plugin-telegram/src/format.ts
@@ -38,15 +38,15 @@ export function markdownToTelegramHtml(md: string): string {
   // Pull fenced code blocks out FIRST so their contents skip inline
   // markdown processing. Replace each with a placeholder, render the
   // rest, then splice them back.
-  const fences: string[] = [];
-  let working = md.replace(/```([a-zA-Z0-9_+-]*)\n?([\s\S]*?)```/g, (_, lang, body) => {
+  const extracted = extractFences(md);
+  const fences = extracted.fences.map(({ lang, body }) => {
     const html =
-      `<pre><code${lang ? ` class="language-${escapeHtml(String(lang))}"` : ''}>` +
-      escapeHtml(String(body)).replace(/\n+$/, '') +
+      `<pre><code${lang ? ` class="language-${escapeHtml(lang)}"` : ''}>` +
+      escapeHtml(trimTrailingNewlines(body)) +
       '</code></pre>';
-    fences.push(html);
-    return ` FENCE${fences.length - 1} `;
+    return html;
   });
+  let working = extracted.working;
 
   // Pull inline code spans out next, same reason.
   const inlines: string[] = [];
@@ -127,6 +127,45 @@ export function markdownToTelegramHtml(md: string): string {
   working = working.replace(/ FENCE(\d+) /g, (_, i) => fences[Number(i)] ?? '');
 
   return working;
+}
+
+function extractFences(md: string): {
+  readonly working: string;
+  readonly fences: ReadonlyArray<{ readonly lang: string; readonly body: string }>;
+} {
+  const output: string[] = [];
+  const fences: Array<{ lang: string; body: string }> = [];
+  let cursor = 0;
+  while (cursor < md.length) {
+    const start = md.indexOf('```', cursor);
+    if (start === -1) break;
+    let bodyStart = start + 3;
+    while (bodyStart < md.length && isFenceLanguageChar(md[bodyStart])) bodyStart += 1;
+    const lang = md.slice(start + 3, bodyStart);
+    if (md[bodyStart] === '\n') bodyStart += 1;
+    const close = md.indexOf('```', bodyStart);
+    if (close === -1) break;
+    output.push(md.slice(cursor, start), ` FENCE${fences.length} `);
+    fences.push({ lang, body: md.slice(bodyStart, close) });
+    cursor = close + 3;
+  }
+  output.push(md.slice(cursor));
+  return { working: output.join(''), fences };
+}
+
+function isFenceLanguageChar(char: string | undefined): boolean {
+  return char !== undefined && (
+    (char >= 'a' && char <= 'z') ||
+    (char >= 'A' && char <= 'Z') ||
+    (char >= '0' && char <= '9') ||
+    char === '_' || char === '+' || char === '-'
+  );
+}
+
+function trimTrailingNewlines(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '\n') end -= 1;
+  return value.slice(0, end);
 }
 
 /**

--- a/packages/plugin-tts-elevenlabs/src/elevenlabs-tts.ts
+++ b/packages/plugin-tts-elevenlabs/src/elevenlabs-tts.ts
@@ -95,7 +95,7 @@ export class ElevenLabsSynthesizer implements Synthesizer {
   constructor(opts: ElevenLabsSynthesizerOptions = {}) {
     this.explicitKey = opts.apiKey;
     this.getSecret = opts.getSecret;
-    this.baseURL = (opts.baseURL ?? 'https://api.elevenlabs.io/v1').replace(/\/+$/, '');
+    this.baseURL = trimTrailingSlashes(opts.baseURL ?? 'https://api.elevenlabs.io/v1');
     this.model = opts.model ?? 'eleven_multilingual_v2';
     this.voiceId = opts.voiceId ?? DEFAULT_VOICE_ID;
     this.format = opts.format ?? 'mp3_44100_128';
@@ -208,6 +208,12 @@ export class ElevenLabsSynthesizer implements Synthesizer {
     this.key = resolved;
     return resolved;
   }
+}
+
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
 }
 
 /**

--- a/packages/plugin-tts-openai/src/openai-tts.ts
+++ b/packages/plugin-tts-openai/src/openai-tts.ts
@@ -83,7 +83,7 @@ export class OpenAiSynthesizer implements Synthesizer {
   constructor(opts: OpenAiSynthesizerOptions = {}) {
     this.explicitKey = opts.apiKey;
     this.getSecret = opts.getSecret;
-    this.baseURL = (opts.baseURL ?? 'https://api.openai.com/v1').replace(/\/+$/, '');
+    this.baseURL = trimTrailingSlashes(opts.baseURL ?? 'https://api.openai.com/v1');
     this.model = opts.model ?? 'gpt-4o-mini-tts';
     this.voice = opts.voice ?? 'alloy';
     this.format = opts.format ?? 'mp3';
@@ -196,6 +196,12 @@ export class OpenAiSynthesizer implements Synthesizer {
     this.key = resolved;
     return resolved;
   }
+}
+
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
 }
 
 /** Map a `SynthesizeOptions.rate` multiplier onto OpenAI's `speed`, clamped to

--- a/packages/plugin-webhooks/src/template.test.ts
+++ b/packages/plugin-webhooks/src/template.test.ts
@@ -152,4 +152,17 @@ describe('renderPrompt', () => {
     });
     expect(out).toBe('static {unknown} text');
   });
+
+  it('leaves a long unterminated placeholder intact', () => {
+    const prompt = `{header.${'x'.repeat(50_000)}`;
+    const out = renderPrompt({
+      trigger: mkTrigger(prompt),
+      headers: {},
+      body: Buffer.from(''),
+      method: 'POST',
+      path: '/',
+      firedAt: new Date(0),
+    });
+    expect(out).toBe(prompt);
+  });
 });

--- a/packages/plugin-webhooks/src/template.ts
+++ b/packages/plugin-webhooks/src/template.ts
@@ -38,8 +38,6 @@ export interface TemplateContext {
   readonly firedAt: Date;
 }
 
-const PLACEHOLDER_RE = /\{(body_json|body|method|path|trigger_name|fired_at|header\.[^}]+)\}/g;
-
 /** Unguessable per-render nonce so payload text can't forge the closing fence. */
 function makeFenceNonce(): string {
   return Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
@@ -63,8 +61,21 @@ export function renderPrompt(ctx: TemplateContext): string {
   const bodyStr = ctx.body.toString('utf8');
   const nonce = makeFenceNonce();
   let bodyJson: string | null = null;
-  return ctx.trigger.prompt.replace(PLACEHOLDER_RE, (_, token: string) => {
-    if (token === 'body') return fenceUntrusted(bodyStr, nonce);
+  const output: string[] = [];
+  const prompt = ctx.trigger.prompt;
+  let cursor = 0;
+  while (cursor < prompt.length) {
+    const open = prompt.indexOf('{', cursor);
+    if (open === -1) break;
+    const close = prompt.indexOf('}', open + 1);
+    if (close === -1) break;
+    const token = prompt.slice(open + 1, close);
+    if (!isPlaceholder(token)) {
+      output.push(prompt.slice(cursor, close + 1));
+      cursor = close + 1;
+      continue;
+    }
+    output.push(prompt.slice(cursor, open));
     if (token === 'body_json') {
       if (bodyJson === null) {
         try {
@@ -73,20 +84,31 @@ export function renderPrompt(ctx: TemplateContext): string {
           bodyJson = bodyStr;
         }
       }
-      return fenceUntrusted(bodyJson, nonce);
+      output.push(fenceUntrusted(bodyJson, nonce));
+      cursor = close + 1;
+      continue;
     }
-    if (token === 'method') return ctx.method;
+    if (token === 'body') output.push(fenceUntrusted(bodyStr, nonce));
+    else if (token === 'method') output.push(ctx.method);
     // The path's query string is fully sender-controlled, so fence it as
     // untrusted data — it must not be able to inject operator instructions.
-    if (token === 'path') return fenceUntrusted(ctx.path, nonce);
-    if (token === 'trigger_name') return ctx.trigger.name;
-    if (token === 'fired_at') return ctx.firedAt.toISOString();
-    if (token.startsWith('header.')) {
+    else if (token === 'path') output.push(fenceUntrusted(ctx.path, nonce));
+    else if (token === 'trigger_name') output.push(ctx.trigger.name);
+    else if (token === 'fired_at') output.push(ctx.firedAt.toISOString());
+    else if (token.startsWith('header.')) {
       const name = token.slice('header.'.length).toLowerCase();
       const v = ctx.headers[name];
       const raw = Array.isArray(v) ? v.join(', ') : typeof v === 'string' ? v : '';
-      return fenceUntrusted(raw, nonce);
+      output.push(fenceUntrusted(raw, nonce));
     }
-    return `{${token}}`;
-  });
+    cursor = close + 1;
+  }
+  output.push(prompt.slice(cursor));
+  return output.join('');
+}
+
+function isPlaceholder(token: string): boolean {
+  return token === 'body_json' || token === 'body' || token === 'method' || token === 'path' ||
+    token === 'trigger_name' || token === 'fired_at' ||
+    (token.startsWith('header.') && token.length > 'header.'.length);
 }

--- a/packages/plugin-workflows/src/template.test.ts
+++ b/packages/plugin-workflows/src/template.test.ts
@@ -25,6 +25,11 @@ describe('renderTemplate', () => {
     expect(renderTemplate('x{{ steps.missing.output }}y', scope)).toBe('xy');
     expect(renderTemplate('x{{ inputs.nope }}y', scope)).toBe('xy');
   });
+
+  it('leaves a long unterminated reference intact', () => {
+    const input = `{{${' '.repeat(50_000)}`;
+    expect(renderTemplate(input, scope)).toBe(input);
+  });
 });
 
 describe('renderArgs', () => {

--- a/packages/plugin-workflows/src/template.ts
+++ b/packages/plugin-workflows/src/template.ts
@@ -22,8 +22,6 @@ export interface TemplateScope {
   readonly vars?: Record<string, unknown>;
 }
 
-const REF_RE = /\{\{\s*([^}]+?)\s*\}\}/g;
-
 function stringifyValue(value: unknown): string {
   if (value == null) return '';
   if (typeof value === 'string') return value;
@@ -61,15 +59,32 @@ export interface RenderOptions {
 
 /** Substitute every `{{ ref }}` in `text`. Unknown refs render empty. */
 export function renderTemplate(text: string, scope: TemplateScope, opts: RenderOptions = {}): string {
-  return text.replace(REF_RE, (_match, ref: string) => {
+  const output: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const open = text.indexOf('{{', cursor);
+    if (open === -1) break;
+    const close = text.indexOf('}}', open + 2);
+    if (close === -1) break;
+    const rawRef = text.slice(open + 2, close);
+    const ref = rawRef.trim();
+    if (!ref || rawRef.includes('}')) {
+      output.push(text.slice(cursor, close + 2));
+      cursor = close + 2;
+      continue;
+    }
+    output.push(text.slice(cursor, open));
     const value = resolveRef(ref.trim(), scope);
     if (value === undefined) {
       const logger = opts.logger;
       if (logger?.warn) logger.warn('workflow template: unresolved reference', { ref: ref.trim() });
-      return '';
+    } else {
+      output.push(stringifyValue(value));
     }
-    return stringifyValue(value);
-  });
+    cursor = close + 2;
+  }
+  output.push(text.slice(cursor));
+  return output.join('');
 }
 
 /** Deep-render string leaves of an args object/array. */

--- a/packages/sdk/src/compactor-helpers.ts
+++ b/packages/sdk/src/compactor-helpers.ts
@@ -134,7 +134,7 @@ export function resolveModelContext(
   // example `claude-sonnet-4-6[1m]`). Prefer the matching base descriptor over
   // the unrelated models[0] fallback; only strip a terminal bracket suffix so
   // genuinely distinct dated/vendor ids are never conflated accidentally.
-  const baseId = ctx.model.replace(/\[[^\]]+\]$/, '');
+  const baseId = stripContextVariant(ctx.model);
   const variant = baseId !== ctx.model
     ? ctx.provider.models.find((model) => model.id === baseId)
     : undefined;
@@ -151,6 +151,13 @@ export function resolveModelContext(
     warnModelFallbackOnce(ctx.provider.name, ctx.model, descriptor.id, contextWindow);
   }
   return { contextWindow, reserveForOutput: descriptor?.maxOutputTokens ?? 0 };
+}
+
+function stripContextVariant(model: string): string {
+  if (!model.endsWith(']')) return model;
+  const priorClose = model.lastIndexOf(']', model.length - 2);
+  const open = model.indexOf('[', priorClose + 1);
+  return open === -1 || open === model.length - 2 ? model : model.slice(0, open);
 }
 
 // One-shot guard for the unlisted-model fallback warning above, keyed on the

--- a/packages/workflows-builder/src/operations.test.ts
+++ b/packages/workflows-builder/src/operations.test.ts
@@ -359,4 +359,8 @@ describe('uniqueId', () => {
     expect(first.id).toBe('my_step');
     expect(uniqueId(s, 'my step')).toBe('my_step_2');
   });
+
+  it('slugifies a long invalid run without changing its boundary semantics', () => {
+    expect(uniqueId(emptyState(), `${'!'.repeat(50_000)}A`)).toBe('a');
+  });
 });

--- a/packages/workflows-builder/src/operations.ts
+++ b/packages/workflows-builder/src/operations.ts
@@ -76,13 +76,23 @@ function defaultNode(id: string, kind: StepKind, x: number, y: number): BuilderN
  * forbidden characters past one path but not the other.
  */
 export function slugifyId(base: string): string {
-  return (
-    base
-      .toLowerCase()
-      .replace(/[^a-z0-9_-]+/g, '_')
-      .replace(/^_+|_+$/g, '')
-      .slice(0, 60) || 'step'
-  );
+  let slug = '';
+  let invalidRun = false;
+  for (const char of base.toLowerCase()) {
+    const allowed = (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char === '_' || char === '-';
+    if (allowed) {
+      slug += char;
+      invalidRun = false;
+    } else if (!invalidRun) {
+      slug += '_';
+      invalidRun = true;
+    }
+  }
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug[start] === '_') start += 1;
+  while (end > start && slug[end - 1] === '_') end -= 1;
+  return slug.slice(start, end).slice(0, 60) || 'step';
 }
 
 /** Generate a unique slug-like id from a desired base. */


### PR DESCRIPTION
## Summary

- replace CodeQL-reported polynomial regular expressions with bounded scanners
- preserve Markdown, template, URL, and identifier behavior
- add hostile-input regression coverage for long malformed delimiters

## Verification

- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm check:deps
- pnpm audit:security
- pnpm exec turbo run test --concurrency=2
- pnpm run test:scripts