### PR TITLE
fix(security): stabilize HTTP error responses

### DIFF
--- a/.changeset/clean-http-error-boundaries.md
+++ b/.changeset/clean-http-error-boundaries.md
@@ -1,0 +1,5 @@
+---
+'@moxxy/cli': patch
+---
+
+Return stable HTTP error bodies without exposing parser or request-stream internals.

--- a/packages/plugin-channel-http/src/router.test.ts
+++ b/packages/plugin-channel-http/src/router.test.ts
@@ -197,6 +197,39 @@ describe('handleTurnAudio', () => {
     expect(res._status).toBe(415);
   });
 
+  it('returns a stable 413 response without exposing request-stream errors', async () => {
+    const session = new Session({ cwd: '/tmp', silent: true });
+    session.transcribers.register(
+      defineTranscriber({
+        name: 't',
+        createClient: () => ({ name: 't', transcribe: async () => ({ text: 'x' }) }),
+      }),
+    );
+    session.transcribers.setActive('t');
+    const req = new Readable({
+      read() {
+        this.destroy(new Error('SECRET /srv/internal/audio-reader.ts'));
+      },
+    }) as unknown as IncomingMessage;
+    Object.assign(req, {
+      method: 'POST',
+      url: '/v1/turn/audio',
+      headers: { 'content-type': 'audio/ogg', authorization: 'Bearer x' },
+      socket: new Socket(),
+    });
+    const res = makeResponse();
+
+    await handleTurnAudio(req, res, ctx(session));
+
+    expect(res._status).toBe(413);
+    expect(JSON.parse(res._body)).toEqual({
+      error: 'payload_too_large',
+      message: 'audio payload exceeds the allowed size',
+    });
+    expect(res._body).not.toContain('SECRET');
+    expect(res._body).not.toContain('audio-reader.ts');
+  });
+
   it('returns 400 on empty body', async () => {
     const session = new Session({ cwd: '/tmp', silent: true });
     session.transcribers.register(
@@ -529,6 +562,30 @@ describe('error shaping — internal errors not echoed verbatim', () => {
     expect(body.message).not.toContain('sk-leak');
     // Full detail still reaches the server-side log.
     expect(warn).toHaveBeenCalledWith('http turn failed', expect.objectContaining({ err: expect.stringContaining('SECRET') }));
+  });
+
+  it('streaming 400 bad_request returns the same stable parser-safe response', async () => {
+    const session = { runTurn: () => (async function* () {})() } as unknown as ClientSession;
+    const res = makeResponse();
+
+    await handleTurnStream(
+      makeIncoming({
+        method: 'POST',
+        url: '/v1/turn/stream',
+        headers: { authorization: 'Bearer x' },
+        body: '{"prompt":"unterminated',
+      }),
+      res,
+      { session, authToken: 'x', logger: silentLogger },
+    );
+
+    expect(res._status).toBe(400);
+    expect(JSON.parse(res._body)).toEqual({
+      error: 'bad_request',
+      message: 'invalid request body',
+    });
+    expect(res._body).not.toContain('unterminated');
+    expect(res._body).not.toContain('JSON');
   });
 });
 

--- a/packages/plugin-channel-http/src/router.ts
+++ b/packages/plugin-channel-http/src/router.ts
@@ -252,8 +252,8 @@ export async function handleTurnAudio(
   let bytes: Buffer;
   try {
     bytes = await readRequestBody(req, DEFAULT_AUDIO_MAX);
-  } catch (err) {
-    reply(res, 413, { error: 'payload_too_large', message: err instanceof Error ? err.message : String(err) });
+  } catch {
+    reply(res, 413, { error: 'payload_too_large', message: 'audio payload exceeds the allowed size' });
     return;
   }
   if (bytes.length === 0) {
@@ -326,8 +326,8 @@ export async function handleTurnStream(
   try {
     const raw = await readBody(req);
     body = turnRequestSchema.parse(JSON.parse(raw));
-  } catch (err) {
-    reply(res, 400, { error: 'bad_request', message: err instanceof Error ? err.message : String(err) });
+  } catch {
+    reply(res, 400, { error: 'bad_request', message: 'invalid request body' });
     return;
   }
 


### PR DESCRIPTION
## Summary
- return fixed client-safe errors for malformed streaming turns
- avoid exposing request-stream errors from audio uploads
- add regression coverage for both CodeQL paths

## Verification
- `pnpm --filter @moxxy/plugin-channel-http test -- router.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (0 errors; 47 existing warnings)
- `pnpm check:deps` (0 errors; 1 existing warning)
- `pnpm audit:security`
- `pnpm test` (full rerun green; isolated known certificate timeout also passed 23/23)