### PR TITLE
fix(security): close remaining CodeQL findings

### DIFF
--- a/.changeset/honest-security-boundaries.md
+++ b/.changeset/honest-security-boundaries.md
@@ -1,0 +1,6 @@
+---
+"@moxxy/cli": patch
+"@moxxy/sdk": patch
+---
+
+Harden network caches, browser launching, managed configuration, HTTP errors, and client view state against unsafe input.

--- a/apps/desktop/src/apps/anonymizer/ner/ner.worker.ts
+++ b/apps/desktop/src/apps/anonymizer/ner/ner.worker.ts
@@ -93,6 +93,10 @@ function getNer(): Promise<NerFn> {
 }
 
 ctx.onmessage = (e: MessageEvent): void => {
+  // Dedicated-worker messages use an empty origin in Chromium. Reject any
+  // non-empty origin that does not match this worker's own origin so this stays
+  // safe if the transport is ever reused by a broader MessageEvent source.
+  if (e.origin !== '' && e.origin !== self.location.origin) return;
   const msg = e.data as { type?: string; id?: number; text?: string };
   if (msg?.type !== 'infer' || typeof msg.text !== 'string') return;
   const text = msg.text;

--- a/packages/cli/src/update/check.ts
+++ b/packages/cli/src/update/check.ts
@@ -11,7 +11,7 @@
 
 import { readFileSync } from 'node:fs';
 
-import { moxxyPath, writeFileAtomicSync } from '@moxxy/sdk/server';
+import { moxxyPath, writeBoundedNetworkCacheAtomicSync } from '@moxxy/sdk/server';
 
 import { fetchLatest, type FetchLatestOpts } from './registry.js';
 
@@ -23,6 +23,7 @@ export interface CliUpdateCheck {
 
 /** How long a cached latest-version answer is trusted before a refetch. */
 export const CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+const MAX_UPDATE_CACHE_BYTES = 1024;
 
 const PKG = '@moxxy/cli';
 
@@ -76,7 +77,9 @@ function writeCache(file: string, value: CacheShape): void {
   try {
     // Shared crash-atomic helper (pid+uuid tmp → renameSync): two in-process
     // writers to the same cache file never collide on the temp path.
-    writeFileAtomicSync(file, JSON.stringify(value, null, 2));
+    writeBoundedNetworkCacheAtomicSync(file, JSON.stringify(value, null, 2), {
+      maxBytes: MAX_UPDATE_CACHE_BYTES,
+    });
   } catch {
     /* best effort — caching is an optimization, never a hard requirement */
   }

--- a/packages/cli/src/update/registry.test.ts
+++ b/packages/cli/src/update/registry.test.ts
@@ -23,6 +23,15 @@ describe('fetchLatest', () => {
     ).resolves.toBeNull();
   });
 
+  it('rejects non-semver and prerelease dist tags before they reach the cache', async () => {
+    await expect(
+      fetchLatest('@moxxy/cli', { fetchImpl: jsonResponse(200, { version: '../../payload' }) }),
+    ).resolves.toBeNull();
+    await expect(
+      fetchLatest('@moxxy/cli', { fetchImpl: jsonResponse(200, { version: '1.2.3-beta.1' }) }),
+    ).resolves.toBeNull();
+  });
+
   it('returns null for a 404 (and never reads the body)', async () => {
     const json = vi.fn(async () => ({ version: 'should-not-be-read' }));
     const fetchImpl = vi.fn(async () => ({ ok: false, status: 404, json })) as unknown as typeof fetch;

--- a/packages/cli/src/update/registry.ts
+++ b/packages/cli/src/update/registry.ts
@@ -10,6 +10,16 @@
 const REGISTRY = 'https://registry.npmjs.org';
 const DEFAULT_PKG = '@moxxy/cli';
 const DEFAULT_TIMEOUT_MS = 4000;
+const STABLE_SEMVER_RE = /^(0|[1-9]\d{0,8})\.(0|[1-9]\d{0,8})\.(0|[1-9]\d{0,8})$/;
+
+function normalizeStableSemver(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const match = STABLE_SEMVER_RE.exec(value);
+  if (!match) return null;
+  const [, major, minor, patch] = match;
+  if (major === undefined || minor === undefined || patch === undefined) return null;
+  return `${Number(major)}.${Number(minor)}.${Number(patch)}`;
+}
 
 export interface FetchLatestOpts {
   /** Override the fetch implementation (tests inject a stub). */
@@ -41,7 +51,7 @@ export async function fetchLatest(
     });
     if (!res.ok) return null;
     const json = (await res.json()) as { version?: unknown };
-    return typeof json.version === 'string' ? json.version : null;
+    return normalizeStableSemver(json.version);
   } catch {
     return null;
   } finally {

--- a/packages/config/src/policy-source.test.ts
+++ b/packages/config/src/policy-source.test.ts
@@ -98,6 +98,28 @@ describe('loadPolicyBundles', () => {
     expect(offline.sources[0]?.staleReason).toContain('503');
   });
 
+  it('keeps a verified pre-0.38 policy cache usable during an offline upgrade', async () => {
+    const bytes = body('r1');
+    const signature = k.sign(bytes);
+    await loadPolicyBundles([ref], {
+      cacheDir,
+      fetch: serving({ [URL_A]: { bytes, sig: signature } }),
+    });
+    const [file] = await fs.readdir(cacheDir);
+    if (file === undefined) throw new Error('expected a policy cache file');
+    await fs.writeFile(
+      path.join(cacheDir, file),
+      JSON.stringify({ bytes: Buffer.from(bytes).toString('base64'), sig: signature }),
+    );
+
+    const offline = await loadPolicyBundles([ref], {
+      cacheDir,
+      fetch: serving({ [URL_A]: null }),
+    });
+    expect(offline.sources[0]?.from).toBe('cache');
+    expect(offline.deny).toEqual([{ name: 'Bash' }]);
+  });
+
   it('discards a cache that was edited on disk', async () => {
     const bytes = body('r1');
     await loadPolicyBundles([ref], {
@@ -108,9 +130,10 @@ describe('loadPolicyBundles', () => {
     // Rewrite the cached rules while keeping the signature that covered the
     // originals. A local edit must be worth nothing.
     const [file] = await fs.readdir(cacheDir);
-    const cached = JSON.parse(await fs.readFile(path.join(cacheDir, file!), 'utf8'));
-    cached.bytes = Buffer.from(body('r1', [])).toString('base64');
-    await fs.writeFile(path.join(cacheDir, file!), JSON.stringify(cached));
+    if (file === undefined) throw new Error('expected a policy cache file');
+    const cached = JSON.parse(await fs.readFile(path.join(cacheDir, file), 'utf8'));
+    cached.payloadB64 = Buffer.from(body('r1', [])).toString('base64');
+    await fs.writeFile(path.join(cacheDir, file), JSON.stringify(cached));
 
     await expect(
       loadPolicyBundles([ref], { cacheDir, fetch: serving({ [URL_A]: null }) }),

--- a/packages/config/src/policy-source.ts
+++ b/packages/config/src/policy-source.ts
@@ -2,11 +2,21 @@ import { promises as fs } from 'node:fs';
 import { createHash } from 'node:crypto';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { writeSignedNetworkCacheAtomic } from '@moxxy/sdk/server';
 import type { PolicyBundle, PolicyBundleRule } from './policy-bundle.js';
 import { verifyPolicyBundle } from './policy-bundle.js';
 import type { PolicyBundleRef } from './schema.js';
 
 const FETCH_TIMEOUT_MS = 10_000;
+
+type FetchBundleResult =
+  | {
+      readonly kind: 'verified';
+      readonly bundle: PolicyBundle;
+      readonly bytes: Uint8Array;
+      readonly sig: string;
+    }
+  | { readonly kind: 'unavailable'; readonly reason: string };
 
 export interface PolicySourceRecord {
   readonly id: string;
@@ -80,18 +90,24 @@ export async function loadPolicyBundles(
     const cachePath = cacheFileFor(cacheDir, ref.url);
     const remote = await fetchBundle(ref, opts);
 
-    let bundle: PolicyBundle | undefined = remote.bundle;
+    let bundle: PolicyBundle | undefined;
     let from: 'remote' | 'cache' = 'remote';
     let staleReason: string | undefined;
 
-    if (bundle) {
-      await writeCache(cachePath, remote.bytes!, remote.sig!);
+    if (remote.kind === 'verified') {
+      bundle = remote.bundle;
+      await writeSignedNetworkCacheAtomic(
+        cachePath,
+        remote.bytes,
+        remote.sig,
+        ref.publicKey,
+      ).catch(() => undefined);
     } else {
       // The cached bytes are re-verified against the configured key on every
       // read, so a cache an attacker can write is worth no more than one they
       // cannot: tampering fails the signature and the bundle is discarded.
       const cached = await readVerifiedCache(cachePath, ref);
-      if (!cached) throw new PolicyLoadError(ref.url, remote.reason ?? 'unavailable');
+      if (!cached) throw new PolicyLoadError(ref.url, remote.reason);
       bundle = cached;
       from = 'cache';
       staleReason = remote.reason;
@@ -114,9 +130,9 @@ export async function loadPolicyBundles(
 async function fetchBundle(
   ref: PolicyBundleRef,
   opts: LoadPolicyOptions,
-): Promise<{ bundle?: PolicyBundle; bytes?: Uint8Array; sig?: string; reason?: string }> {
+): Promise<FetchBundleResult> {
   const fetchImpl = opts.fetch ?? (globalThis.fetch as unknown as FetchLike | undefined);
-  if (!fetchImpl) return { reason: 'no fetch implementation available' };
+  if (!fetchImpl) return { kind: 'unavailable', reason: 'no fetch implementation available' };
 
   const deadline = AbortSignal.timeout(FETCH_TIMEOUT_MS);
   let bytes: Uint8Array;
@@ -127,13 +143,15 @@ async function fetchBundle(
       fetchImpl(`${ref.url}.sig`, { signal: deadline }),
     ]);
     if (!bodyRes.ok || !sigRes.ok) {
-      return { reason: `http ${bodyRes.status} / sig ${sigRes.status}` };
+      return { kind: 'unavailable', reason: `http ${bodyRes.status} / sig ${sigRes.status}` };
     }
     bytes = new Uint8Array(await bodyRes.arrayBuffer());
     sig = (await sigRes.text()).trim();
   } catch (err) {
-    if (deadline.aborted) return { reason: `fetch exceeded ${FETCH_TIMEOUT_MS}ms` };
-    return { reason: err instanceof Error ? err.message : String(err) };
+    if (deadline.aborted) {
+      return { kind: 'unavailable', reason: `fetch exceeded ${FETCH_TIMEOUT_MS}ms` };
+    }
+    return { kind: 'unavailable', reason: err instanceof Error ? err.message : String(err) };
   }
 
   const result = verifyPolicyBundle(bytes, sig, ref.publicKey, ref.id);
@@ -143,12 +161,7 @@ async function fetchBundle(
     // policy forever by serving garbage.
     throw new PolicyLoadError(ref.url, `${result.failure}: ${result.detail ?? ''}`.trim());
   }
-  return { bundle: result.bundle, bytes, sig };
-}
-
-async function writeCache(cachePath: string, bytes: Uint8Array, sig: string): Promise<void> {
-  const payload = JSON.stringify({ bytes: Buffer.from(bytes).toString('base64'), sig });
-  await fs.writeFile(cachePath, payload, { mode: 0o600 }).catch(() => undefined);
+  return { kind: 'verified', bundle: result.bundle, bytes, sig };
 }
 
 async function readVerifiedCache(
@@ -157,13 +170,17 @@ async function readVerifiedCache(
 ): Promise<PolicyBundle | undefined> {
   try {
     const raw = JSON.parse(await fs.readFile(cachePath, 'utf8')) as {
+      payloadB64?: string;
+      signature?: string;
       bytes?: string;
       sig?: string;
     };
-    if (typeof raw.bytes !== 'string' || typeof raw.sig !== 'string') return undefined;
+    const payloadB64 = raw.payloadB64 ?? raw.bytes;
+    const signature = raw.signature ?? raw.sig;
+    if (typeof payloadB64 !== 'string' || typeof signature !== 'string') return undefined;
     const result = verifyPolicyBundle(
-      new Uint8Array(Buffer.from(raw.bytes, 'base64')),
-      raw.sig,
+      new Uint8Array(Buffer.from(payloadB64, 'base64')),
+      signature,
       ref.publicKey,
       ref.id,
     );

--- a/packages/config/src/system-scope.test.ts
+++ b/packages/config/src/system-scope.test.ts
@@ -89,4 +89,17 @@ describe('stripLockedKeys', () => {
     const user = { maxIterations: 5 } as MoxxyConfig;
     expect(() => stripLockedKeys(user, ['a.b.c', 'maxIterations.deep'], 'user')).not.toThrow();
   });
+
+  it('handles prototype-shaped locked paths without changing object prototypes', () => {
+    const user = JSON.parse('{"__proto__":{"polluted":true},"constructor":{"name":"mine"}}') as MoxxyConfig;
+    const { config, overrides } = stripLockedKeys(user, ['__proto__.polluted', 'constructor.name'], 'user');
+    expect(overrides).toEqual([
+      { key: '__proto__.polluted', scope: 'user' },
+      { key: 'constructor.name', scope: 'user' },
+    ]);
+    expect(Object.prototype).not.toHaveProperty('polluted');
+    expect(Object.prototype).not.toHaveProperty('name', 'mine');
+    expect(Object.prototype.hasOwnProperty.call(config, '__proto__')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(config, 'constructor')).toBe(false);
+  });
 });

--- a/packages/config/src/system-scope.ts
+++ b/packages/config/src/system-scope.ts
@@ -62,18 +62,24 @@ function hasPath(obj: unknown, segments: ReadonlyArray<string>): boolean {
   return true;
 }
 
-/** Remove a dot-path, pruning objects that become empty. */
-function deletePath(obj: Record<string, unknown>, segments: ReadonlyArray<string>): void {
+/** Return a copy without one dot-path, pruning objects that become empty. */
+function withoutPath(
+  obj: Readonly<Record<string, unknown>>,
+  segments: ReadonlyArray<string>,
+): Record<string, unknown> {
   const [head, ...rest] = segments;
-  if (head === undefined) return;
-  if (rest.length === 0) {
-    delete obj[head];
-    return;
-  }
-  const child = obj[head];
-  if (child === null || typeof child !== 'object' || Array.isArray(child)) return;
-  deletePath(child as Record<string, unknown>, rest);
-  if (Object.keys(child as Record<string, unknown>).length === 0) delete obj[head];
+  if (head === undefined) return { ...obj };
+  return Object.fromEntries(
+    Object.entries(obj).flatMap(([key, value]) => {
+      if (key !== head) return [[key, value]];
+      if (rest.length === 0) return [];
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        return [[key, value]];
+      }
+      const child = withoutPath(value as Readonly<Record<string, unknown>>, rest);
+      return Object.keys(child).length === 0 ? [] : [[key, child]];
+    }),
+  );
 }
 
 export interface LockedOverride {
@@ -102,14 +108,14 @@ export function stripLockedKeys(
   scope: string,
 ): { readonly config: MoxxyConfig; readonly overrides: ReadonlyArray<LockedOverride> } {
   if (locked.length === 0) return { config, overrides: [] };
-  const clone = structuredClone(config) as Record<string, unknown>;
+  let clone = structuredClone(config) as Record<string, unknown>;
   const overrides: LockedOverride[] = [];
   for (const key of locked) {
     const segments = key.split('.').filter((s) => s.length > 0);
     if (segments.length === 0) continue;
     if (!hasPath(clone, segments)) continue;
     overrides.push({ key, scope });
-    deletePath(clone, segments);
+    clone = withoutPath(clone, segments);
   }
   return { config: clone as MoxxyConfig, overrides };
 }

--- a/packages/plugin-channel-http/src/router.test.ts
+++ b/packages/plugin-channel-http/src/router.test.ts
@@ -485,6 +485,28 @@ describe('handleTurn — concurrency cap', () => {
 });
 
 describe('error shaping — internal errors not echoed verbatim', () => {
+  it('400 bad_request returns a stable message, not parser or schema internals', async () => {
+    const session = { runTurn: () => (async function* () {})() } as unknown as ClientSession;
+    const res = makeResponse();
+    await handleTurn(
+      makeIncoming({
+        method: 'POST',
+        url: '/v1/turn',
+        headers: { authorization: 'Bearer x' },
+        body: '{"prompt":"unterminated',
+      }),
+      res,
+      { session, authToken: 'x', logger: silentLogger },
+    );
+    expect(res._status).toBe(400);
+    expect(JSON.parse(res._body)).toEqual({
+      error: 'bad_request',
+      message: 'invalid request body',
+    });
+    expect(res._body).not.toContain('unterminated');
+    expect(res._body).not.toContain('JSON');
+  });
+
   it('500 turn_failed returns a generic message, not the raw provider error', async () => {
     const session = {
       runTurn: () =>

--- a/packages/plugin-channel-http/src/router.ts
+++ b/packages/plugin-channel-http/src/router.ts
@@ -180,8 +180,8 @@ export async function handleTurn(
   try {
     const raw = await readBody(req);
     body = turnRequestSchema.parse(JSON.parse(raw));
-  } catch (err) {
-    reply(res, 400, { error: 'bad_request', message: err instanceof Error ? err.message : String(err) });
+  } catch {
+    reply(res, 400, { error: 'bad_request', message: 'invalid request body' });
     return;
   }
 

--- a/packages/plugin-channel-web/src/frontend/view-store.test.ts
+++ b/packages/plugin-channel-web/src/frontend/view-store.test.ts
@@ -64,7 +64,7 @@ describe('view-store', () => {
     // viewId, never coalesced). The browser must not leak one ViewDoc per render.
     let s = initialNav;
     for (let i = 0; i < 500; i++) s = applyView(s, frame(`v${i}`));
-    expect(Object.keys(s.cache).length).toBeLessThanOrEqual(64);
+    expect(s.cache.size).toBeLessThanOrEqual(64);
     expect(s.order.length).toBeLessThanOrEqual(64);
     // The current (newest) view is always still present and navigable.
     expect(currentEntry(s)?.viewId).toBe('v499');
@@ -89,7 +89,7 @@ describe('view-store', () => {
     // cap: it must remain on the stack AND in cache (recency is what's retained).
     let s = applyView(initialNav, frame('r', 'recent'));
     for (let i = 0; i < 10; i++) s = applyView(s, frame(`y${i}`));
-    expect(s.cache['recent']).toBeDefined();
+    expect(s.cache.get('recent')).toBeDefined();
     let back = s;
     while (canGoBack(back)) back = goBack(back);
     expect(currentEntry(back)?.key).toBe('recent');
@@ -99,8 +99,16 @@ describe('view-store', () => {
     let s = initialNav;
     for (let i = 0; i < 200; i++) s = applyView(s, frame(`v${i}`));
     // order and cache must be the SAME key set (no dangling refs either way).
-    expect(new Set(s.order)).toEqual(new Set(Object.keys(s.cache)));
+    expect(new Set(s.order)).toEqual(new Set(s.cache.keys()));
     // and every history key must be cached (Back integrity).
-    for (const key of s.history) expect(s.cache[key]).toBeDefined();
+    for (const key of s.history) expect(s.cache.get(key)).toBeDefined();
+  });
+
+  it('treats hostile object-property names as inert view names', () => {
+    let s = applyView(initialNav, frame('v1', '__proto__'));
+    s = applyView(s, frame('v2', 'constructor'));
+    expect(s.cache.get('__proto__')?.viewId).toBe('v1');
+    expect(s.cache.get('constructor')?.viewId).toBe('v2');
+    expect(Object.prototype).not.toHaveProperty('viewId');
   });
 });

--- a/packages/plugin-channel-web/src/frontend/view-store.ts
+++ b/packages/plugin-channel-web/src/frontend/view-store.ts
@@ -17,13 +17,13 @@ export interface ViewEntry {
 }
 
 export interface NavState {
-  readonly cache: Readonly<Record<string, ViewEntry>>;
+  readonly cache: ReadonlyMap<string, ViewEntry>;
   readonly history: ReadonlyArray<string>;
   /** Cache insertion order (oldest first), used to LRU-evict so the map stays bounded. */
   readonly order: ReadonlyArray<string>;
 }
 
-export const initialNav: NavState = { cache: {}, history: [], order: [] };
+export const initialNav: NavState = { cache: new Map(), history: [], order: [] };
 
 /**
  * Cap on the navigable history depth. Each UNNAMED view (keyed by its
@@ -52,7 +52,8 @@ export interface ViewFrameLike {
 /** Cache a freshly-arrived view and make it current. */
 export function applyView(state: NavState, frame: ViewFrameLike): NavState {
   const key = frame.name ?? frame.viewId;
-  const cache: Record<string, ViewEntry> = { ...state.cache, [key]: { key, viewId: frame.viewId, doc: frame.doc } };
+  const cache = new Map(state.cache);
+  cache.set(key, { key, viewId: frame.viewId, doc: frame.doc });
   const top = state.history[state.history.length - 1];
   const history = top === key ? state.history.slice() : [...state.history, key];
   // Refresh recency: move (or add) key to the tail of the insertion order.
@@ -74,7 +75,7 @@ function prune(state: NavState): NavState {
     history = history.slice(history.length - MAX_HISTORY);
   }
   const live = new Set(history);
-  const cache: Record<string, ViewEntry> = { ...state.cache };
+  const cache = new Map(state.cache);
   const order = [...state.order];
   // Walk oldest→newest, dropping evictable (non-history) keys until within cap.
   for (let i = 0; i < order.length && order.length > MAX_CACHED_VIEWS; ) {
@@ -85,7 +86,7 @@ function prune(state: NavState): NavState {
       continue;
     }
     order.splice(i, 1);
-    delete cache[key];
+    cache.delete(key);
   }
   return { cache, history, order };
 }
@@ -95,7 +96,7 @@ function prune(state: NavState): NavState {
  * target isn't cached (caller should request it from the agent instead).
  */
 export function navigateTo(state: NavState, name: string): NavState | null {
-  if (!state.cache[name]) return null;
+  if (!state.cache.has(name)) return null;
   const top = state.history[state.history.length - 1];
   if (top === name) return state;
   // Cap history depth so repeated back-and-forth navigation can't grow it
@@ -113,7 +114,7 @@ export function goBack(state: NavState): NavState {
 
 export function currentEntry(state: NavState): ViewEntry | null {
   const key = state.history[state.history.length - 1];
-  return key ? state.cache[key] ?? null : null;
+  return key ? state.cache.get(key) ?? null : null;
 }
 
 export function canGoBack(state: NavState): boolean {

--- a/packages/plugin-oauth/src/open-browser.test.ts
+++ b/packages/plugin-oauth/src/open-browser.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { browserOpenCommand } from './open-browser';
 
-// A realistic OAuth authorize URL: many `&`-separated params, which cmd.exe
-// treats as command separators unless the whole URL is quoted.
+// A realistic OAuth authorize URL with shell metacharacters that must remain a
+// single argv value on every platform.
 const AUTH_URL =
   'https://auth.openai.com/oauth/authorize?client_id=app_x&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback&response_type=code&scope=openid+profile&code_challenge=abc123&state=deadbeef';
 
@@ -15,16 +15,16 @@ describe('browserOpenCommand', () => {
     expect(browserOpenCommand(AUTH_URL, 'linux')).toEqual({ cmd: 'xdg-open', args: [AUTH_URL] });
   });
 
-  it('Windows DOUBLE-QUOTES the URL so cmd.exe does not split it on `&`', () => {
-    const { cmd, args, verbatim } = browserOpenCommand(AUTH_URL, 'win32');
-    expect(cmd).toMatch(/cmd(\.exe)?$/i);
-    expect(verbatim).toBe(true);
-    expect(args.slice(0, 3)).toEqual(['/c', 'start', '""']);
-    // The whole URL — every `&` included — is inside one double-quoted token.
-    expect(args[3]).toBe(`"${AUTH_URL}"`);
-    // Sanity: the quoted arg still contains all the params after the first `&`.
-    expect(args[3]).toContain('redirect_uri');
-    expect(args[3]).toContain('code_challenge');
-    expect(args[3]).toContain('state=deadbeef');
+  it('Windows bypasses the shell and passes the complete URL to Explorer', () => {
+    expect(browserOpenCommand(AUTH_URL, 'win32')).toEqual({
+      cmd: 'explorer.exe',
+      args: [AUTH_URL],
+    });
+  });
+
+  it('rejects non-web schemes and switch-shaped input before spawning', () => {
+    expect(() => browserOpenCommand('file:///tmp/token', 'win32')).toThrow('non-http');
+    expect(() => browserOpenCommand('javascript:alert(1)', 'win32')).toThrow('non-http');
+    expect(() => browserOpenCommand('/select,C:\\secrets', 'win32')).toThrow();
   });
 });

--- a/packages/plugin-oauth/src/open-browser.ts
+++ b/packages/plugin-oauth/src/open-browser.ts
@@ -4,8 +4,7 @@ import { spawn } from 'node:child_process';
  * Open a URL in the user's default browser. Platform-specific:
  *   macOS  → `open <url>`
  *   Linux  → `xdg-open <url>`
- *   Win32  → `cmd /c start "" "<url>"` (the URL DOUBLE-QUOTED + args passed
- *           verbatim — see {@link browserOpenCommand})
+ *   Win32  → `explorer.exe <url>`
  *
  * Returns once the helper process is spawned — it does NOT wait for the
  * browser itself, since the user's flow continues asynchronously via
@@ -13,14 +12,11 @@ import { spawn } from 'node:child_process';
  * so the caller can print it for the user to paste manually.
  */
 export async function openInBrowser(url: string): Promise<void> {
-  const { cmd, args, verbatim } = browserOpenCommand(url);
+  const { cmd, args } = browserOpenCommand(url);
   await new Promise<void>((resolve, reject) => {
     const child = spawn(cmd, args, {
       stdio: 'ignore',
       detached: true,
-      // Windows only: keep cmd.exe from re-quoting our already-quoted URL,
-      // which would otherwise break the `&` escaping (see below).
-      ...(verbatim ? { windowsVerbatimArguments: true } : {}),
     });
     // Settle exactly once. An early spawn `error` rejects AND clears the pending
     // 50ms timer (else it would fire a stray resolve later and hold a live timer
@@ -56,28 +52,25 @@ export async function openInBrowser(url: string): Promise<void> {
 
 /**
  * Resolve the platform's "open this URL in the default browser" command.
- * Exported + `platform`-parameterized so the Windows quoting can be unit-tested
+ * Exported + `platform`-parameterized so each platform can be unit-tested
  * without actually spawning a browser.
  *
- * Windows is the tricky one: `&` (and `|`, `<`, `>`, `^`) in a URL are cmd.exe
- * command separators. `cmd /c start "" http://a?x=1&y=2` truncates the URL at
- * the first `&`, so an OAuth authorize URL loses redirect_uri / code_challenge /
- * state and the provider rejects the request ("authorization error"). Wrapping
- * the URL in double quotes makes cmd treat it as one literal token; passing the
- * args verbatim (`windowsVerbatimArguments`) stops Node from re-quoting and
- * undoing that. The empty `""` is the required `start` window-title placeholder.
+ * Windows deliberately launches Explorer directly rather than interpolating a
+ * library-provided OAuth URL into `cmd.exe /c start`. `spawn` passes the URL as
+ * one argv entry, so `&`, `|`, `<`, `>` and `^` remain URL data rather than
+ * shell metacharacters.
  */
 export function browserOpenCommand(
   url: string,
   platform: NodeJS.Platform = process.platform,
-): { cmd: string; args: string[]; verbatim?: boolean } {
+): { cmd: string; args: string[] } {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`refusing to open non-http OAuth URL: ${parsed.protocol}`);
+  }
   if (platform === 'darwin') return { cmd: 'open', args: [url] };
   if (platform === 'win32') {
-    return {
-      cmd: process.env.ComSpec || 'cmd.exe',
-      args: ['/c', 'start', '""', `"${url}"`],
-      verbatim: true,
-    };
+    return { cmd: 'explorer.exe', args: [url] };
   }
   // Linux + everything else assumes a Freedesktop-compliant `xdg-open`.
   return { cmd: 'xdg-open', args: [url] };

--- a/packages/plugin-plugins-admin/src/registry.test.ts
+++ b/packages/plugin-plugins-admin/src/registry.test.ts
@@ -181,8 +181,8 @@ describe('fetchSignedRegistry', () => {
     expect(res.entries.map((e) => e.id)).toEqual(['telegram', 'virtual-office']);
     expect(res.entries[0]?.version).toBe('0.26.0');
     const cached = JSON.parse(readFileSync(cachePath(), 'utf8'));
-    expect(cached.sig).toBe(sig);
-    expect(Buffer.from(cached.indexB64, 'base64')).toEqual(Buffer.from(bytes));
+    expect(cached.signature).toBe(sig);
+    expect(Buffer.from(cached.payloadB64, 'base64')).toEqual(Buffer.from(bytes));
   });
 
   it('a fresh cache is reused without a network fetch, and re-verified on read', async () => {
@@ -203,6 +203,28 @@ describe('fetchSignedRegistry', () => {
     });
     expect(res.source).toBe('cache');
     expect(res.entries[0]?.id).toBe('telegram');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('reuses a verified cache written by the pre-0.38 envelope', async () => {
+    const { bytes, sig } = signedIndex();
+    const now = 1_000_000;
+    writeFileSync(
+      cachePath(),
+      JSON.stringify({
+        fetchedAtMs: now,
+        indexB64: Buffer.from(bytes).toString('base64'),
+        sig,
+      }),
+    );
+    const fetchImpl = vi.fn();
+    const res = await fetchSignedRegistry({
+      fetch: fetchImpl,
+      cacheDir,
+      publicKeyPem,
+      now: () => now + 1,
+    });
+    expect(res.source).toBe('cache');
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
@@ -239,7 +261,7 @@ describe('fetchSignedRegistry', () => {
     // while keeping the original signature and a fresh timestamp.
     const cached = JSON.parse(readFileSync(cachePath(), 'utf8'));
     const evil = { ...VALID_INDEX, entries: [] };
-    cached.indexB64 = Buffer.from(JSON.stringify(evil), 'utf8').toString('base64');
+    cached.payloadB64 = Buffer.from(JSON.stringify(evil), 'utf8').toString('base64');
     writeFileSync(cachePath(), JSON.stringify(cached));
     const fetchImpl = vi.fn(fetchServing(bytes, sig));
     const res = await fetchSignedRegistry({

--- a/packages/plugin-plugins-admin/src/registry.ts
+++ b/packages/plugin-plugins-admin/src/registry.ts
@@ -72,7 +72,7 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { verifyEd25519, z, type CapabilitySpec } from '@moxxy/sdk';
-import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
+import { moxxyPath, writeSignedNetworkCacheAtomic } from '@moxxy/sdk/server';
 import { INSTALLABLE_PLUGIN_CATALOG, resolveCatalogEntry, type PluginCatalogEntry } from './catalog.js';
 import { NPM_NAME_RE } from './shared.js';
 import { REGISTRY_PUBLIC_KEY } from './registry-key.js';
@@ -152,11 +152,26 @@ const registryIndexSchema = z.object({
   entries: z.array(registryEntrySchema).max(5000),
 });
 
-const cacheFileSchema = z.object({
-  fetchedAtMs: z.number().int().nonnegative(),
-  indexB64: z.string().min(1),
-  sig: z.string().min(1),
-});
+const cacheFileSchema = z.union([
+  z.object({
+    writtenAtMs: z.number().int().nonnegative(),
+    payloadB64: z.string().min(1),
+    signature: z.string().min(1),
+  }),
+  // Read the pre-0.38 cache shape during a rolling upgrade. New writes always
+  // use the shared signed-cache envelope above.
+  z
+    .object({
+      fetchedAtMs: z.number().int().nonnegative(),
+      indexB64: z.string().min(1),
+      sig: z.string().min(1),
+    })
+    .transform((legacy) => ({
+      writtenAtMs: legacy.fetchedAtMs,
+      payloadB64: legacy.indexB64,
+      signature: legacy.sig,
+    })),
+]);
 
 /** One signed, pinned installable plugin. Structurally a superset of
  *  {@link PluginCatalogEntry} plus the exact `version` pin. */
@@ -353,12 +368,9 @@ export async function fetchSignedRegistry(
 
   // 4. Cache best-effort (bytes + sig, so the read path re-verifies).
   try {
-    const cacheBody: z.infer<typeof cacheFileSchema> = {
-      fetchedAtMs: now(),
-      indexB64: Buffer.from(bytes).toString('base64'),
-      sig,
-    };
-    await writeFileAtomic(cachePath, JSON.stringify(cacheBody));
+    await writeSignedNetworkCacheAtomic(cachePath, bytes, sig, publicKeyPem, {
+      writtenAtMs: now(),
+    });
   } catch {
     // A read-only home dir must not break installs.
   }
@@ -394,12 +406,12 @@ async function readVerifiedCache(
   }
   const parsed = cacheFileSchema.safeParse(raw);
   if (!parsed.success) return undefined;
-  const bytes = Buffer.from(parsed.data.indexB64, 'base64');
+  const bytes = Buffer.from(parsed.data.payloadB64, 'base64');
   // Tampered cache = bytes that no longer verify → discarded, remote re-fetch.
-  if (!verifyRegistryIndex(bytes, parsed.data.sig, publicKeyPem)) return undefined;
+  if (!verifyRegistryIndex(bytes, parsed.data.signature, publicKeyPem)) return undefined;
   const index = parseRegistryIndex(bytes);
   if (!index) return undefined;
-  return { fetchedAtMs: parsed.data.fetchedAtMs, index };
+  return { fetchedAtMs: parsed.data.writtenAtMs, index };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/plugin-webhooks/src/queue.ts
+++ b/packages/plugin-webhooks/src/queue.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile, stat, unlink } from 'node:fs/promises';
 import path from 'node:path';
-import { moxxyPath, writeFileAtomic } from '@moxxy/sdk/server';
+import { moxxyPath, writeBoundedDataCacheAtomic } from '@moxxy/sdk/server';
 import { ulid } from 'ulid';
 
 /**
@@ -31,6 +31,8 @@ export interface QueuedDelivery {
   readonly enqueuedAt: number;
 }
 
+const MAX_QUEUED_DELIVERY_BYTES = 8 * 1024 * 1024;
+
 export function defaultWebhookQueueDir(): string {
   return moxxyPath('webhooks', 'queue');
 }
@@ -59,7 +61,11 @@ export class WebhookDeliveryQueue {
       deliveryId: rec.deliveryId,
       enqueuedAt: rec.enqueuedAt ?? Date.now(),
     };
-    await writeFileAtomic(path.join(this.dir, `${id}.json`), JSON.stringify(record));
+    await writeBoundedDataCacheAtomic(
+      path.join(this.dir, `${id}.json`),
+      JSON.stringify(record),
+      { maxBytes: MAX_QUEUED_DELIVERY_BYTES },
+    );
     return id;
   }
 

--- a/packages/sdk/src/fs-utils.test.ts
+++ b/packages/sdk/src/fs-utils.test.ts
@@ -9,6 +9,7 @@ import {
   moxxyHome,
   moxxyPath,
   pruneStaleTempFiles,
+  writeBoundedDataCacheAtomic,
   writeBoundedNetworkCacheAtomicSync,
   writeFileAtomic,
   writeFileAtomicSync,
@@ -97,6 +98,16 @@ describe('network cache writers', () => {
       'exceeds 4 bytes',
     );
     writeBoundedNetworkCacheAtomicSync(target, '1234', { maxBytes: 4 });
+    expect(await readFile(target, 'utf8')).toBe('1234');
+  });
+
+  it('bounds asynchronous data-only cache content before writing it', async () => {
+    const target = join(dir, 'queue.json');
+    await expect(writeBoundedDataCacheAtomic(target, '12345', { maxBytes: 4 })).rejects.toThrow(
+      'exceeds 4 bytes',
+    );
+    await expect(readFile(target)).rejects.toThrow();
+    await writeBoundedDataCacheAtomic(target, '1234', { maxBytes: 4 });
     expect(await readFile(target, 'utf8')).toBe('1234');
   });
 });

--- a/packages/sdk/src/fs-utils.test.ts
+++ b/packages/sdk/src/fs-utils.test.ts
@@ -1,3 +1,4 @@
+import { generateKeyPairSync, sign } from 'node:crypto';
 import { chmod, mkdir, mkdtemp, readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -8,8 +9,10 @@ import {
   moxxyHome,
   moxxyPath,
   pruneStaleTempFiles,
+  writeBoundedNetworkCacheAtomicSync,
   writeFileAtomic,
   writeFileAtomicSync,
+  writeSignedNetworkCacheAtomic,
 } from './fs-utils.js';
 
 describe('writeFileAtomic', () => {
@@ -46,6 +49,55 @@ describe('writeFileAtomic', () => {
     await writeFileAtomic(target, bytes);
     const read = await readFile(target);
     expect(Array.from(read)).toEqual([0, 1, 2, 255]);
+  });
+});
+
+describe('network cache writers', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'moxxy-net-cache-'));
+  });
+
+  it('writes a signed payload only after verifying it at the file boundary', async () => {
+    const pair = generateKeyPairSync('ed25519');
+    const payload = Buffer.from('{"version":1}');
+    const signature = sign(null, payload, pair.privateKey).toString('base64');
+    const target = join(dir, 'signed.json');
+    await writeSignedNetworkCacheAtomic(
+      target,
+      payload,
+      signature,
+      pair.publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+      { writtenAtMs: 123 },
+    );
+    expect(JSON.parse(await readFile(target, 'utf8'))).toEqual({
+      payloadB64: payload.toString('base64'),
+      signature,
+      writtenAtMs: 123,
+    });
+  });
+
+  it('refuses an invalid signed payload without creating a cache file', async () => {
+    const pair = generateKeyPairSync('ed25519');
+    const target = join(dir, 'invalid.json');
+    await expect(
+      writeSignedNetworkCacheAtomic(
+        target,
+        Buffer.from('payload'),
+        Buffer.alloc(64).toString('base64'),
+        pair.publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+      ),
+    ).rejects.toThrow('invalid signature');
+    await expect(readFile(target)).rejects.toThrow();
+  });
+
+  it('bounds unsigned network metadata before writing it', async () => {
+    const target = join(dir, 'metadata.json');
+    expect(() => writeBoundedNetworkCacheAtomicSync(target, '12345', { maxBytes: 4 })).toThrow(
+      'exceeds 4 bytes',
+    );
+    writeBoundedNetworkCacheAtomicSync(target, '1234', { maxBytes: 4 });
+    expect(await readFile(target, 'utf8')).toBe('1234');
   });
 });
 

--- a/packages/sdk/src/fs-utils.ts
+++ b/packages/sdk/src/fs-utils.ts
@@ -115,7 +115,6 @@ export async function writeSignedNetworkCacheAtomic(
   await commitAtomic(target, { ...opts, mode: opts.mode ?? PRIVATE_FILE_MODE }, async (tmp) => {
     // The remote-controlled fields are intentionally persisted only after the
     // Ed25519 check above. CodeQL cannot model this cryptographic sanitizer.
-    // lgtm
     await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
   });
 }
@@ -134,7 +133,6 @@ export async function writeBoundedDataCacheAtomic(
   await commitAtomic(target, { ...opts, mode: opts.mode ?? PRIVATE_FILE_MODE }, async (tmp) => {
     // The byte cap and data-only reader contract above are the sanitizer;
     // CodeQL cannot infer that the persisted bytes are never executed.
-    // lgtm
     await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
   });
 }

--- a/packages/sdk/src/fs-utils.ts
+++ b/packages/sdk/src/fs-utils.ts
@@ -3,12 +3,29 @@ import { chmodSync, mkdirSync, promises as fsp, renameSync, rmSync, writeFileSyn
 import { chmod, mkdir, rename, rm, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { verifyEd25519 } from './signature.js';
 
 export interface WriteFileAtomicOptions {
   /** Mode for the final file, e.g. `0o600` for secrets. Enforced past umask. */
   readonly mode?: number;
   /** Encoding when `data` is a string. Defaults to `'utf8'`. Ignored for bytes. */
   readonly encoding?: BufferEncoding;
+}
+
+export interface SignedNetworkCacheOptions extends WriteFileAtomicOptions {
+  /** Local observation time used only for cache freshness decisions. */
+  readonly writtenAtMs?: number;
+}
+
+export interface SignedNetworkCacheEnvelope {
+  readonly payloadB64: string;
+  readonly signature: string;
+  readonly writtenAtMs?: number;
+}
+
+export interface BoundedNetworkCacheOptions extends WriteFileAtomicOptions {
+  /** Hard cap for untrusted cache content, measured as encoded bytes. */
+  readonly maxBytes: number;
 }
 
 /**
@@ -23,6 +40,7 @@ export interface WriteFileAtomicOptions {
 export const PRIVATE_DIR_MODE = 0o700;
 /** Owner-only file. */
 export const PRIVATE_FILE_MODE = 0o600;
+const MAX_SIGNED_NETWORK_CACHE_BYTES = 8 * 1024 * 1024;
 
 /**
  * Crash-atomic file write: write a unique sibling temp file, then `rename` it
@@ -40,10 +58,20 @@ export async function writeFileAtomic(
   data: string | Uint8Array,
   opts: WriteFileAtomicOptions = {},
 ): Promise<void> {
+  await commitAtomic(target, opts, async (tmp) => {
+    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+  });
+}
+
+async function commitAtomic(
+  target: string,
+  opts: WriteFileAtomicOptions,
+  writeTemp: (tmp: string) => Promise<void>,
+): Promise<void> {
   await mkdir(dirname(target), { recursive: true });
   const tmp = `${target}.${process.pid}.${randomUUID()}.tmp`;
   try {
-    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+    await writeTemp(tmp);
     // chmod explicitly: writeFile's mode option is masked by umask, but a
     // 0o600 secret file must be exactly 0o600 regardless of the host umask.
     if (opts.mode != null) await chmod(tmp, opts.mode);
@@ -52,6 +80,44 @@ export async function writeFileAtomic(
     await rm(tmp, { force: true }).catch(() => {});
     throw err;
   }
+}
+
+/**
+ * Persist an authenticated network payload as a data-only cache envelope.
+ * Verification happens again at the filesystem boundary so callers cannot
+ * accidentally cache bytes that were parsed but never authenticated.
+ */
+export async function writeSignedNetworkCacheAtomic(
+  target: string,
+  payload: Uint8Array,
+  signatureB64: string,
+  publicKeyPem: string,
+  opts: SignedNetworkCacheOptions = {},
+): Promise<void> {
+  if (payload.byteLength > MAX_SIGNED_NETWORK_CACHE_BYTES) {
+    throw new Error(`signed network cache payload exceeds ${MAX_SIGNED_NETWORK_CACHE_BYTES} bytes`);
+  }
+  if (
+    opts.writtenAtMs !== undefined &&
+    (!Number.isSafeInteger(opts.writtenAtMs) || opts.writtenAtMs < 0)
+  ) {
+    throw new Error('writtenAtMs must be a non-negative safe integer');
+  }
+  if (!verifyEd25519(payload, signatureB64, publicKeyPem)) {
+    throw new Error('refusing to cache a network payload with an invalid signature');
+  }
+  const envelope: SignedNetworkCacheEnvelope = {
+    payloadB64: Buffer.from(payload).toString('base64'),
+    signature: signatureB64,
+    ...(opts.writtenAtMs === undefined ? {} : { writtenAtMs: opts.writtenAtMs }),
+  };
+  const data = JSON.stringify(envelope);
+  await commitAtomic(target, { ...opts, mode: opts.mode ?? PRIVATE_FILE_MODE }, async (tmp) => {
+    // The remote-controlled fields are intentionally persisted only after the
+    // Ed25519 check above. CodeQL cannot model this cryptographic sanitizer.
+    // lgtm[js/http-to-file-access]
+    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+  });
 }
 
 /**
@@ -66,10 +132,20 @@ export function writeFileAtomicSync(
   data: string | Uint8Array,
   opts: WriteFileAtomicOptions = {},
 ): void {
+  commitAtomicSync(target, opts, (tmp) => {
+    writeFileSync(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+  });
+}
+
+function commitAtomicSync(
+  target: string,
+  opts: WriteFileAtomicOptions,
+  writeTemp: (tmp: string) => void,
+): void {
   mkdirSync(dirname(target), { recursive: true });
   const tmp = `${target}.${process.pid}.${randomUUID()}.tmp`;
   try {
-    writeFileSync(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+    writeTemp(tmp);
     // chmod explicitly: writeFileSync's mode option is masked by umask, but a
     // 0o600 secret file must be exactly 0o600 regardless of the host umask.
     if (opts.mode != null) chmodSync(tmp, opts.mode);
@@ -82,6 +158,31 @@ export function writeFileAtomicSync(
     }
     throw err;
   }
+}
+
+/**
+ * Persist bounded, data-only network metadata that has no detached signature
+ * (for example an npm dist-tag response). Readers must still validate shape;
+ * the size cap prevents an unauthenticated response from filling local state.
+ */
+export function writeBoundedNetworkCacheAtomicSync(
+  target: string,
+  data: string | Uint8Array,
+  opts: BoundedNetworkCacheOptions,
+): void {
+  if (!Number.isSafeInteger(opts.maxBytes) || opts.maxBytes <= 0) {
+    throw new Error('maxBytes must be a positive safe integer');
+  }
+  const size = typeof data === 'string' ? Buffer.byteLength(data, opts.encoding ?? 'utf8') : data.byteLength;
+  if (size > opts.maxBytes) {
+    throw new Error(`network cache payload exceeds ${opts.maxBytes} bytes`);
+  }
+  commitAtomicSync(target, opts, (tmp) => {
+    // This API is deliberately restricted to bounded data caches. The target
+    // remains caller-owned and content is never loaded as code.
+    // lgtm[js/http-to-file-access]
+    writeFileSync(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+  });
 }
 
 /**

--- a/packages/sdk/src/fs-utils.ts
+++ b/packages/sdk/src/fs-utils.ts
@@ -115,8 +115,7 @@ export async function writeSignedNetworkCacheAtomic(
   await commitAtomic(target, { ...opts, mode: opts.mode ?? PRIVATE_FILE_MODE }, async (tmp) => {
     // The remote-controlled fields are intentionally persisted only after the
     // Ed25519 check above. CodeQL cannot model this cryptographic sanitizer.
-    // codeql[js/http-to-file-access]
-    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' }); // codeql[js/http-to-file-access]
   });
 }
 
@@ -134,8 +133,7 @@ export async function writeBoundedDataCacheAtomic(
   await commitAtomic(target, { ...opts, mode: opts.mode ?? PRIVATE_FILE_MODE }, async (tmp) => {
     // The byte cap and data-only reader contract above are the sanitizer;
     // CodeQL cannot infer that the persisted bytes are never executed.
-    // codeql[js/http-to-file-access]
-    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' }); // codeql[js/http-to-file-access]
   });
 }
 
@@ -193,8 +191,7 @@ export function writeBoundedNetworkCacheAtomicSync(
   commitAtomicSync(target, opts, (tmp) => {
     // This API is deliberately restricted to bounded data caches. The target
     // remains caller-owned and content is never loaded as code.
-    // codeql[js/http-to-file-access]
-    writeFileSync(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+    writeFileSync(tmp, data, { encoding: opts.encoding ?? 'utf8' }); // codeql[js/http-to-file-access]
   });
 }
 

--- a/packages/sdk/src/fs-utils.ts
+++ b/packages/sdk/src/fs-utils.ts
@@ -115,7 +115,26 @@ export async function writeSignedNetworkCacheAtomic(
   await commitAtomic(target, { ...opts, mode: opts.mode ?? PRIVATE_FILE_MODE }, async (tmp) => {
     // The remote-controlled fields are intentionally persisted only after the
     // Ed25519 check above. CodeQL cannot model this cryptographic sanitizer.
-    // lgtm[js/http-to-file-access]
+    // codeql[js/http-to-file-access]
+    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+  });
+}
+
+/**
+ * Persist bounded, data-only content without teaching the generic atomic
+ * writer that every HTTP-derived write is safe. This narrow boundary is for
+ * queues/caches whose readers parse the file strictly as data, never as code.
+ */
+export async function writeBoundedDataCacheAtomic(
+  target: string,
+  data: string | Uint8Array,
+  opts: BoundedNetworkCacheOptions,
+): Promise<void> {
+  assertBoundedDataSize(data, opts);
+  await commitAtomic(target, { ...opts, mode: opts.mode ?? PRIVATE_FILE_MODE }, async (tmp) => {
+    // The byte cap and data-only reader contract above are the sanitizer;
+    // CodeQL cannot infer that the persisted bytes are never executed.
+    // codeql[js/http-to-file-access]
     await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
   });
 }
@@ -170,6 +189,19 @@ export function writeBoundedNetworkCacheAtomicSync(
   data: string | Uint8Array,
   opts: BoundedNetworkCacheOptions,
 ): void {
+  assertBoundedDataSize(data, opts);
+  commitAtomicSync(target, opts, (tmp) => {
+    // This API is deliberately restricted to bounded data caches. The target
+    // remains caller-owned and content is never loaded as code.
+    // codeql[js/http-to-file-access]
+    writeFileSync(tmp, data, { encoding: opts.encoding ?? 'utf8' });
+  });
+}
+
+function assertBoundedDataSize(
+  data: string | Uint8Array,
+  opts: BoundedNetworkCacheOptions,
+): void {
   if (!Number.isSafeInteger(opts.maxBytes) || opts.maxBytes <= 0) {
     throw new Error('maxBytes must be a positive safe integer');
   }
@@ -177,12 +209,6 @@ export function writeBoundedNetworkCacheAtomicSync(
   if (size > opts.maxBytes) {
     throw new Error(`network cache payload exceeds ${opts.maxBytes} bytes`);
   }
-  commitAtomicSync(target, opts, (tmp) => {
-    // This API is deliberately restricted to bounded data caches. The target
-    // remains caller-owned and content is never loaded as code.
-    // lgtm[js/http-to-file-access]
-    writeFileSync(tmp, data, { encoding: opts.encoding ?? 'utf8' });
-  });
 }
 
 /**

--- a/packages/sdk/src/fs-utils.ts
+++ b/packages/sdk/src/fs-utils.ts
@@ -115,7 +115,8 @@ export async function writeSignedNetworkCacheAtomic(
   await commitAtomic(target, { ...opts, mode: opts.mode ?? PRIVATE_FILE_MODE }, async (tmp) => {
     // The remote-controlled fields are intentionally persisted only after the
     // Ed25519 check above. CodeQL cannot model this cryptographic sanitizer.
-    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' }); // codeql[js/http-to-file-access]
+    // lgtm
+    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
   });
 }
 
@@ -133,7 +134,8 @@ export async function writeBoundedDataCacheAtomic(
   await commitAtomic(target, { ...opts, mode: opts.mode ?? PRIVATE_FILE_MODE }, async (tmp) => {
     // The byte cap and data-only reader contract above are the sanitizer;
     // CodeQL cannot infer that the persisted bytes are never executed.
-    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' }); // codeql[js/http-to-file-access]
+    // lgtm
+    await writeFile(tmp, data, { encoding: opts.encoding ?? 'utf8' });
   });
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -268,7 +268,12 @@ export {
   resolveProviderTools,
   type ResolvedProviderTools,
 } from './provider-tool-utils.js';
-export type { WriteFileAtomicOptions } from './fs-utils.js';
+export type {
+  BoundedNetworkCacheOptions,
+  SignedNetworkCacheEnvelope,
+  SignedNetworkCacheOptions,
+  WriteFileAtomicOptions,
+} from './fs-utils.js';
 export type {
   EgressProxySettings,
   EgressStatus,

--- a/packages/sdk/src/package-root.test.ts
+++ b/packages/sdk/src/package-root.test.ts
@@ -47,6 +47,7 @@ describe('@moxxy/sdk package root', () => {
     'writeFileAtomic',
     'writeFileAtomicSync',
     'writeSignedNetworkCacheAtomic',
+    'writeBoundedDataCacheAtomic',
     'writeBoundedNetworkCacheAtomicSync',
     'moxxyHome',
     'moxxyPath',

--- a/packages/sdk/src/package-root.test.ts
+++ b/packages/sdk/src/package-root.test.ts
@@ -46,6 +46,8 @@ describe('@moxxy/sdk package root', () => {
   const NODE_ONLY_VALUE_EXPORTS = [
     'writeFileAtomic',
     'writeFileAtomicSync',
+    'writeSignedNetworkCacheAtomic',
+    'writeBoundedNetworkCacheAtomicSync',
     'moxxyHome',
     'moxxyPath',
     'readRequestBody',

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -19,6 +19,7 @@ export {
   writeFileAtomic,
   writeFileAtomicSync,
   writeSignedNetworkCacheAtomic,
+  writeBoundedDataCacheAtomic,
   writeBoundedNetworkCacheAtomicSync,
   moxxyHome,
   moxxyPath,

--- a/packages/sdk/src/server.ts
+++ b/packages/sdk/src/server.ts
@@ -18,6 +18,8 @@
 export {
   writeFileAtomic,
   writeFileAtomicSync,
+  writeSignedNetworkCacheAtomic,
+  writeBoundedNetworkCacheAtomicSync,
   moxxyHome,
   moxxyPath,
   ensurePrivateDir,

--- a/packages/sdk/src/signature.ts
+++ b/packages/sdk/src/signature.ts
@@ -24,10 +24,15 @@ export function verifyEd25519(
   signatureB64: string,
   publicKeyPem: string,
 ): boolean {
-  if (!publicKeyPem || !signatureB64) return false;
+  // An Ed25519 signature is exactly 64 bytes (88 base64 characters including
+  // padding). Reject absurd input before decoding so an unauthenticated `.sig`
+  // response cannot force a large allocation at the verification boundary.
+  if (!publicKeyPem || !signatureB64 || signatureB64.length > 128) return false;
   try {
     const key = createPublicKey(publicKeyPem);
-    return cryptoVerify(null, Buffer.from(bytes), key, Buffer.from(signatureB64, 'base64'));
+    const signature = Buffer.from(signatureB64, 'base64');
+    if (signature.byteLength !== 64) return false;
+    return cryptoVerify(null, Buffer.from(bytes), key, signature);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- replace attacker-keyed object caches and managed-config mutation with Map/pure reconstruction
- authenticate signed network caches at the filesystem boundary and bound unsigned update metadata
- remove the Windows OAuth shell, validate browser schemes, sanitize HTTP errors, and verify worker message origins
- preserve legacy signed-cache compatibility and add hostile-input regressions

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings only)
- `pnpm check:deps` (0 errors; existing warning only)
- `pnpm audit:security` (0 unmitigated advisories)
- `pnpm test`
