### PR TITLE
ci(security): submit resolved pnpm dependency graph

### DIFF
--- a/.changeset/accurate-dependency-graph.md
+++ b/.changeset/accurate-dependency-graph.md
@@ -1,0 +1,4 @@
+---
+---
+
+Submit the resolved pnpm workspace graph to GitHub after dependency changes.

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,55 @@
+name: Dependency Graph
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4 * * 1'
+  push:
+    branches: [development]
+    paths:
+      - '.github/workflows/dependency-graph.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '**/package.json'
+      - 'patches/**'
+      - 'scripts/dependency-snapshot.mjs'
+
+concurrency:
+  group: dependency-graph-development
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    name: Submit resolved pnpm graph
+    if: github.repository == 'moxxy-ai/moxxy' && github.ref == 'refs/heads/development'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.30.0
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22.x'
+          cache: pnpm
+
+      - name: Resolve dependencies without lifecycle scripts
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Submit dependency snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node --test scripts/dependency-snapshot.test.mjs
+          node scripts/dependency-snapshot.mjs

--- a/scripts/dependency-snapshot.mjs
+++ b/scripts/dependency-snapshot.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const REPOSITORY = 'moxxy-ai/moxxy';
+const DEVELOPMENT_REF = 'refs/heads/development';
+const MAX_LIST_BYTES = 64 * 1024 * 1024;
+const DEPENDENCY_SECTIONS = [
+  ['dependencies', 'runtime'],
+  ['optionalDependencies', 'runtime'],
+];
+const ROOT_DEPENDENCY_SECTIONS = [
+  ...DEPENDENCY_SECTIONS,
+  ['devDependencies', 'development'],
+];
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isRegistryVersion(version) {
+  return typeof version === 'string'
+    && version.length > 0
+    && !/^(?:file|link|portal|workspace):/.test(version);
+}
+
+function isNpmPackageName(name) {
+  if (typeof name !== 'string' || name.length === 0 || /[:\s]/.test(name)) return false;
+  const segments = name.split('/');
+  return name.startsWith('@')
+    ? segments.length === 2 && segments.every((part) => part.length > 0)
+    : segments.length === 1;
+}
+
+export function npmPackageUrl(name, version) {
+  if (typeof name !== 'string' || name.length === 0 || !isRegistryVersion(version)) {
+    throw new Error('a registry package name and version are required');
+  }
+  const segments = name.startsWith('@') ? name.split('/') : [name];
+  if ((name.startsWith('@') && segments.length !== 2) || segments.some((part) => part.length === 0)) {
+    throw new Error(`invalid npm package name: ${name}`);
+  }
+  const encodedName = segments.map((part) => encodeURIComponent(part)).join('/');
+  return `pkg:npm/${encodedName}@${encodeURIComponent(version)}`;
+}
+
+function mergeNode(nodes, packageUrl, relationship, scope) {
+  const current = nodes.get(packageUrl);
+  if (!current) {
+    const created = {
+      package_url: packageUrl,
+      relationship,
+      scope,
+      dependencies: new Set(),
+    };
+    nodes.set(packageUrl, created);
+    return created;
+  }
+  if (relationship === 'direct') current.relationship = 'direct';
+  if (scope === 'runtime') current.scope = 'runtime';
+  return current;
+}
+
+function visitDependency(nodes, name, candidate, relationship, scope) {
+  if (!isRecord(candidate)) return null;
+  const version = candidate.version;
+  let current = null;
+  if (isRegistryVersion(version)) {
+    const packageName = isNpmPackageName(candidate.from) ? candidate.from : name;
+    const packageUrl = npmPackageUrl(packageName, version);
+    current = mergeNode(nodes, packageUrl, relationship, scope);
+  }
+
+  for (const [section] of DEPENDENCY_SECTIONS) {
+    const children = candidate[section];
+    if (!isRecord(children)) continue;
+    for (const [childName, child] of Object.entries(children)) {
+      const childUrl = visitDependency(nodes, childName, child, 'indirect', scope);
+      if (current && childUrl) current.dependencies.add(childUrl);
+    }
+  }
+  return current?.package_url ?? null;
+}
+
+export function resolvedDependenciesFromPnpmList(workspaces) {
+  if (!Array.isArray(workspaces)) throw new Error('pnpm list output must be an array');
+  const nodes = new Map();
+  for (const workspace of workspaces) {
+    if (!isRecord(workspace)) continue;
+    for (const [section, scope] of ROOT_DEPENDENCY_SECTIONS) {
+      const dependencies = workspace[section];
+      if (!isRecord(dependencies)) continue;
+      for (const [name, candidate] of Object.entries(dependencies)) {
+        visitDependency(nodes, name, candidate, 'direct', scope);
+      }
+    }
+  }
+
+  const resolved = {};
+  for (const packageUrl of [...nodes.keys()].sort()) {
+    const node = nodes.get(packageUrl);
+    const dependencies = [...node.dependencies]
+      .filter((dependency) => nodes.has(dependency))
+      .sort();
+    resolved[packageUrl] = {
+      package_url: node.package_url,
+      relationship: node.relationship,
+      scope: node.scope,
+      ...(dependencies.length === 0 ? {} : { dependencies }),
+    };
+  }
+  return resolved;
+}
+
+export function buildDependencySnapshot(workspaces, metadata) {
+  const resolved = resolvedDependenciesFromPnpmList(workspaces);
+  if (Object.keys(resolved).length === 0) {
+    throw new Error('refusing to submit an empty dependency snapshot');
+  }
+  return {
+    version: 0,
+    sha: metadata.sha,
+    ref: metadata.ref,
+    job: {
+      correlator: 'moxxy-pnpm-resolved',
+      id: metadata.jobId,
+      html_url: metadata.jobUrl,
+    },
+    detector: {
+      name: 'moxxy-pnpm-resolved',
+      version: '1.0.0',
+      url: `https://github.com/${REPOSITORY}/blob/${metadata.sha}/scripts/dependency-snapshot.mjs`,
+    },
+    scanned: metadata.scanned,
+    manifests: {
+      'pnpm-lock.yaml': {
+        name: 'moxxy pnpm workspace',
+        file: { source_location: 'pnpm-lock.yaml' },
+        resolved,
+      },
+    },
+  };
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+export async function submitDependencySnapshot(snapshot, token, fetchImpl = fetch) {
+  const response = await fetchImpl(
+    `https://api.github.com/repos/${REPOSITORY}/dependency-graph/snapshots`,
+    {
+      method: 'POST',
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+        'x-github-api-version': '2022-11-28',
+      },
+      body: JSON.stringify(snapshot),
+    },
+  );
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 2_000);
+    throw new Error(`GitHub dependency submission failed (${response.status}): ${detail}`);
+  }
+  return response.json();
+}
+
+async function main() {
+  const repository = requiredEnv('GITHUB_REPOSITORY');
+  const ref = requiredEnv('GITHUB_REF');
+  const sha = requiredEnv('GITHUB_SHA');
+  if (repository !== REPOSITORY || ref !== DEVELOPMENT_REF || !/^[0-9a-f]{40}$/i.test(sha)) {
+    throw new Error('dependency snapshots may only be submitted for moxxy development commits');
+  }
+
+  const raw = execFileSync('pnpm', ['-r', 'list', '--depth', 'Infinity', '--json'], {
+    encoding: 'utf8',
+    maxBuffer: MAX_LIST_BYTES,
+  });
+  const workspaces = JSON.parse(raw);
+  const runId = requiredEnv('GITHUB_RUN_ID');
+  const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
+  const snapshot = buildDependencySnapshot(workspaces, {
+    sha,
+    ref,
+    jobId: `${runId}.${process.env.GITHUB_RUN_ATTEMPT ?? '1'}`,
+    jobUrl: `${serverUrl}/${repository}/actions/runs/${runId}`,
+    scanned: new Date().toISOString(),
+  });
+  const result = await submitDependencySnapshot(snapshot, requiredEnv('GITHUB_TOKEN'));
+  const count = Object.keys(snapshot.manifests['pnpm-lock.yaml'].resolved).length;
+  console.log(`Submitted ${count} resolved pnpm dependencies (${result.result ?? 'accepted'}).`);
+}
+
+const entry = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (entry === import.meta.url) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/dependency-snapshot.test.mjs
+++ b/scripts/dependency-snapshot.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildDependencySnapshot,
+  npmPackageUrl,
+  resolvedDependenciesFromPnpmList,
+  submitDependencySnapshot,
+} from './dependency-snapshot.mjs';
+
+test('npmPackageUrl encodes scoped package names and versions', () => {
+  assert.equal(
+    npmPackageUrl('@hono/node-server', '2.1.0'),
+    'pkg:npm/%40hono/node-server@2.1.0',
+  );
+  assert.equal(npmPackageUrl('pkg', '1.0.0+build'), 'pkg:npm/pkg@1.0.0%2Bbuild');
+});
+
+test('resolvedDependenciesFromPnpmList folds workspace trees into one stable graph', () => {
+  const shared = { from: 'shared', version: '3.0.0' };
+  const workspaces = [
+    {
+      name: 'app',
+      dependencies: {
+        '@scope/runtime': {
+          from: '@scope/runtime',
+          version: '1.2.3',
+          dependencies: { shared },
+        },
+        internal: {
+          from: 'internal',
+          version: 'link:packages/internal',
+          dependencies: {
+            nested: { from: 'nested', version: '4.0.0' },
+          },
+        },
+        'aliased-package': {
+          from: 'canonical-package',
+          version: '5.0.0',
+        },
+      },
+      devDependencies: {
+        shared,
+        devonly: { from: 'devonly', version: '2.0.0' },
+      },
+    },
+  ];
+
+  const resolved = resolvedDependenciesFromPnpmList(workspaces);
+  assert.deepEqual(Object.keys(resolved), [...Object.keys(resolved)].sort());
+  assert.equal(resolved['pkg:npm/%40scope/runtime@1.2.3'].relationship, 'direct');
+  assert.equal(resolved['pkg:npm/%40scope/runtime@1.2.3'].scope, 'runtime');
+  assert.deepEqual(resolved['pkg:npm/%40scope/runtime@1.2.3'].dependencies, [
+    'pkg:npm/shared@3.0.0',
+  ]);
+  assert.equal(resolved['pkg:npm/shared@3.0.0'].relationship, 'direct');
+  assert.equal(resolved['pkg:npm/shared@3.0.0'].scope, 'runtime');
+  assert.equal(resolved['pkg:npm/devonly@2.0.0'].scope, 'development');
+  assert.equal(resolved['pkg:npm/nested@4.0.0'].relationship, 'indirect');
+  assert.equal(resolved['pkg:npm/canonical-package@5.0.0'].relationship, 'direct');
+  assert.equal('pkg:npm/aliased-package@5.0.0' in resolved, false);
+  assert.equal('pkg:npm/internal@link%3Apackages%2Finternal' in resolved, false);
+});
+
+test('buildDependencySnapshot binds the graph to the exact development commit', () => {
+  const snapshot = buildDependencySnapshot(
+    [{ name: 'app', dependencies: { pkg: { from: 'pkg', version: '1.0.0' } } }],
+    {
+      sha: 'a'.repeat(40),
+      ref: 'refs/heads/development',
+      jobId: '123.1',
+      jobUrl: 'https://github.com/moxxy-ai/moxxy/actions/runs/123',
+      scanned: '2026-08-12T00:00:00.000Z',
+    },
+  );
+  assert.equal(snapshot.sha, 'a'.repeat(40));
+  assert.equal(snapshot.ref, 'refs/heads/development');
+  assert.equal(snapshot.job.correlator, 'moxxy-pnpm-resolved');
+  assert.equal(snapshot.manifests['pnpm-lock.yaml'].resolved['pkg:npm/pkg@1.0.0'].scope, 'runtime');
+});
+
+test('buildDependencySnapshot refuses to replace the graph with an empty snapshot', () => {
+  assert.throws(
+    () => buildDependencySnapshot([], {
+      sha: 'a'.repeat(40),
+      ref: 'refs/heads/development',
+      jobId: '123.1',
+      jobUrl: 'https://example.test',
+      scanned: '2026-08-12T00:00:00.000Z',
+    }),
+    /empty dependency snapshot/,
+  );
+});
+
+test('submitDependencySnapshot posts only to the repository snapshot endpoint', async () => {
+  let request;
+  const fetchImpl = async (url, init) => {
+    request = { url, init };
+    return new Response(JSON.stringify({ result: 'SUCCESS' }), { status: 201 });
+  };
+  const snapshot = { version: 0 };
+
+  const result = await submitDependencySnapshot(snapshot, 'token-value', fetchImpl);
+
+  assert.equal(request.url, 'https://api.github.com/repos/moxxy-ai/moxxy/dependency-graph/snapshots');
+  assert.equal(request.init.method, 'POST');
+  assert.equal(request.init.headers.authorization, 'Bearer token-value');
+  assert.equal(request.init.body, JSON.stringify(snapshot));
+  assert.deepEqual(result, { result: 'SUCCESS' });
+});


### PR DESCRIPTION
## Summary
- submit the fully resolved pnpm workspace graph to GitHub after dependency changes and on a weekly refresh
- canonicalize npm aliases, classify direct/runtime dependencies conservatively, and reject empty snapshots
- cover the snapshot contract, PURL encoding, graph folding, and fixed GitHub endpoint with script tests

## Why
GitHub vulnerability alerts are enabled, but the repository currently exposes zero parsed dependency manifests, leaving stale alerts after the vulnerable versions were removed. This submission records the installed `pnpm-lock.yaml` resolution instead of dismissing fixed alerts by hand. Dependabot version updates remain enabled by `.github/dependabot.yml`.

## Verification
- `node --test scripts/dependency-snapshot.test.mjs`
- real dry-run: 92 workspaces, 2,067 resolved external packages, 439 KB snapshot
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:deps`
- `pnpm audit:security`
- `pnpm test`